### PR TITLE
Update Jina embeddings archive card with RAG notes

### DIFF
--- a/src/content/archive/0326-jina-embeddings-api-deep-dive.md
+++ b/src/content/archive/0326-jina-embeddings-api-deep-dive.md
@@ -2,12 +2,13 @@
 title: Jina Embeddings API 深度解析
 description: 关于 Jina Embeddings 在多语言检索、长文本、Late Chunking、v4/v5 选型上的整理笔记。
 date: 2026-03-14
-updatedDate: 2026-04-14
+updatedDate: 2026-04-16
 tags:
   - ai
   - llm
   - rag
   - embedding
+  - reranker
   - jina
   - qwen
 type: research
@@ -542,27 +543,214 @@ benchmark 叙事也比之前更具体：
 
 这比单看 Jina 官方 release note 更接近真正做系统时的决策方式。
 
+## 新增补充：RAG 里 Embedding + Reranker 为什么几乎是标配
+
+这次新读的 Grok 分享，最适合补进来的不是 Jina 产品列表本身，而是它把 **Embedding / Reranker 在 RAG 里的分工** 讲得比较顺。
+
+### 1. 在生产级 RAG 里，Embedding 和 Reranker 往往不是二选一
+
+如果只做最简版 RAG，流程通常是：
+
+1. 文档切块
+2. 用 embedding 建索引
+3. 用户 query 也做 embedding
+4. 相似度搜索出 top-k
+5. 丢给 LLM 生成答案
+
+这个流程能跑，但一旦要求变成：
+
+- 准确率更高
+- 幻觉更少
+- 上下文更干净
+- LLM token 更省
+
+就会很快发现：**只靠 embedding recall 往往不够。**
+
+更常见的生产做法是 two-stage retrieval：
+
+`Embedding recall -> top-50~100 candidates -> Reranker rerank -> top-5~10 contexts -> LLM`
+
+也就是：
+
+- **Embedding** 负责大范围、低成本、快速召回
+- **Reranker** 负责把候选逐个和 query 精排，提升 precision
+
+这个分工很像：
+
+- embedding 是“先撒网捞一批可能相关的”
+- reranker 是“再把捞上来的逐条过秤，只留最相关的”
+
+### 2. Embedding 强在 recall，不强在最终排序
+
+这次补充里最值得记的一点是：embedding 的强项不是“最终判断谁最相关”，而是“从海量语料里先缩小搜索空间”。
+
+原因很简单，它通常是 **bi-encoder** 路线：
+
+- query 单独编码
+- document/chunk 单独编码
+- 用向量距离做近似匹配
+
+这样做的好处是：
+
+- 非常快
+- 易于预计算
+- 适合大规模向量库
+
+但代价是：
+
+- 对细粒度关系判断没那么强
+- 对否定、限定条件、细微逻辑差异不够敏感
+- top-k 里容易混入“语义有点像，但其实不够准”的 chunk
+
+所以 embedding 更像 **high recall, medium precision** 的第一关。
+
+### 3. Reranker 的价值，是把“看起来像”变成“真正相关”
+
+Reranker 常见是 **cross-encoder** 思路，它会把 query 和候选文本放在一起重新判断。
+
+这意味着它能看得更细：
+
+- 这个 chunk 真的是在回答这个问题吗
+- 只是主题接近，还是条件也匹配
+- 有无被否定、反转、范围限制
+
+这一步虽然慢一些、贵一些，但通常只处理几十条候选，所以整体成本可控。
+
+更关键的是，它常常能直接带来：
+
+- 更准的上下文
+- 更少的噪声 chunk
+- 更低的 hallucination 风险
+- 更少的 LLM token 浪费
+
+所以在真实系统里，**加一个 reranker 往往比盲目换更大的生成模型更划算。**
+
+### 4. 一个很实用的 RAG 心智模型
+
+如果要用一句最短的话记住它们的区别，我会写成：
+
+- **Embedding 是 RAG 的腿**，负责跑得快、找得广
+- **Reranker 是 RAG 的眼睛**，负责看得准、挑得精
+
+这也是为什么之前那句混合方案现在看更顺了：
+
+- `Jina recall + Qwen rerank`
+
+本质上不是随便拼，而是顺着两阶段检索的职责分工来设计。
+
+## 新增补充：除了 Embedding / Reranker，还值得继续学的 RAG 细节
+
+这次分享里还有一部分挺适合保留下来，作为“下一阶段该学什么”的路线图。
+
+### 1. Chunking 仍然是 RAG 的地基
+
+虽然这张卡已经写了 Late Chunking，但 broader RAG 视角里，chunking 仍然是最容易决定上限的环节。
+
+值得继续分开研究的方向包括：
+
+- fixed-size chunking
+- semantic chunking
+- overlap 策略
+- parent-child / hierarchical chunking
+- Late Chunking 和传统 chunking 的边界条件
+
+很多检索问题，最后追根究底不是 embedding 模型差，而是 chunk 切得不对。
+
+### 2. Hybrid Search 很值得放进默认设计
+
+单纯 dense retrieval 有一个老问题：
+
+- 语义相近能找到
+- 但对专有名词、编号、精确字符串不够稳
+
+所以更像生产默认项的常常是：
+
+- dense retrieval（embedding）
+- sparse / keyword retrieval（如 BM25）
+- 再做融合和 rerank
+
+也就是常说的 **Hybrid Search**。
+
+如果语料里有这些内容，它会特别重要：
+
+- 产品名
+- API 名
+- 报错文本
+- 版本号
+- 法律条文编号
+- 代码符号
+
+### 3. Query Transformation 常常是低成本高收益项
+
+用户原始 query 经常太短、太模糊，或者缺关键上下文。
+
+所以在检索前加一层 query transformation，通常很划算，比如：
+
+- query rewrite
+- query expansion
+- multi-query retrieval
+- HyDE
+
+这个方向的价值在于：
+
+- 对用户提问质量要求更低
+- 对 recall 提升常常很明显
+- 实现复杂度通常不高
+
+### 4. Post-retrieval processing 能直接省 token
+
+检索回来之后，不一定要把原始 top-k 全塞给 LLM。
+
+中间还可以做：
+
+- metadata filtering
+- context compression
+- chunk summarization
+- duplicate removal
+- citation alignment
+
+这层做得好，常常会同时改善：
+
+- 成本
+- 延迟
+- 答案可控性
+
+### 5. 更高级的方向是 Agentic / Corrective / Graph RAG
+
+如果基础两阶段检索已经跑顺，再往上走通常会进入这些方向：
+
+- **Agentic RAG**：让 agent 判断要不要继续搜、换关键词、调用额外工具
+- **Corrective RAG**：先检查当前检索结果够不够好，不够就修正流程
+- **Graph RAG**：当知识本身更像实体关系网络时，用图结构辅助检索
+
+这些方向都不是“先学”的，但它们决定了 RAG 从“检索增强”升级到“检索驱动推理”的上限。
+
 ## 当前理解 / 结论
 
