### PR TITLE
add archive card for modern nextjs stack tradeoffs

### DIFF
--- a/src/content/archive/0326-jina-embeddings-api-deep-dive.md
+++ b/src/content/archive/0326-jina-embeddings-api-deep-dive.md
@@ -2,7 +2,7 @@
 title: Jina Embeddings API 深度解析
 description: 关于 Jina Embeddings 在多语言检索、长文本、Late Chunking、v4/v5 选型上的整理笔记。
 date: 2026-03-14
-updatedDate: 2026-03-14
+updatedDate: 2026-03-25
 tags:
   - ai
   - llm
@@ -81,9 +81,9 @@ Jina 在多语言 embedding 排行里长期表现很强，尤其适合：
 
 **Late Chunking** 的思路是：
 
-1. 先对全文编码
-2. 利用全文级别的 attention 让 token 拿到全局上下文
-3. 再根据切片边界对输出做 pooling
+1. 先让 embedding 模型处理整段长文本
+2. 在 token 级别得到带全文上下文的 hidden states / token representations
+3. 再根据预先定义好的 chunk 边界，对对应 token 做 pooling，得到 chunk vector
 
 结果就是：
 
@@ -93,6 +93,60 @@ Jina 在多语言 embedding 排行里长期表现很强，尤其适合：
 
 这个点对知识库、笔记库、长文档检索特别重要。
 
+#### 为什么 Late Chunking 比传统切分更稳
+可以把它理解成：**传统 chunking 是“先切再理解”，Late Chunking 是“先理解再切”。**
+
+##### 传统切分（Traditional Chunking）
+流程大致是：
+
+`文本 -> 切成 Chunk A/B/C -> 各自做 Embedding -> 得到多个向量`
+
+这种方法的核心问题是“上下文孤立”。
+
+如果 Chunk B 里出现：
+
+- “它”
+- “这个算法”
+- “该公司”
+
+而真正的指代对象在 Chunk A 中，那么 Chunk B 单独做 embedding 时，就很容易丢掉最关键的语义锚点。
+
+##### Late Chunking
+流程则变成：
+
+`全文 -> 一次性输入长文本 embedding 模型 -> 得到 token 级表征 -> 按边界切分并聚合`
+
+因为模型先看过全文，token 在 self-attention 过程中已经吸收了周围乃至更远处的上下文，所以即使最后再把这些 token 按 chunk 边界做池化，得到的 chunk vector 仍然保留了较强的全局语义。
+
+这也是为什么 Late Chunking 特别适合：
+
+- 长文档 RAG
+- 知识库整页检索
+- 对代词指代和跨段落关系敏感的内容
+
+#### 对开发者最直接的价值
+如果从工程视角看，Late Chunking 有几个特别实用的优点：
+
+- **解决指代消解问题**：像“这个方法”“它”“前者/后者”这类表达，不再因为 chunk 被切开而失真
+- **减少暴力切分的语义损耗**：不容易把一句话、一个定义、一个论证链条从中间硬切断
+- **向量索引层基本不用改**：你仍然可以照常存 chunk-level vectors，但这些向量本身会更有信息量
+
+也就是说，它并不会强迫你完全重写向量库或召回结构，但会显著提高已有检索管线里的 chunk 质量。
+
+#### 一个很实用的实现心智模型
+如果你在代码里自己实现，最常见的思路可以记成三步：
+
+1. 用支持长上下文的 embedding encoder 编码全文
+2. 取出所有 token 的 hidden states
+3. 按 chunk 边界对 token vectors 做 pooling（常见是 mean pooling）
+
+可以粗略写成：
+
+`Chunk Vector = (1 / n) * Σ Token Vector_i`
+
+其中 `i` 覆盖这个 chunk 对应的 token 区间。
+
+这个实现思路的好处是简单直接，而且很容易和现有的 sentence / paragraph / fixed-token chunking 策略结合。
 #### Matryoshka 支持很适合生产环境
 整理里提到它支持通过 `dimensions` 参数把高维向量压到更低维，比如：
 

