### PR TITLE
feat: add archive knowledge base module

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -54,7 +54,12 @@ const archive = defineCollection({
     type: z.enum(['note', 'snippet', 'draft', 'idea', 'research', 'reference']).default('note'),
     // Status: in-progress, incomplete, ready, archived
     status: z.enum(['in-progress', 'incomplete', 'ready', 'archived']).default('in-progress'),
-    draft: z.boolean().default(false)
+    draft: z.boolean().default(false),
+    // Relationships - connect archive entries to blog posts and other archives
+    relatedBlog: z.array(z.string()).optional(),
+    relatedArchive: z.array(z.string()).optional(),
+    // External source or reference URL
+    source: z.string().url().optional()
   })
 })
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -39,4 +39,23 @@ const blog = defineCollection({
     })
 })
 
-export const collections = { blog }
+const archive = defineCollection({
+  // Load Markdown and MDX files in the `src/content/archive/` directory.
+  loader: glob({ base: './src/content/archive', pattern: '**/*.{md,mdx}' }),
+  schema: z.object({
+    // Required
+    title: z.string(),
+    date: z.coerce.date(),
+    // Optional
+    description: z.string().optional(),
+    updatedDate: z.coerce.date().optional(),
+    tags: z.array(z.string()).default([]).transform(removeDupsAndLowerCase),
+    // Type of archive entry: note, snippet, draft, idea, research, etc.
+    type: z.enum(['note', 'snippet', 'draft', 'idea', 'research', 'reference']).default('note'),
+    // Status: in-progress, incomplete, ready, archived
+    status: z.enum(['in-progress', 'incomplete', 'ready', 'archived']).default('in-progress'),
+    draft: z.boolean().default(false)
+  })
+})
+
+export const collections = { blog, archive }

--- a/src/content/archive/astro-image-optimization.md
+++ b/src/content/archive/astro-image-optimization.md
@@ -1,0 +1,27 @@
+---
+title: Astro 图片优化技巧
+description: 收集的一些 Astro 图片优化和性能相关的笔记
+date: 2026-01-15
+updatedDate: 2026-02-10
+tags: ['astro', 'performance', 'images']
+type: 'note'
+status: 'in-progress'
+draft: false
+---
+
+## Image 组件使用
+
+- 使用 `<Image>` 组件自动优化
+- Sharp service 比 Squoosh 性能更好
+- 支持 webp/avif 格式自动转换
+
+## 待研究
+
+- [ ] lazy loading 策略
+- [ ] 响应式图片最佳实践
+- [ ] CDN 集成方案
+
+## 参考资料
+
+- [Astro Image docs](https://docs.astro.build/en/guides/images/)
+- 项目中的实践：`astro.config.ts` 配置了 sharp service

--- a/src/content/archive/llm-context-window-strategies.md
+++ b/src/content/archive/llm-context-window-strategies.md
@@ -1,0 +1,38 @@
+---
+title: LLM 上下文窗口管理策略
+date: 2026-02-20
+tags: ['llm', 'agent', 'ai']
+type: 'research'
+status: 'incomplete'
+draft: false
+---
+
+## 问题
+
+在 Agent 开发中，长对话会导致上下文窗口溢出。
+
+## 常见解决方案
+
+### 1. FIFO (First In First Out)
+简单但会丢失重要信息
+
+### 2. 记忆分层
+- Working Memory: 当前对话
+- Short-term: 近期摘要
+- Long-term: 持久化知识库
+
+### 3. 摘要压缩
+使用 LLM 对历史对话进行摘要
+
+### 4. 语义检索
+将历史存入向量数据库，按需检索
+
+## 待深入
+
+- Token Budget 管控实现
+- Prompt Cache 最佳实践
+- 混合策略设计
+
+## 来源
+
+面试复盘笔记

--- a/src/content/archive/llm-context-window-strategies.md
+++ b/src/content/archive/llm-context-window-strategies.md
@@ -1,10 +1,12 @@
 ---
 title: LLM 上下文窗口管理策略
 date: 2026-02-20
+description: Agent 开发中的上下文窗口管理策略和实践
 tags: ['llm', 'agent', 'ai']
 type: 'research'
 status: 'incomplete'
 draft: false
+relatedArchive: ['prompt-engineering-patterns']
 ---
 
 ## 问题

--- a/src/content/archive/prompt-engineering-patterns.md
+++ b/src/content/archive/prompt-engineering-patterns.md
@@ -6,6 +6,8 @@ tags: ['ai', 'prompt', 'llm']
 type: 'snippet'
 status: 'in-progress'
 draft: false
+relatedArchive: ['llm-context-window-strategies']
+source: 'https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering'
 ---
 
 ## 结构化 Prompt

--- a/src/content/archive/prompt-engineering-patterns.md
+++ b/src/content/archive/prompt-engineering-patterns.md
@@ -1,0 +1,52 @@
+---
+title: Prompt Engineering 常用模式
+description: 整理的一些实用 Prompt 编写技巧和模式
+date: 2026-03-01
+tags: ['ai', 'prompt', 'llm']
+type: 'snippet'
+status: 'in-progress'
+draft: false
+---
+
+## 结构化 Prompt
+
+使用 XML 标签或 JSON Schema 帮助模型理解结构
+
+```xml
+<task>
+  <objective>...</objective>
+  <constraints>...</constraints>
+  <output_format>...</output_format>
+</task>
+```
+
+## Chain of Thought
+
+引导模型逐步推理
+
+```
+Let's think step by step:
+1. First, ...
+2. Then, ...
+3. Finally, ...
+```
+
+## Few-shot Learning
+
+提供示例但要注意多样性
+
+```
+Example 1: ...
+Example 2: ...
+Now, handle this case: ...
+```
+
+## 指令层级
+
+System Prompt > Developer Instructions > User Input
+
+## 待补充
+
+- 角色扮演模式
+- 反思模式 (Self-Reflection)
+- 多智能体协作模式

--- a/src/content/archive/react-optimization-ideas.md
+++ b/src/content/archive/react-optimization-ideas.md
@@ -1,0 +1,25 @@
+---
+title: React 性能优化思路草稿
+date: 2025-12-20
+tags: ['react', 'performance', 'frontend']
+type: 'draft'
+status: 'incomplete'
+draft: false
+---
+
+## 可能的优化点
+
+- useMemo for expensive calculations
+- React.memo for component memoization
+- useCallback for stable function references
+- Code splitting with lazy()
+- Virtualization for long lists
+
+## 疑问
+
+- 什么时候 useMemo 真的有用？
+- memo 的浅比较开销 vs 重渲染开销如何权衡？
+
+## 资源
+
+需要读：React 官方性能优化文档

--- a/src/content/archive/typescript-utility-types.md
+++ b/src/content/archive/typescript-utility-types.md
@@ -1,0 +1,40 @@
+---
+title: TypeScript 实用类型备忘
+date: 2025-11-10
+updatedDate: 2026-01-05
+tags: ['typescript', 'reference']
+type: 'reference'
+status: 'ready'
+draft: false
+---
+
+## Pick & Omit
+
+```typescript
+type User = { id: string; name: string; email: string }
+type UserPreview = Pick<User, 'id' | 'name'>
+type UserWithoutEmail = Omit<User, 'email'>
+```
+
+## Partial & Required
+
+```typescript
+type PartialUser = Partial<User>  // 所有字段可选
+type RequiredUser = Required<PartialUser>  // 所有字段必填
+```
+
+## Record
+
+```typescript
+type PageInfo = Record<string, { title: string; url: string }>
+```
+
+## 条件类型
+
+```typescript
+type NonNullable<T> = T extends null | undefined ? never : T
+```
+
+## 使用场景
+
+在 Astro 项目中用 Pick 提取 frontmatter 字段

--- a/src/pages/archive/[...id].astro
+++ b/src/pages/archive/[...id].astro
@@ -1,0 +1,117 @@
+---
+import { render, type CollectionEntry } from 'astro:content'
+import { getCollection } from 'astro:content'
+import PageLayout from '@/layouts/ContentLayout.astro'
+import { Button, Icon } from 'astro-pure/user'
+
+export const prerender = true
+
+export async function getStaticPaths() {
+  const archives = await getCollection('archive')
+  return archives.map((entry) => ({
+    params: { id: entry.id },
+    props: { entry }
+  }))
+}
+
+type Props = {
+  entry: CollectionEntry<'archive'>
+}
+
+const { entry } = Astro.props
+const { Content } = await render(entry)
+
+const { title, description, date, updatedDate, tags, type, status } = entry.data
+
+// Status labels and colors
+const statusLabels: Record<string, string> = {
+  'in-progress': '🚧 In Progress',
+  incomplete: '⏸️ Incomplete',
+  ready: '✅ Ready',
+  archived: '📦 Archived'
+}
+
+const typeLabels: Record<string, string> = {
+  note: '📝 Note',
+  snippet: '💡 Snippet',
+  draft: '✏️ Draft',
+  idea: '🔮 Idea',
+  research: '🔬 Research',
+  reference: '📚 Reference'
+}
+
+const meta = {
+  title,
+  description: description || title
+}
+---
+
+<PageLayout {meta} back='/archive'>
+  {/* Header */}
+  <div slot='header' class='animate gap-y-4'>
+    <div class='mb-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground'>
+      <span class='rounded-md bg-muted px-2 py-1'>{typeLabels[type] || type}</span>
+      <span class='rounded-md bg-muted px-2 py-1'>{statusLabels[status] || status}</span>
+      {
+        tags.length > 0 && (
+          <>
+            <span>·</span>
+            {tags.map((tag) => (
+              <span class='rounded-md border border-border px-2 py-1'>{tag}</span>
+            ))}
+          </>
+        )
+      }
+    </div>
+
+    <h1 class='mb-4 text-3xl font-bold leading-tight sm:text-4xl'>{title}</h1>
+
+    {description && <p class='text-lg text-muted-foreground'>{description}</p>}
+
+    <div class='mt-4 flex flex-wrap items-center gap-4 text-sm text-muted-foreground'>
+      <div class='flex items-center gap-2'>
+        <Icon name='calendar' />
+        <time datetime={date.toISOString()}>
+          {
+            date.toLocaleDateString('zh-CN', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric'
+            })
+          }
+        </time>
+      </div>
+      {
+        updatedDate && (
+          <div class='flex items-center gap-2'>
+            <Icon name='calendar' />
+            <span>
+              Updated{' '}
+              {updatedDate.toLocaleDateString('zh-CN', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric'
+              })}
+            </span>
+          </div>
+        )
+      }
+    </div>
+  </div>
+
+  {/* Content */}
+  <article class='prose prose-pure dark:prose-invert max-w-none'>
+    <Content />
+  </article>
+
+  {/* Bottom info */}
+  <div slot='bottom' class='animate mt-8 border-t border-border pt-6'>
+    <div class='text-sm text-muted-foreground'>
+      <p class='mb-4'>
+        This is an archive entry - part of a knowledge base for ideas, snippets, and working notes.
+        Content may be incomplete or in-progress.
+      </p>
+      <Button title='← Back to Archive' href='/archive' style='back' />
+    </div>
+  </div>
+</PageLayout>