-这次重新读完官方页面、再补上与 Qwen3-Embedding 的对比后，我对 Jina Embeddings 的判断是：
+这次重新读完官方页面、再补上与 Qwen3-Embedding 的对比，以及 Grok 里关于 RAG pipeline 的说明后，我对 Jina Embeddings 的判断是：
 
 ### 适合认真尝试的情况
 - 中文或多语言 RAG
 - 长文档检索
 - 需要更高 retrieval quality
 - 想要研究 Late Chunking 带来的收益
+- 希望搭两阶段检索，而不只是单层 embedding search
 - 关心存储成本，希望通过维度压缩省成本
 - 未来可能做多模态检索
 
 ### 暂时不一定优先的情况
 - 只是做一个很小、纯英文、短文本的 demo
 - 没有明显长文档 / 多语言 / 检索质量诉求
+- 只想最短路径验证“能不能搜到”，还没到精排阶段
 - 更看重“最省事的默认接入”而不是检索细节优化
 
 ### 目前最值得记住的几个关键词
 - `Late Chunking`
 - `Matryoshka`
 - `Task-specific Adapters`
+- `Embedding recall + Reranker rerank`
+- `Hybrid Search`
+- `Query Transformation`
 - `v4 = Multimodal`
 - `v5 = Compact / production-oriented`
 