--- a/src/content/archive/0326-modern-nextjs-stack-tradeoffs.md
+++ b/src/content/archive/0326-modern-nextjs-stack-tradeoffs.md
@@ -1,0 +1,281 @@
+---
+title: 现代 Next.js 技术栈选型取舍：Drizzle / Prisma、Arctic / Auth.js、Jotai / Redux
+description: 围绕一段 Grok 对话整理现代 Next.js 项目在 ORM、认证、状态管理上的实际选型取舍与判断标准。
+date: 2026-03-30
+updatedDate: 2026-03-30
+tags:
+  - frontend
+  - typescript
+  - react
+  - software engineering
+  - agent
+  - reference
+type: research
+status: ready
+source: https://grok.com/share/c2hhcmQtMw_cd0724ae-7bf8-49c0-88f9-f6f0a496513f
+draft: false
+---
+
+## 核心内容
+
+这张卡片来自一段关于 **现代 Next.js / TypeScript 技术栈选型** 的 Grok 对话，核心对比集中在三组：
+
+- **Drizzle vs Prisma**
+- **Arctic vs NextAuth / Auth.js**
+- **Jotai vs Redux**
+
+这段讨论最有价值的地方，不是给出一个“唯一正确答案”，而是把三类常见取舍拆开了：
+
+1. **数据库访问层**：更轻、更贴近 SQL，还是更成熟、更抽象的 ORM 体验
+2. **认证方案**：更底层、更可控的 OAuth 组合，还是更完整的认证框架
+3. **前端状态管理**：更轻的原子化状态，还是更强规范和更大生态的全局状态方案
+
+如果先写一个压缩版结论：
+
+> 对于 2026 年的多数新 Next.js 项目，整体倾向是 **Drizzle +（Arctic / Auth.js 视复杂度而定）+ Jotai**。但一旦团队更依赖成熟工具链、低 SQL 心智负担、完整认证能力、严格状态流转，Prisma / Auth.js / Redux Toolkit 依然有合理位置。
+
+## 要点整理
+
+### 1. Drizzle vs Prisma：本质是“轻薄 SQL-first”与“成熟抽象层”之间的取舍
+
+这段对话里，对 Drizzle 的整体判断是：
+
+- 更贴近数据库
+- 更轻量
+- 对 Serverless / Edge 更友好
+- 查询路径更短
+- 更适合追求性能和控制感的新项目
+
+对 Prisma 的判断则是：
+
+- 更成熟
+- Studio / Migrate 等工具更完整
+- 团队更容易上手
+- 更适合不想深碰 SQL 的团队
+
+#### Drizzle 的优势集中在这些点
+
+- **SQL-first / Code-first**：用 TypeScript 描述 schema，但思维方式仍然更像在写 SQL
+- **几乎没有额外查询引擎负担**：更接近薄层封装，而不是厚重抽象
+- **bundle 更小、冷启动更短**：尤其适合 Vercel Serverless、Cloudflare Workers、Edge Runtime
+- **性能更接近 raw SQL**：尤其在复杂查询、索引利用、对生成 SQL 质量更敏感的场景里更有优势
+- **控制感更强**：需要手写 raw SQL 或微调查询时不容易“打架”
+
+#### Prisma 的优势集中在这些点
+
+- **开发体验成熟**：Schema、Client、Studio、Migrate 这套工作流对很多团队非常顺手
+- **学习曲线更低**：尤其对 SQL 不熟、但习惯高级 ORM 的开发者更友好
+- **生态更稳**：文档、社区惯例、历史项目沉淀都更多
+- **团队协作更一致**：在多人协作和规范化开发里，经常更容易建立统一约束
+
+#### 这段对话里最值得记的一句判断
+
+> **Drizzle 更像“面向现代部署环境和性能敏感场景的默认选择”，Prisma 更像“面向成熟团队工具链和抽象体验的稳妥选择”。**
+
+### 2. 为什么 Drizzle 更适合 Serverless
+
+这段对话后半段有一段追问，重点解释了：
+
+- 为什么会说 Drizzle 更适合 Serverless
+- Serverless / Vercel Serverless 到底意味着什么
+- 为什么 bundle 大小和冷启动会直接影响 ORM 的实际体验
+
+核心理解是：
+
+#### Serverless 不是“没有服务器”，而是“函数按需启动”
+
+典型场景包括：
+
+- Next.js API Routes
+- Vercel Serverless Functions
+- Vercel Edge Functions
+- Cloudflare Workers
+- AWS Lambda
+
+这些环境里，函数实例会被频繁拉起。每次拉起时，都会有：
+
+- 加载代码包
+- 初始化依赖
+- 建立数据库连接或准备驱动
+- 执行请求
+
+如果依赖很重：
+
+- 冷启动更慢
+- 用户更容易感到首屏 / 首次请求延迟
+- 按执行时间计费的平台成本也更高
+
+#### Drizzle 在这里的优势，不是“功能更多”，而是“负担更少”
+
+这段讨论给出的逻辑很清楚：
+
+- Drizzle 本身非常轻
+- 没有那么重的额外查询引擎负担
+- 更适合边缘环境
+- 冷启动和内存占用更友好
+
+所以它更适合：
+
+- 高并发 API
+- 全球边缘部署
+- 对冷启动敏感的 SaaS / App 后端
+- 以 Vercel / Cloudflare / Supabase Edge 为核心部署平台的项目
+
+这里真正该记住的不是“Drizzle 永远更好”，而是：
+
+> **一旦部署环境对 bundle、冷启动、边缘兼容性特别敏感，ORM 的重量就会从“工程细节”变成“产品体验问题”。**
+
+### 3. 为什么 Drizzle 通常被认为查询更快
+
+对话里的解释很直白：
+
+- Drizzle 是更薄的一层
+- Prisma 即使已经明显变轻，仍然是一套更高层的抽象
+- 抽象层越厚，查询路径越长，生成 SQL 的不可控因素也越多
+
+这里的关键不是“Prisma 很慢”，而是：
+
+- **简单 CRUD**：两者差距通常不大
+- **复杂查询 / 复杂 join / 对 SQL 质量敏感的查询**：Drizzle 更容易贴近数据库原生能力
+- **raw SQL 混用场景**：Drizzle 更自然
+
+所以更准确的结论应该是：
+
+> Drizzle 的性能优势主要来自“少一层抽象”和“更贴近数据库语义”，不是魔法加速。
+
+### 4. Arctic vs Auth.js：轻量 OAuth 工具 vs 完整认证框架
+
+这段对话里对 Arctic 的定位很清楚：
+
+- 它是一个 **轻量 OAuth 库**
+- 它不是一整套完整认证框架
+- 它更适合你自己掌控 session、database、认证流程时使用
+
+而 Auth.js（原 NextAuth）的定位是：
+
+- **完整认证框架**
+- 在 Next.js 生态里更主流
+- 适合快速支持 OAuth、Session、Database Adapter 等常见需求
+
+#### 什么时候更偏 Arctic
+
+- 项目规模较小
+- 你想保留更大控制权
+- 你不喜欢“全家桶式”认证框架
+- 你已经有自己的 Session / Database 方案
+- 你更在意系统干净、轻量、可组合
+
+#### 什么时候更偏 Auth.js
+
+- 你要快速上线
+- 你需要多个 OAuth provider
+- 你需要比较完整的认证能力
+- 你不想自己重新拼 Session / Adapter / 持久化逻辑
+- 你希望站在 Next.js 主流生态一侧
+
+这类判断很像前面的 Drizzle / Prisma：
+
+> **Arctic 更像可组合的小零件，Auth.js 更像完整工具箱。**
+
+### 5. Jotai vs Redux：状态管理从“规范优先”转向“轻量优先”
+
+这段对话的整体倾向是：
+
+- 到了 2026 年，Redux 已经不再是默认选择
+- 对很多 React / Next.js 新项目来说，Jotai / Zustand 这类轻量方案更自然
+
+#### Jotai 的优势
+
+- 原子化心智模型更轻
+- 写法简洁
+- 局部状态与全局共享状态之间切换更自然
+- boilerplate 少
+- 更适合中小型项目或组件驱动的现代 React 开发
+
+#### Redux Toolkit 的优势
+
+- 规范强
+- DevTools 生态非常成熟
+- 多人协作和复杂业务状态更容易统一管理
+- 适合大型企业应用、复杂异步流、严格状态流转场景
+
+### 6. 这里的 boilerplate 到底是什么意思
+
+对话里专门解释了 Jotai vs Redux 里的 **boilerplate**。
+
+这个词最值得保留的理解是：
+
+> **不是业务本身需要的代码，而是“为了使用这个框架，不得不先写的一大堆样板结构”。**
+
+在 Redux 体系里，这通常意味着：
+
+- action
+- reducer / slice
+- store
+- dispatch 流程
+- selector
+- 各种固定组织方式
+
+Redux Toolkit 已经把很多老式 Redux 的痛苦降下来了，但在很多轻量项目里，这些结构依然显得偏重。
+
+而 Jotai 的吸引力就在于：
+
+- 状态定义通常更接近直接声明
+- 业务代码和状态代码距离更近
+- 为了“让状态管理框架工作”而写的额外代码明显更少
+
+所以这个问题的实质不是“代码少就更高级”，而是：
+
+> **状态复杂度如果不高，就没必要过早引入一整套重型约束。**
+
+## 当前理解 / 结论
+
+这段对话最后可以压成一套很实用的判断框架：
+
+### 更偏现代轻量组合时
+
+优先考虑：
+
+- **Drizzle**：部署在 Serverless / Edge、追求性能与轻量、愿意接近 SQL
+- **Arctic**：想保留最大控制权，自己组合 Session / DB / Auth 流程
+- **Jotai**：项目状态复杂度中低，想降低样板代码和心智负担
+
+这套组合更适合：
+
+- 新项目
+- 个人项目
+- 小团队产品
+- 追求轻、快、可控的现代 Web 应用
+
+### 更偏成熟稳妥组合时
+
+优先考虑：
+
+- **Prisma**：更成熟的 DX、Studio、Migrate、团队协作一致性
+- **Auth.js**：完整认证能力、Next.js 主流方案、快速上线
+- **Redux Toolkit**：复杂状态、多人协作、强规范与强调试需求
+
+这套组合更适合：
+
+- 多人团队
+- 中大型业务系统
+- 已有生态包袱
+- 更看重工具成熟度而不是极致轻量
+
+### 最值得保留的 meta 判断
+
+这不是三组选型题，而是同一个大问题在三个层面的展开：
+
+> **你到底更想要“轻量、贴近底层、可控”，还是“成熟、抽象、完整工具链”？**
+
+ORM、Auth、State 只是这个问题在不同层面的不同体现。
+
+## 待补充
+
+- 补一版 **Better Auth / Lucia / Auth.js / Arctic** 的更细选型对比
+- 补一版 **Jotai / Zustand / Redux Toolkit** 的更贴近真实项目案例比较
+- 如果后续自己要做 Next.js 项目，可以把这张卡升级成一张“实际项目技术栈决策记录”
+
+## 相关链接 / 来源
+
+- Grok shared conversation: <https://grok.com/share/c2hhcmQtMw_cd0724ae-7bf8-49c0-88f9-f6f0a496513f>


### PR DESCRIPTION
## Summary
- add an archive card from the Grok shared conversation
- capture tradeoffs across Drizzle/Prisma, Arctic/Auth.js, and Jotai/Redux
- preserve the Serverless and boilerplate discussion as reusable notes

## Validation
- bun run check