### PR TITLE
Fix dark mode blockquote text contrast

### DIFF
--- a/uno.config.ts
+++ b/uno.config.ts
@@ -31,11 +31,20 @@ const typographyConfig = {
     blockquote: {
       position: 'relative',
       overflow: 'hidden',
+      color: fg,
+      '--un-prose-quotes': fg,
+      '--un-prose-quote-borders': 'hsl(var(--border) / 1)',
       'border-width': '1px',
       'border-left': 'inherit',
       'border-radius': 'var(--radius)',
       'padding-inline': '1.6rem',
       'box-shadow': '0 5px 0 ' + bgMuted
+    },
+    'blockquote p': {
+      color: 'inherit'
+    },
+    'blockquote p::before,blockquote p::after': {
+      color: 'inherit'
     },
     'blockquote::after': {
       color: fgMuted,


### PR DESCRIPTION
## Summary
- update Uno typography `blockquote` styles to use the theme foreground color
- set quote border color from theme border tokens for consistent dark mode rendering
- ensure blockquote paragraphs and quote pseudo-elements inherit the corrected text color

## Testing
- Not run (not requested)