@@ -580,7 +768,7 @@ benchmark 叙事也比之前更具体：
 ## 相关链接 / 来源
 
 - Gemini 分享原文：<https://gemini.google.com/share/c221a0c3c0cc>
-- Grok 分享原文（本次已实际浏览阅读）：<https://grok.com/share/c2hhcmQtMw_3d5fb2d0-7943-43ac-9f33-1781024a8f87>
+- Grok 分享原文（本次已实际浏览阅读）：<https://grok.com/share/c2hhcmQtMw_bfcbbc2f-d30d-44f3-85ac-fb7d88b5803e>
 - Jina Embeddings 产品页（本次已实际浏览阅读）：<https://jina.ai/embeddings/>
 - Jina Embeddings v4 release note（本次已实际浏览阅读）：<https://jina.ai/news/jina-embeddings-v4-universal-embeddings-for-multimodal-multilingual-retrieval/>
 - Jina Embeddings v5 release note（本次已实际浏览阅读）：<https://jina.ai/news/jina-embeddings-v5-text-distilling-4b-quality-into-sub-1b-multilingual-embeddings/>

--- a/src/content/archive/0326-jina-embeddings-api-deep-dive.md
+++ b/src/content/archive/0326-jina-embeddings-api-deep-dive.md
@@ -2,13 +2,14 @@
 title: Jina Embeddings API 深度解析
 description: 关于 Jina Embeddings 在多语言检索、长文本、Late Chunking、v4/v5 选型上的整理笔记。
 date: 2026-03-14
-updatedDate: 2026-03-31
+updatedDate: 2026-04-14
 tags:
   - ai
   - llm
   - rag
   - embedding
   - jina
+  - qwen
 type: research
 status: ready
 source: https://gemini.google.com/share/c221a0c3c0cc
@@ -460,9 +461,90 @@ benchmark 叙事也比之前更具体：
 
 那 v5 可能比 v4 更值得优先试。
 
+## 新增补充：Jina Embeddings vs Qwen3 Embedding
+
+这次又补读了一份 Grok 分享内容，主题是把 Jina Embeddings 和 Qwen3-Embedding 放在一起比较。它不是官方文档，所以更适合当作一份选型视角整理，而不是硬 benchmark 定论，但有几个判断值得并进这张卡。
+
+### 一个很实用的总判断
+
+如果把两边的产品定位压缩成一句话：
+
+- **Qwen3-Embedding** 更像“高精度优先”的选手，尤其适合中文和多语言场景
+- **Jina Embeddings** 更像“高效、长文档、生产友好”的选手，尤其是 v5
+
+这个结论和我前面对 Jina 的理解并不冲突，反而补全了它在选型时的参照物。
+
+### 这份对比里值得记住的几个点
+
+#### 1. Qwen3 在中文、多语言精度上更值得优先考虑
+对比里反复强调：
+
+- Qwen3-Embedding 在中文 / 多语言任务上更强
+- Qwen3-Reranker 在中文重排上优势明显
+- 如果目标是追求极致精度，而不是先压成本，Qwen3-8B 会更像“上限更高”的选择
+
+这点很符合直觉，因为 Qwen 系列本身就更贴近中文生态。
+
+所以如果场景是：
+
+- 中文知识库
+- 中文问答
+- 混合中英资料但中文占大头
+- 对 rerank 质量很敏感
+
+那 Qwen3 这条线应该认真 benchmark，而不是默认只看 Jina。
+
+#### 2. Jina 更强的地方，不只是“小模型便宜”
+这份整理把 Jina 的优势概括得比较准确：
+
+- 长文档处理更稳
+- Late Chunking 思路更成熟
+- v4 能处理多模态内容
+- v5 在质量 / 体积比上非常强
+
+尤其是如果系统里会遇到：
+
+- 超长文档
+- PDF / 图表 /表格
+- 视觉信息密度高的资料
+- 需要更低部署成本
+
+那 Jina 依然是非常合理的优先候选。
+
+#### 3. 一个很现实的混合方案
+这份对比里我最认可的建议其实不是“二选一”，而是：
+
+- **粗召回** 用 Jina v5-small
+- **重排** 用 Qwen3-Reranker-4B / 8B
+
+这个组合很有工程味，因为它承认 embedding 和 reranking 的最优解未必来自同一家。
+
+如果目标是平衡：
+
+- 召回速度
+- 推理成本
+- 中文效果
+- 最终排序质量
+
+那这种混合方案比执着于单模型统一更现实。
+
+### 我现在对两者的工作性判断
+
+可以先这样记：
+
+- **要中文精度、多语言精度、指令感知、强 reranker 生态**，优先看 Qwen3
+- **要长文档、Late Chunking、多模态、生产部署性价比**，优先看 Jina
+- **要综合平衡**，可以考虑 `Jina recall + Qwen rerank`
+
+### 这次补充对原卡的影响
+
+它没有推翻原来对 Jina 的判断，而是让这张卡从“只看 Jina 自己强在哪”变成了“放到真实选型盘里，Jina 在哪里赢、Qwen 在哪里更强”。
+
+这比单看 Jina 官方 release note 更接近真正做系统时的决策方式。
+
 ## 当前理解 / 结论
 
