### PR TITLE
Add Faiss vs Chroma archive stub

### DIFF
--- a/src/content/archive/0426-faiss-vs-chroma-vector-store-tradeoffs.md
+++ b/src/content/archive/0426-faiss-vs-chroma-vector-store-tradeoffs.md
@@ -1,0 +1,67 @@
+---
+title: Faiss vs Chroma 向量库选型取舍
+description: 围绕 Faiss 与 Chroma 在 RAG / 向量检索场景中的定位差异，先记录一个待补完的选型卡。
+date: 2026-04-16
+tags:
+  - ai
+  - llm
+  - rag
+  - retrieval
+  - vector database
+  - faiss
+  - chroma
+type: research
+status: incomplete
+relatedArchive:
+  - 0426-rag-retrieval-details-and-pipeline-design
+source: https://grok.com/share/c2hhcmQtMw_b7e297d7-8c50-4cb8-8e2b-cf958a287c0b
+draft: false
+---
+
+## 核心内容
+
+这张卡先记录一个明确的主题：**Faiss vs Chroma 的向量库选型差异**。
+
+目前我能稳定拿到的只有 Grok 分享页标题：
+
+- `Faiss vs Chroma 向量数据库对比`
+
+但分享页正文这次没有成功抓到，所以这里先不伪造细节，也不把它硬并到现有卡里。
+
+## 当前理解 / 结论
+
+即使还没拿到这次分享的完整正文，这个主题本身也值得单独立一张卡，因为它和已有 archive 的边界很清楚：
+
+- 它不是 provider-specific embedding 模型选型
+- 它也不只是通用 retrieval pipeline 设计
+- 它更像 **vector store / index layer** 的工程取舍
+
+这层问题通常包括：
+
+- Faiss 更偏 library 还是 service
+- Chroma 更偏开发体验还是生产能力
+- 本地原型、单机部署、嵌入式使用时怎么选
+- 真正进入 production RAG 时，Faiss / Chroma 和其他向量库的边界在哪
+
+所以它适合作为一张独立卡，后面再补完整内容。
+
+## 待补充
+
+1. Faiss 的定位，本质上是 ANN library、index engine，还是可直接当作向量数据库使用
+2. Chroma 的定位，更适合 local-first prototyping 还是中小规模 production
+3. 两者在数据持久化、过滤、元数据、服务化能力上的差异
+4. 与 production RAG 常见向量库的职责边界
+5. 适合用 Faiss 的场景
+6. 适合用 Chroma 的场景
+7. 什么时候不该在这两者之间纠结，而应该直接换别的系统
+
+## 相关链接 / 来源
+
+- Grok 分享原文（本次正文未成功抓取，仅确认标题）：<https://grok.com/share/c2hhcmQtMw_b7e297d7-8c50-4cb8-8e2b-cf958a287c0b>
+- 相关 archive：<./0426-rag-retrieval-details-and-pipeline-design>
+
+## 备注
+
+- 这张卡目前是一个占位型 archive card，不是完整总结。
+- 之所以先建，是为了避免只记一个裸链接，后面忘了它讲的是什么。
+- 这次浏览器和网页提取都没稳定拿到分享正文，只确认到页面标题，所以内容状态标记为 `incomplete`。


### PR DESCRIPTION
## Summary
- add a new archive card for Faiss vs Chroma vector store tradeoffs
- mark the card as incomplete because the Grok share body could not be reliably retrieved
- link it to the existing RAG retrieval archive

## Validation
- bun run check