--- a/src/pages/archive/[...id].astro
+++ b/src/pages/archive/[...id].astro
@@ -21,7 +21,23 @@ type Props = {
 const { entry } = Astro.props
 const { Content } = await render(entry)
 
-const { title, description, date, updatedDate, tags, type, status } = entry.data
+const { title, description, date, updatedDate, tags, type, status, relatedBlog, relatedArchive, source } = entry.data
+
+// Fetch related blog posts if any
+let relatedBlogPosts: any[] = []
+if (relatedBlog && relatedBlog.length > 0) {
+  const allBlogPosts = await getCollection('blog')
+  relatedBlogPosts = allBlogPosts.filter((post) => relatedBlog.includes(post.id))
+}
+
+// Fetch related archive entries if any
+let relatedArchiveEntries: any[] = []
+if (relatedArchive && relatedArchive.length > 0) {
+  const allArchives = await getCollection('archive')
+  relatedArchiveEntries = allArchives.filter((arch) =>
+    relatedArchive.includes(arch.id) && arch.id !== entry.id
+  )
+}
 
 // Status labels and colors
 const statusLabels: Record<string, string> = {
@@ -57,7 +73,12 @@ const meta = {
           <>
             <span>·</span>
             {tags.map((tag) => (
-              <span class='rounded-md border border-border px-2 py-1'>{tag}</span>
+              <a
+                href={`/archive/tags/${tag}`}
+                class='rounded-md border border-border px-2 py-1 transition hover:border-foreground/20'
+              >
+                {tag}
+              </a>
             ))}
           </>
         )
@@ -97,6 +118,20 @@ const meta = {
         )
       }
     </div>
+
+    {
+      source && (
+        <div class='mt-4 flex items-start gap-2 rounded-lg bg-muted/50 p-3 text-sm'>
+          <Icon name='link-2' class='mt-0.5 shrink-0 text-muted-foreground' />
+          <div>
+            <span class='text-muted-foreground'>Source: </span>
+            <a href={source} target='_blank' rel='noopener noreferrer' class='hover:underline'>
+              {source}
+            </a>
+          </div>
+        </div>
+      )
+    }
   </div>
 
   {/* Content */}
@@ -104,14 +139,83 @@ const meta = {
     <Content />
   </article>
 
+  {/* Relationships Section */}
+  {
+    (relatedBlogPosts.length > 0 || relatedArchiveEntries.length > 0) && (
+      <div slot='bottom' class='animate mt-8 border-t border-border pt-6'>
+        <h2 class='mb-4 text-xl font-semibold'>Related Content</h2>
+
+        {relatedBlogPosts.length > 0 && (
+          <div class='mb-6'>
+            <h3 class='mb-3 flex items-center text-sm font-medium text-muted-foreground'>
+              <Icon name='file-text' class='me-2' />
+              Blog Posts
+            </h3>
+            <ul class='space-y-2'>
+              {relatedBlogPosts.map((post) => (
+                <li>
+                  <a
+                    href={`/blog/${post.id}`}
+                    class='block rounded-lg border border-border bg-card p-3 transition hover:border-foreground/20'
+                    data-astro-prefetch
+                  >
+                    <div class='font-medium'>{post.data.title}</div>
+                    {post.data.description && (
+                      <p class='mt-1 text-sm text-muted-foreground'>{post.data.description}</p>
+                    )}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {relatedArchiveEntries.length > 0 && (
+          <div class='mb-6'>
+            <h3 class='mb-3 flex items-center text-sm font-medium text-muted-foreground'>
+              <Icon name='archive' class='me-2' />
+              Archive Entries
+            </h3>
+            <ul class='space-y-2'>
+              {relatedArchiveEntries.map((arch) => (
+                <li>
+                  <a
+                    href={`/archive/${arch.id}`}
+                    class='block rounded-lg border border-border bg-card p-3 transition hover:border-foreground/20'
+                    data-astro-prefetch
+                  >
+                    <div class='flex items-center gap-2'>
+                      <span class='font-medium'>{arch.data.title}</span>
+                      <span class='text-xs text-muted-foreground'>
+                        {typeLabels[arch.data.type] || arch.data.type}
+                      </span>
+                    </div>
+                    {arch.data.description && (
+                      <p class='mt-1 text-sm text-muted-foreground'>{arch.data.description}</p>
+                    )}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    )
+  }
+
   {/* Bottom info */}
   <div slot='bottom' class='animate mt-8 border-t border-border pt-6'>
-    <div class='text-sm text-muted-foreground'>
-      <p class='mb-4'>
-        This is an archive entry - part of a knowledge base for ideas, snippets, and working notes.
-        Content may be incomplete or in-progress.
-      </p>
-      <Button title='← Back to Archive' href='/archive' style='back' />
+    <div class='flex items-start justify-between gap-4'>
+      <div class='text-sm text-muted-foreground'>
+        <p class='mb-2 flex items-center gap-2'>
+          <Icon name='archive' class='shrink-0' />
+          <span>
+            This is a {typeLabels[type]?.toLowerCase() || type} in the knowledge base.
+          </span>
+        </p>
+        <p class='text-xs'>Content may be incomplete or work-in-progress.</p>
+      </div>
+      <Button title='← Back' href='/archive' style='back' />
     </div>
   </div>
 </PageLayout>

--- a/src/pages/archive/[...page].astro
+++ b/src/pages/archive/[...page].astro
@@ -74,10 +74,18 @@ const statusColors: Record<string, string> = {
 
   <main class='mt-6 lg:mt-10'>
     <div id='content-header' class='animate'>
-      <h1 class='mb-2 text-3xl font-medium'>Archive</h1>
-      <p class='mb-6 text-muted-foreground'>
-        Knowledge base and working notes - a collection of ideas, snippets, and semi-finished
-        materials
+      <div class='mb-2 flex items-center gap-3'>
+        <div class='rounded-lg bg-muted/50 p-2'>
+          <Icon name='archive' class='size-6 text-foreground' />
+        </div>
+        <div>
+          <h1 class='text-3xl font-medium'>Archive</h1>
+          <p class='text-sm text-muted-foreground'>Knowledge Base & Working Notes</p>
+        </div>
+      </div>
+      <p class='mb-6 mt-4 text-muted-foreground'>
+        A collection of research notes, code snippets, and semi-finished materials. This is my
+        digital workbench for ideas in progress.
       </p>
     </div>
 
@@ -100,55 +108,70 @@ const statusColors: Record<string, string> = {
 
             <ul class='space-y-3'>
               {page.data.map((entry: any) => (
-                <li class='rounded-lg border border-border bg-card p-4 transition hover:border-foreground/20'>
+                <li class='group relative rounded-lg border border-border bg-card p-4 transition hover:border-foreground/20 hover:shadow-sm'>
                   <a href={`/archive/${entry.id}`} class='block' data-astro-prefetch>
-                    <div class='mb-1 flex items-start justify-between gap-4'>
-                      <h3 class='font-medium leading-tight'>{entry.data.title}</h3>
-                      <div class='flex shrink-0 items-center gap-2 text-xs'>
-                        <span class='text-muted-foreground'>
-                          {typeLabels[entry.data.type] || entry.data.type}
-                        </span>
-                        <span class={statusColors[entry.data.status]}>
-                          {statusLabels[entry.data.status] || entry.data.status}
-                        </span>
+                    <div class='mb-2 flex items-start gap-3'>
+                      <div class='mt-0.5 shrink-0 text-xl opacity-70 group-hover:opacity-100'>
+                        {entry.data.type === 'note' && '📝'}
+                        {entry.data.type === 'snippet' && '💡'}
+                        {entry.data.type === 'draft' && '✏️'}
+                        {entry.data.type === 'idea' && '🔮'}
+                        {entry.data.type === 'research' && '🔬'}
+                        {entry.data.type === 'reference' && '📚'}
                       </div>
-                    </div>
-                    {entry.data.description && (
-                      <p class='mb-2 text-sm text-muted-foreground'>{entry.data.description}</p>
-                    )}
-                    <div class='flex flex-wrap items-center gap-2 text-xs text-muted-foreground'>
-                      <time datetime={entry.data.date.toISOString()}>
-                        {entry.data.date.toLocaleDateString('zh-CN', {
-                          year: 'numeric',
-                          month: 'short',
-                          day: 'numeric'
-                        })}
-                      </time>
-                      {entry.data.updatedDate && (
-                        <span>
-                          · Updated{' '}
-                          {entry.data.updatedDate.toLocaleDateString('zh-CN', {
-                            month: 'short',
-                            day: 'numeric'
-                          })}
-                        </span>
-                      )}
-                      {entry.data.tags.length > 0 && (
-                        <>
-                          <span>·</span>
-                          <div class='flex flex-wrap gap-1'>
-                            {entry.data.tags.map((tag: string) => (
-                              <a
-                                href={`/archive/tags/${tag}`}
-                                class='rounded bg-muted px-1.5 py-0.5 hover:bg-muted/80'
-                                onclick={(e: Event) => e.stopPropagation()}
-                              >
-                                {tag}
-                              </a>
-                            ))}
-                          </div>
-                        </>
-                      )}
+                      <div class='min-w-0 flex-1'>
+                        <div class='mb-1 flex items-start justify-between gap-4'>
+                          <h3 class='font-medium leading-tight group-hover:text-foreground'>
+                            {entry.data.title}
+                          </h3>
+                          <span
+                            class={`shrink-0 text-xs ${statusColors[entry.data.status]}`}
+                            title={statusLabels[entry.data.status]}
+                          >
+                            {entry.data.status === 'in-progress' && '🚧'}
+                            {entry.data.status === 'incomplete' && '⏸️'}
+                            {entry.data.status === 'ready' && '✅'}
+                            {entry.data.status === 'archived' && '📦'}
+                          </span>
+                        </div>
+                        {entry.data.description && (
+                          <p class='mb-2 text-sm text-muted-foreground'>{entry.data.description}</p>
+                        )}
+                        <div class='flex flex-wrap items-center gap-2 text-xs text-muted-foreground'>
+                          <time datetime={entry.data.date.toISOString()}>
+                            {entry.data.date.toLocaleDateString('zh-CN', {
+                              year: 'numeric',
+                              month: 'short',
+                              day: 'numeric'
+                            })}
+                          </time>
+                          {entry.data.updatedDate && (
+                            <span>
+                              · Updated{' '}
+                              {entry.data.updatedDate.toLocaleDateString('zh-CN', {
+                                month: 'short',
+                                day: 'numeric'
+                              })}
+                            </span>
+                          )}
+                          {entry.data.tags.length > 0 && (
+                            <>
+                              <span>·</span>
+                              <div class='flex flex-wrap gap-1'>
+                                {entry.data.tags.map((tag: string) => (
+                                  <a
+                                    href={`/archive/tags/${tag}`}
+                                    class='rounded bg-muted px-1.5 py-0.5 hover:bg-muted/80'
+                                    onclick={(e: Event) => e.stopPropagation()}
+                                  >
+                                    {tag}
+                                  </a>
+                                ))}
+                              </div>
+                            </>
+                          )}
+                        </div>
+                      </div>
                     </div>
                   </a>
                 </li>

--- a/src/pages/archive/[...page].astro
+++ b/src/pages/archive/[...page].astro
@@ -5,36 +5,42 @@
  * Note: This is different from /archives (plural) which shows blog posts grouped by year.
  */
 import { getCollection } from 'astro:content'
-import { Button, Icon } from 'astro-pure/user'
+import { Button, Icon, Pagination } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
 
 export const prerender = true
 
-// Get all archive entries, sorted by date (most recent first)
-const allArchives = await getCollection('archive')
-const sortedArchives = allArchives
-  .filter((entry) => !entry.data.draft)
-  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+export async function getStaticPaths({ paginate }: any) {
+  const allArchives = await getCollection('archive')
+  const sortedArchives = allArchives
+    .filter((entry) => !entry.data.draft)
+    .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
 
-// Get unique tags, types, and statuses for filtering
+  return paginate(sortedArchives, {
+    pageSize: 20
+  })
+}
+
+const { page } = Astro.props
+
+// Get unique tags, types, and statuses for sidebar
+const allArchives = await getCollection('archive')
 const uniqueTags = [...new Set(allArchives.flatMap((entry) => entry.data.tags))].sort()
 const uniqueTypes = [...new Set(allArchives.map((entry) => entry.data.type))].sort()
 const uniqueStatuses = [...new Set(allArchives.map((entry) => entry.data.status))].sort()
 
-// Group by type for display
-const groupedByType = sortedArchives.reduce(
+// Count entries by type
+const typeCounts = allArchives.reduce(
   (acc, entry) => {
-    const type = entry.data.type
-    if (!acc[type]) acc[type] = []
-    acc[type].push(entry)
+    acc[entry.data.type] = (acc[entry.data.type] || 0) + 1
     return acc
   },
-  {} as Record<string, typeof sortedArchives>
+  {} as Record<string, number>
 )
 
 const meta = {
   description: 'Knowledge base and working notes - ideas, snippets, and semi-finished materials',
-  title: 'Archive'
+  title: page.currentPage === 1 ? 'Archive' : `Archive - Page ${page.currentPage}`
 }
 
 // Type labels with emoji icons
@@ -76,77 +82,84 @@ const statusColors: Record<string, string> = {
     </div>
 
     {
-      sortedArchives.length === 0 ? (
+      page.data.length === 0 ? (
         <p>No archive entries yet.</p>
       ) : (
         <div class='grid gap-y-8 sm:grid-cols-[3fr_1fr] sm:gap-x-8'>
           <section id='content' class='animate' aria-label='Archive entries'>
-            <div class='mb-3 text-sm text-muted-foreground sm:mb-5'>
-              {sortedArchives.length} entries
+            <div class='mb-3 flex items-center justify-between text-sm text-muted-foreground sm:mb-5'>
+              <span>
+                Showing {page.start + 1}-{page.end + 1} of {page.total} entries
+              </span>
+              {page.lastPage > 1 && (
+                <span>
+                  Page {page.currentPage} of {page.lastPage}
+                </span>
+              )}
             </div>
 
-            {/* Group by type */}
-            {Object.entries(groupedByType).map(([type, entries]) => (
-              <div class='mb-8'>
-                <h2 class='mb-4 flex items-center text-lg font-semibold'>
-                  {typeLabels[type] || type}
-                  <span class='ml-2 text-sm text-muted-foreground'>({entries.length})</span>
-                </h2>
-                <ul class='space-y-3'>
-                  {entries.map((entry) => (
-                    <li class='rounded-lg border border-border bg-card p-4 transition hover:border-foreground/20'>
-                      <a href={`/archive/${entry.id}`} class='block' data-astro-prefetch>
-                        <div class='mb-1 flex items-start justify-between gap-4'>
-                          <h3 class='font-medium leading-tight'>{entry.data.title}</h3>
-                          <span class={`shrink-0 text-xs ${statusColors[entry.data.status]}`}>
-                            {statusLabels[entry.data.status] || entry.data.status}
-                          </span>
-                        </div>
-                        {entry.data.description && (
-                          <p class='mb-2 text-sm text-muted-foreground'>
-                            {entry.data.description}
-                          </p>
-                        )}
-                        <div class='flex flex-wrap items-center gap-2 text-xs text-muted-foreground'>
-                          <time datetime={entry.data.date.toISOString()}>
-                            {entry.data.date.toLocaleDateString('zh-CN', {
-                              year: 'numeric',
-                              month: 'short',
-                              day: 'numeric'
-                            })}
-                          </time>
-                          {entry.data.updatedDate && (
-                            <span>
-                              · Updated{' '}
-                              {entry.data.updatedDate.toLocaleDateString('zh-CN', {
-                                month: 'short',
-                                day: 'numeric'
-                              })}
-                            </span>
-                          )}
-                          {entry.data.tags.length > 0 && (
-                            <>
-                              <span>·</span>
-                              <div class='flex flex-wrap gap-1'>
-                                {entry.data.tags.map((tag) => (
-                                  <a
-                                    href={`/archive/tags/${tag}`}
-                                    class='rounded bg-muted px-1.5 py-0.5 hover:bg-muted/80'
-                                    onclick={(e: Event) => e.stopPropagation()}
-                                  >
-                                    {tag}
-                                  </a>
-                                ))}
-                              </div>
-                            </>
-                          )}
-                        </div>
-                      </a>
-                    </li>
-                  ))}
-                </ul>
+            <ul class='space-y-3'>
+              {page.data.map((entry: any) => (
+                <li class='rounded-lg border border-border bg-card p-4 transition hover:border-foreground/20'>
+                  <a href={`/archive/${entry.id}`} class='block' data-astro-prefetch>
+                    <div class='mb-1 flex items-start justify-between gap-4'>
+                      <h3 class='font-medium leading-tight'>{entry.data.title}</h3>
+                      <div class='flex shrink-0 items-center gap-2 text-xs'>
+                        <span class='text-muted-foreground'>
+                          {typeLabels[entry.data.type] || entry.data.type}
+                        </span>
+                        <span class={statusColors[entry.data.status]}>
+                          {statusLabels[entry.data.status] || entry.data.status}
+                        </span>
+                      </div>
+                    </div>
+                    {entry.data.description && (
+                      <p class='mb-2 text-sm text-muted-foreground'>{entry.data.description}</p>
+                    )}
+                    <div class='flex flex-wrap items-center gap-2 text-xs text-muted-foreground'>
+                      <time datetime={entry.data.date.toISOString()}>
+                        {entry.data.date.toLocaleDateString('zh-CN', {
+                          year: 'numeric',
+                          month: 'short',
+                          day: 'numeric'
+                        })}
+                      </time>
+                      {entry.data.updatedDate && (
+                        <span>
+                          · Updated{' '}
+                          {entry.data.updatedDate.toLocaleDateString('zh-CN', {
+                            month: 'short',
+                            day: 'numeric'
+                          })}
+                        </span>
+                      )}
+                      {entry.data.tags.length > 0 && (
+                        <>
+                          <span>·</span>
+                          <div class='flex flex-wrap gap-1'>
+                            {entry.data.tags.map((tag: string) => (
+                              <a
+                                href={`/archive/tags/${tag}`}
+                                class='rounded bg-muted px-1.5 py-0.5 hover:bg-muted/80'
+                                onclick={(e: Event) => e.stopPropagation()}
+                              >
+                                {tag}
+                              </a>
+                            ))}
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  </a>
+                </li>
+              ))}
+            </ul>
+
+            {page.lastPage > 1 && (
+              <div class='mt-8'>
+                <Pagination page={page} />
               </div>
-            ))}
+            )}
           </section>
 
           {/* sidebar */}
@@ -208,9 +221,7 @@ const statusColors: Record<string, string> = {
                 {uniqueTypes.map((type) => (
                   <li>
                     {typeLabels[type] || type}
-                    <span class='ml-2 text-muted-foreground'>
-                      ({groupedByType[type]?.length || 0})
-                    </span>
+                    <span class='ml-2 text-muted-foreground'>({typeCounts[type] || 0})</span>
                   </li>
                 ))}
               </ul>

--- a/src/pages/archive/index.astro
+++ b/src/pages/archive/index.astro
@@ -1,0 +1,194 @@
+---
+/**
+ * Archive Module - /archive (singular)
+ * This is a knowledge base for ideas, snippets, and semi-finished materials.
+ * Note: This is different from /archives (plural) which shows blog posts grouped by year.
+ */
+import { getCollection } from 'astro:content'
+import { Button, Icon } from 'astro-pure/user'
+import PageLayout from '@/layouts/BaseLayout.astro'
+
+export const prerender = true
+
+// Get all archive entries, sorted by date (most recent first)
+const allArchives = await getCollection('archive')
+const sortedArchives = allArchives
+  .filter((entry) => !entry.data.draft)
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+
+// Get unique tags, types, and statuses for filtering
+const uniqueTags = [...new Set(allArchives.flatMap((entry) => entry.data.tags))].sort()
+const uniqueTypes = [...new Set(allArchives.map((entry) => entry.data.type))].sort()
+const uniqueStatuses = [...new Set(allArchives.map((entry) => entry.data.status))].sort()
+
+// Group by type for display
+const groupedByType = sortedArchives.reduce(
+  (acc, entry) => {
+    const type = entry.data.type
+    if (!acc[type]) acc[type] = []
+    acc[type].push(entry)
+    return acc
+  },
+  {} as Record<string, typeof sortedArchives>
+)
+
+const meta = {
+  description: 'Knowledge base and working notes - ideas, snippets, and semi-finished materials',
+  title: 'Archive'
+}
+
+// Type labels with emoji icons
+const typeLabels: Record<string, string> = {
+  note: '📝 Notes',
+  snippet: '💡 Snippets',
+  draft: '✏️ Drafts',
+  idea: '🔮 Ideas',
+  research: '🔬 Research',
+  reference: '📚 Reference'
+}
+
+// Status labels
+const statusLabels: Record<string, string> = {
+  'in-progress': '🚧 In Progress',
+  incomplete: '⏸️ Incomplete',
+  ready: '✅ Ready',
+  archived: '📦 Archived'
+}
+
+const statusColors: Record<string, string> = {
+  'in-progress': 'text-blue-600 dark:text-blue-400',
+  incomplete: 'text-yellow-600 dark:text-yellow-400',
+  ready: 'text-green-600 dark:text-green-400',
+  archived: 'text-gray-500 dark:text-gray-400'
+}
+---
+
+<PageLayout {meta}>
+  <Button title='Back' href='/' style='back' />
+
+  <main class='mt-6 lg:mt-10'>
+    <div id='content-header' class='animate'>
+      <h1 class='mb-2 text-3xl font-medium'>Archive</h1>
+      <p class='mb-6 text-muted-foreground'>
+        Knowledge base and working notes - a collection of ideas, snippets, and semi-finished
+        materials
+      </p>
+    </div>
+
+    {
+      sortedArchives.length === 0 ? (
+        <p>No archive entries yet.</p>
+      ) : (
+        <div class='grid gap-y-8 sm:grid-cols-[3fr_1fr] sm:gap-x-8'>
+          <section id='content' class='animate' aria-label='Archive entries'>
+            <div class='mb-3 text-sm text-muted-foreground sm:mb-5'>
+              {sortedArchives.length} entries
+            </div>
+
+            {/* Group by type */}
+            {Object.entries(groupedByType).map(([type, entries]) => (
+              <div class='mb-8'>
+                <h2 class='mb-4 flex items-center text-lg font-semibold'>
+                  {typeLabels[type] || type}
+                  <span class='ml-2 text-sm text-muted-foreground'>({entries.length})</span>
+                </h2>
+                <ul class='space-y-3'>
+                  {entries.map((entry) => (
+                    <li class='rounded-lg border border-border bg-card p-4 transition hover:border-foreground/20'>
+                      <a href={`/archive/${entry.id}`} class='block' data-astro-prefetch>
+                        <div class='mb-1 flex items-start justify-between gap-4'>
+                          <h3 class='font-medium leading-tight'>{entry.data.title}</h3>
+                          <span class={`shrink-0 text-xs ${statusColors[entry.data.status]}`}>
+                            {statusLabels[entry.data.status] || entry.data.status}
+                          </span>
+                        </div>
+                        {entry.data.description && (
+                          <p class='mb-2 text-sm text-muted-foreground'>
+                            {entry.data.description}
+                          </p>
+                        )}
+                        <div class='flex flex-wrap items-center gap-2 text-xs text-muted-foreground'>
+                          <time datetime={entry.data.date.toISOString()}>
+                            {entry.data.date.toLocaleDateString('zh-CN', {
+                              year: 'numeric',
+                              month: 'short',
+                              day: 'numeric'
+                            })}
+                          </time>
+                          {entry.data.updatedDate && (
+                            <span>
+                              · Updated{' '}
+                              {entry.data.updatedDate.toLocaleDateString('zh-CN', {
+                                month: 'short',
+                                day: 'numeric'
+                              })}
+                            </span>
+                          )}
+                          {entry.data.tags.length > 0 && (
+                            <>
+                              <span>·</span>
+                              <div class='flex flex-wrap gap-1'>
+                                {entry.data.tags.map((tag) => (
+                                  <span class='rounded bg-muted px-1.5 py-0.5'>{tag}</span>
+                                ))}
+                              </div>
+                            </>
+                          )}
+                        </div>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </section>
+
+          {/* sidebar */}
+          <aside class='animate' id='sidebar'>
+            {/* Tags */}
+            {!!uniqueTags.length && (
+              <div class='mb-6'>
+                <h2 class='mb-4 flex items-center text-lg font-semibold'>
+                  <Icon name='tag-2' class='me-2' />
+                  Tags
+                </h2>
+                <ul class='flex flex-wrap gap-2 text-xs'>
+                  {uniqueTags.map((tag) => (
+                    <li>
+                      <span class='rounded-md border border-border bg-card px-2 py-1'>{tag}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* Status Legend */}
+            <div class='mb-6'>
+              <h2 class='mb-4 text-lg font-semibold'>Status</h2>
+              <ul class='space-y-2 text-sm'>
+                {uniqueStatuses.map((status) => (
+                  <li class={statusColors[status]}>{statusLabels[status] || status}</li>
+                ))}
+              </ul>
+            </div>
+
+            {/* Types */}
+            <div>
+              <h2 class='mb-4 text-lg font-semibold'>Types</h2>
+              <ul class='space-y-2 text-sm'>
+                {uniqueTypes.map((type) => (
+                  <li>
+                    {typeLabels[type] || type}
+                    <span class='ml-2 text-muted-foreground'>
+                      ({groupedByType[type]?.length || 0})
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </aside>
+        </div>
+      )
+    }
+  </main>
+</PageLayout>

--- a/src/pages/archive/index.astro
+++ b/src/pages/archive/index.astro
@@ -129,7 +129,13 @@ const statusColors: Record<string, string> = {
                               <span>·</span>
                               <div class='flex flex-wrap gap-1'>
                                 {entry.data.tags.map((tag) => (
-                                  <span class='rounded bg-muted px-1.5 py-0.5'>{tag}</span>
+                                  <a
+                                    href={`/archive/tags/${tag}`}
+                                    class='rounded bg-muted px-1.5 py-0.5 hover:bg-muted/80'
+                                    onclick={(e: Event) => e.stopPropagation()}
+                                  >
+                                    {tag}
+                                  </a>
                                 ))}
                               </div>
                             </>
@@ -148,16 +154,39 @@ const statusColors: Record<string, string> = {
             {/* Tags */}
             {!!uniqueTags.length && (
               <div class='mb-6'>
-                <h2 class='mb-4 flex items-center text-lg font-semibold'>
-                  <Icon name='tag-2' class='me-2' />
-                  Tags
-                </h2>
+                <div class='mb-4 flex items-center justify-between'>
+                  <h2 class='flex items-center text-lg font-semibold'>
+                    <Icon name='tag-2' class='me-2' />
+                    Tags
+                  </h2>
+                  <a
+                    href='/archive/tags'
+                    class='text-xs text-muted-foreground hover:text-foreground'
+                  >
+                    View all →
+                  </a>
+                </div>
                 <ul class='flex flex-wrap gap-2 text-xs'>
-                  {uniqueTags.map((tag) => (
+                  {uniqueTags.slice(0, 15).map((tag) => (
                     <li>
-                      <span class='rounded-md border border-border bg-card px-2 py-1'>{tag}</span>
+                      <a
+                        href={`/archive/tags/${tag}`}
+                        class='rounded-md border border-border bg-card px-2 py-1 transition hover:border-foreground/20'
+                      >
+                        {tag}
+                      </a>
                     </li>
                   ))}
+                  {uniqueTags.length > 15 && (
+                    <li>
+                      <a
+                        href='/archive/tags'
+                        class='rounded-md border border-dashed border-border bg-card px-2 py-1 text-muted-foreground hover:text-foreground'
+                      >
+                        +{uniqueTags.length - 15} more
+                      </a>
+                    </li>
+                  )}
                 </ul>
               </div>
             )}

--- a/src/pages/archive/tags/[tag]/[...page].astro
+++ b/src/pages/archive/tags/[tag]/[...page].astro
@@ -79,56 +79,72 @@ const meta = {
       <ul class='space-y-3'>
         {
           page.data.map((entry: any) => (
-            <li class='rounded-lg border border-border bg-card p-4 transition hover:border-foreground/20'>
+            <li class='group relative rounded-lg border border-border bg-card p-4 transition hover:border-foreground/20 hover:shadow-sm'>
               <a href={`/archive/${entry.id}`} class='block' data-astro-prefetch>
-                <div class='mb-1 flex items-start justify-between gap-4'>
-                  <h3 class='font-medium leading-tight'>{entry.data.title}</h3>
-                  <div class='flex shrink-0 items-center gap-2'>
-                    <span class='text-xs text-muted-foreground'>
-                      {typeLabels[entry.data.type] || entry.data.type}
-                    </span>
-                    <span class={`text-xs ${statusColors[entry.data.status]}`}>
-                      {statusLabels[entry.data.status] || entry.data.status}
-                    </span>
+                <div class='mb-2 flex items-start gap-3'>
+                  <div class='mt-0.5 shrink-0 text-xl opacity-70 group-hover:opacity-100'>
+                    {entry.data.type === 'note' && '📝'}
+                    {entry.data.type === 'snippet' && '💡'}
+                    {entry.data.type === 'draft' && '✏️'}
+                    {entry.data.type === 'idea' && '🔮'}
+                    {entry.data.type === 'research' && '🔬'}
+                    {entry.data.type === 'reference' && '📚'}
                   </div>
-                </div>
-                {entry.data.description && (
-                  <p class='mb-2 text-sm text-muted-foreground'>{entry.data.description}</p>
-                )}
-                <div class='flex flex-wrap items-center gap-2 text-xs text-muted-foreground'>
-                  <time datetime={entry.data.date.toISOString()}>
-                    {entry.data.date.toLocaleDateString('zh-CN', {
-                      year: 'numeric',
-                      month: 'short',
-                      day: 'numeric'
-                    })}
-                  </time>
-                  {entry.data.updatedDate && (
-                    <span>
-                      · Updated{' '}
-                      {entry.data.updatedDate.toLocaleDateString('zh-CN', {
-                        month: 'short',
-                        day: 'numeric'
-                      })}
-                    </span>
-                  )}
-                  {entry.data.tags.length > 1 && (
-                    <>
-                      <span>·</span>
-                      <div class='flex flex-wrap gap-1'>
-                        {entry.data.tags
-                          .filter((t: string) => t !== tag)
-                          .map((t: string) => (
-                            <a
-                              href={`/archive/tags/${t}`}
-                              class='rounded bg-muted px-1.5 py-0.5 hover:bg-muted/80'
-                            >
-                              {t}
-                            </a>
-                          ))}
-                      </div>
-                    </>
-                  )}
+                  <div class='min-w-0 flex-1'>
+                    <div class='mb-1 flex items-start justify-between gap-4'>
+                      <h3 class='font-medium leading-tight group-hover:text-foreground'>
+                        {entry.data.title}
+                      </h3>
+                      <span
+                        class={`shrink-0 text-xs ${statusColors[entry.data.status]}`}
+                        title={statusLabels[entry.data.status]}
+                      >
+                        {entry.data.status === 'in-progress' && '🚧'}
+                        {entry.data.status === 'incomplete' && '⏸️'}
+                        {entry.data.status === 'ready' && '✅'}
+                        {entry.data.status === 'archived' && '📦'}
+                      </span>
+                    </div>
+                    {entry.data.description && (
+                      <p class='mb-2 text-sm text-muted-foreground'>{entry.data.description}</p>
+                    )}
+                    <div class='flex flex-wrap items-center gap-2 text-xs text-muted-foreground'>
+                      <time datetime={entry.data.date.toISOString()}>
+                        {entry.data.date.toLocaleDateString('zh-CN', {
+                          year: 'numeric',
+                          month: 'short',
+                          day: 'numeric'
+                        })}
+                      </time>
+                      {entry.data.updatedDate && (
+                        <span>
+                          · Updated{' '}
+                          {entry.data.updatedDate.toLocaleDateString('zh-CN', {
+                            month: 'short',
+                            day: 'numeric'
+                          })}
+                        </span>
+                      )}
+                      {entry.data.tags.length > 1 && (
+                        <>
+                          <span>·</span>
+                          <div class='flex flex-wrap gap-1'>
+                            {entry.data.tags
+                              .filter((t: string) => t !== tag)
+                              .map((t: string) => (
+                                <a
+                                  href={`/archive/tags/${t}`}
+                                  class='rounded bg-muted px-1.5 py-0.5 hover:bg-muted/80'
+                                  onclick={(e: Event) => e.stopPropagation()}
+                                >
+                                  {t}
+                                </a>
+                              ))}
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  </div>
                 </div>
               </a>
             </li>

--- a/src/pages/archive/tags/[tag]/[...page].astro
+++ b/src/pages/archive/tags/[tag]/[...page].astro
@@ -1,0 +1,146 @@
+---
+/**
+ * Archive Tag Filter Page with Pagination
+ * Shows archive entries filtered by tag
+ */
+import { getCollection } from 'astro:content'
+import { Button, Icon, Pagination } from 'astro-pure/user'
+import PageLayout from '@/layouts/BaseLayout.astro'
+
+export const prerender = true
+
+export async function getStaticPaths({ paginate }: any) {
+  const allArchives = (await getCollection('archive')).filter((entry) => !entry.data.draft)
+
+  // Get all unique tags
+  const uniqueTags = [...new Set(allArchives.flatMap((entry) => entry.data.tags))]
+
+  return uniqueTags.flatMap((tag) => {
+    const filteredEntries = allArchives
+      .filter((entry) => entry.data.tags.includes(tag))
+      .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+
+    return paginate(filteredEntries, {
+      params: { tag },
+      pageSize: 10
+    })
+  })
+}
+
+const { page } = Astro.props
+const { tag } = Astro.params
+
+// Type labels with emoji icons
+const typeLabels: Record<string, string> = {
+  note: '📝 Note',
+  snippet: '💡 Snippet',
+  draft: '✏️ Draft',
+  idea: '🔮 Idea',
+  research: '🔬 Research',
+  reference: '📚 Reference'
+}
+
+// Status labels and colors
+const statusLabels: Record<string, string> = {
+  'in-progress': '🚧 In Progress',
+  incomplete: '⏸️ Incomplete',
+  ready: '✅ Ready',
+  archived: '📦 Archived'
+}
+
+const statusColors: Record<string, string> = {
+  'in-progress': 'text-blue-600 dark:text-blue-400',
+  incomplete: 'text-yellow-600 dark:text-yellow-400',
+  ready: 'text-green-600 dark:text-green-400',
+  archived: 'text-gray-500 dark:text-gray-400'
+}
+
+const meta = {
+  title: `Archive Tag: ${tag}`,
+  description: `Archive entries tagged with ${tag}`
+}
+---
+
+<PageLayout {meta}>
+  <Button title='Back' href='/archive' style='back' />
+
+  <main class='mt-6 lg:mt-10'>
+    <div id='content-header' class='animate'>
+      <div class='mb-2 flex items-center gap-2'>
+        <Icon name='tag-2' class='text-muted-foreground' />
+        <h1 class='text-3xl font-medium'>{tag}</h1>
+      </div>
+      <p class='mb-6 text-muted-foreground'>
+        {page.total} {page.total === 1 ? 'entry' : 'entries'} with this tag
+      </p>
+    </div>
+
+    <section id='content' class='animate' aria-label='Archive entries'>
+      <ul class='space-y-3'>
+        {
+          page.data.map((entry: any) => (
+            <li class='rounded-lg border border-border bg-card p-4 transition hover:border-foreground/20'>
+              <a href={`/archive/${entry.id}`} class='block' data-astro-prefetch>
+                <div class='mb-1 flex items-start justify-between gap-4'>
+                  <h3 class='font-medium leading-tight'>{entry.data.title}</h3>
+                  <div class='flex shrink-0 items-center gap-2'>
+                    <span class='text-xs text-muted-foreground'>
+                      {typeLabels[entry.data.type] || entry.data.type}
+                    </span>
+                    <span class={`text-xs ${statusColors[entry.data.status]}`}>
+                      {statusLabels[entry.data.status] || entry.data.status}
+                    </span>
+                  </div>
+                </div>
+                {entry.data.description && (
+                  <p class='mb-2 text-sm text-muted-foreground'>{entry.data.description}</p>
+                )}
+                <div class='flex flex-wrap items-center gap-2 text-xs text-muted-foreground'>
+                  <time datetime={entry.data.date.toISOString()}>
+                    {entry.data.date.toLocaleDateString('zh-CN', {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric'
+                    })}
+                  </time>
+                  {entry.data.updatedDate && (
+                    <span>
+                      · Updated{' '}
+                      {entry.data.updatedDate.toLocaleDateString('zh-CN', {
+                        month: 'short',
+                        day: 'numeric'
+                      })}
+                    </span>
+                  )}
+                  {entry.data.tags.length > 1 && (
+                    <>
+                      <span>·</span>
+                      <div class='flex flex-wrap gap-1'>
+                        {entry.data.tags
+                          .filter((t: string) => t !== tag)
+                          .map((t: string) => (
+                            <a
+                              href={`/archive/tags/${t}`}
+                              class='rounded bg-muted px-1.5 py-0.5 hover:bg-muted/80'
+                            >
+                              {t}
+                            </a>
+                          ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+
+      {page.lastPage > 1 && (
+        <div class='mt-8'>
+          <Pagination page={page} />
+        </div>
+      )}
+    </section>
+  </main>
+</PageLayout>

--- a/src/pages/archive/tags/index.astro
+++ b/src/pages/archive/tags/index.astro
@@ -1,0 +1,76 @@
+---
+/**
+ * Archive Tags Index
+ * Shows all tags used in the archive with entry counts
+ */
+import { getCollection } from 'astro:content'
+import { Button, Icon } from 'astro-pure/user'
+import PageLayout from '@/layouts/BaseLayout.astro'
+
+export const prerender = true
+
+const allArchives = (await getCollection('archive')).filter((entry) => !entry.data.draft)
+
+// Count entries per tag
+const tagCounts = allArchives.reduce(
+  (acc, entry) => {
+    entry.data.tags.forEach((tag) => {
+      acc[tag] = (acc[tag] || 0) + 1
+    })
+    return acc
+  },
+  {} as Record<string, number>
+)
+
+// Sort tags by count (descending), then alphabetically
+const sortedTags = Object.entries(tagCounts).sort(([tagA, countA], [tagB, countB]) => {
+  if (countB !== countA) return countB - countA
+  return tagA.localeCompare(tagB)
+})
+
+const meta = {
+  title: 'Archive Tags',
+  description: 'Browse archive entries by tag'
+}
+---
+
+<PageLayout {meta}>
+  <Button title='Back' href='/archive' style='back' />
+
+  <main class='mt-6 lg:mt-10'>
+    <div id='content-header' class='animate'>
+      <h1 class='mb-2 flex items-center gap-2 text-3xl font-medium'>
+        <Icon name='tag-2' />
+        Archive Tags
+      </h1>
+      <p class='mb-6 text-muted-foreground'>
+        Browse {sortedTags.length} tags across {allArchives.length} archive entries
+      </p>
+    </div>
+
+    <section id='content' class='animate'>
+      <div class='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
+        {
+          sortedTags.map(([tag, count]) => (
+            <a
+              href={`/archive/tags/${tag}`}
+              class='group rounded-lg border border-border bg-card p-4 transition hover:border-foreground/20 hover:shadow-sm'
+              data-astro-prefetch
+            >
+              <div class='flex items-center justify-between'>
+                <span class='font-medium group-hover:text-foreground'>{tag}</span>
+                <span class='rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground'>
+                  {count}
+                </span>
+              </div>
+            </a>
+          ))
+        }
+      </div>
+
+      {sortedTags.length === 0 && (
+        <p class='text-muted-foreground'>No tags found in archive entries.</p>
+      )}
+    </section>
+  </main>
+</PageLayout>

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -1,4 +1,9 @@
 ---
+/**
+ * Blog Archives by Year - /archives (plural)
+ * This page shows blog posts grouped by year.
+ * Note: This is different from /archive (singular) which is the knowledge base/archive module.
+ */
 import { PostPreview } from 'astro-pure/components/pages'
 import { getBlogCollection, groupCollectionsByYear, sortMDByDate } from 'astro-pure/server'
 import { Button } from 'astro-pure/user'

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -48,6 +48,7 @@ export const theme: ThemeUserConfig = {
   header: {
     menu: [
       { title: 'Blog', link: '/blog' },
+      { title: 'Archive', link: '/archive' },
       { title: 'Projects', link: '/projects' },
       { title: 'Links', link: '/links' },
       { title: 'About', link: '/about' }


### PR DESCRIPTION
## Summary\n- add a dedicated archive content collection for working notes and knowledge base entries\n- add archive listing, detail pages, tags, pagination, and improved archive-specific UI\n- add archive metadata relationships and sample entries while keeping existing blog archives intact\n\n## Included\n- archive collection schema with status/type/relations/source metadata\n- /archive listing page\n- /archive/[...page] pagination\n- /archive/tags and tag detail pagination\n- archive detail page polish\n- navigation update and /archive vs /archives clarification\n\n## Verification\n- bun run build