-这次重新读完官方页面后，我对 Jina Embeddings 的判断是：
+这次重新读完官方页面、再补上与 Qwen3-Embedding 的对比后，我对 Jina Embeddings 的判断是：
 
 ### 适合认真尝试的情况
 - 中文或多语言 RAG
@@ -488,21 +570,24 @@ benchmark 叙事也比之前更具体：
 
 后面值得继续补的点：
 
-1. Jina 和 `BGE`、`Voyage`、`OpenAI text-embedding-3-large` 的更细对比
+1. Jina、Qwen3、`BGE`、`Voyage`、`OpenAI text-embedding-3-large` 的统一选型表
 2. Node.js / TypeScript 实际调用示例
 3. Late Chunking 的工程落地方式
 4. 向量维度压缩对 recall 的真实影响
 5. 在中文知识库场景中的真实体验
+6. `Jina recall + Qwen rerank` 这类混合 pipeline 的真实 benchmark
 
 ## 相关链接 / 来源
 
 - Gemini 分享原文：<https://gemini.google.com/share/c221a0c3c0cc>
+- Grok 分享原文（本次已实际浏览阅读）：<https://grok.com/share/c2hhcmQtMw_3d5fb2d0-7943-43ac-9f33-1781024a8f87>
 - Jina Embeddings 产品页（本次已实际浏览阅读）：<https://jina.ai/embeddings/>
 - Jina Embeddings v4 release note（本次已实际浏览阅读）：<https://jina.ai/news/jina-embeddings-v4-universal-embeddings-for-multimodal-multilingual-retrieval/>
 - Jina Embeddings v5 release note（本次已实际浏览阅读）：<https://jina.ai/news/jina-embeddings-v5-text-distilling-4b-quality-into-sub-1b-multilingual-embeddings/>
 
 ## 备注
 
-- 这次补充是基于浏览器直接阅读官网渲染后的页面内容，而不是只依据链接标题或对话摘要。
+- 这次补充一部分来自浏览器直接阅读 Jina 官网渲染页面，另一部分来自浏览器实际读取的 Grok 分享页内容。
+- Grok 分享更适合当作“选型整理”而不是原始官方 benchmark 来源，所以这里主要吸收的是对比框架和工程判断，不把其中数字直接当最终定论。
 - 产品页是交互式页面，能看到 API playground、参数项、计费 / usage 提示等真实产品信息。
 - 页面里出现了账号相关界面元素，但这里不记录任何密钥、个人额度或敏感内容。


### PR DESCRIPTION
## Summary
- merge new Grok-shared notes into the existing Jina embeddings archive card
- add RAG two-stage retrieval framing around embedding and reranker
- capture next-step topics like chunking, hybrid search, query transformation, and post-retrieval processing

## Validation
- bun run check