### PR TITLE
Fill Faiss vs Chroma archive card

### DIFF
--- a/src/content/archive/0426-faiss-vs-chroma-vector-store-tradeoffs.md
+++ b/src/content/archive/0426-faiss-vs-chroma-vector-store-tradeoffs.md
@@ -1,6 +1,6 @@
 ---
 title: Faiss vs Chroma 向量库选型取舍
-description: 围绕 Faiss 与 Chroma 在 RAG / 向量检索场景中的定位差异，先记录一个待补完的选型卡。
+description: 围绕 Faiss、Chroma 及相关向量库在 RAG / 向量检索场景中的定位差异与索引算法取舍整理。
 date: 2026-04-16
 tags:
   - ai
@@ -11,7 +11,7 @@ tags:
   - faiss
   - chroma
 type: research
-status: incomplete
+status: ready
 relatedArchive:
   - 0426-rag-retrieval-details-and-pipeline-design
 source: https://grok.com/share/c2hhcmQtMw_b7e297d7-8c50-4cb8-8e2b-cf958a287c0b
@@ -20,48 +20,231 @@ draft: false
 
 ## 核心内容
 
-这张卡先记录一个明确的主题：**Faiss vs Chroma 的向量库选型差异**。
+这张卡记的是 **Faiss、Chroma 以及相邻向量库在 RAG / 向量检索系统里的定位差异**。
 
-目前我能稳定拿到的只有 Grok 分享页标题：
+如果只记一句话，可以先记成：
 
-- `Faiss vs Chroma 向量数据库对比`
+> **Faiss 更像底层高性能向量索引引擎，Chroma 更像开发者友好的轻量向量数据库；真正进入生产选型时，还要一起看 Milvus、pgvector、Qdrant、Weaviate，以及背后的 ANN 索引算法。**
 
-但分享页正文这次没有成功抓到，所以这里先不伪造细节，也不把它硬并到现有卡里。
+所以这张卡不只是 “Faiss vs Chroma”，更像是从这两个入口展开，整理整个 **vector store / index layer** 的取舍逻辑。
+
+## 要点整理
+
+### 1. Faiss 的核心定位不是“完整数据库”，而是高性能索引引擎
+
+这次分享里最值得先钉住的一点是：
+
+- **Faiss 不是一个完整意义上的数据库**
+- 它更像一个高性能向量相似性搜索与聚类库
+- 常被上层框架当作 VectorStore 使用，但很多“数据库能力”要自己补
+
+它的强项集中在：
+
+- 海量向量检索
+- CPU + GPU 加速
+- 多种索引算法
+- 对速度 / 内存 / recall 的细粒度调优
+
+但它的代价也很直接：
+
+- 持久化要自己管理
+- metadata 过滤要外接系统
+- service 化、分布式、运维能力不是默认给你的
+
+所以 Faiss 更像是：
+
+> **给高手用来搭底层检索引擎的组件**，不是开箱即用的产品化向量数据库。
+
+### 2. Chroma 的核心定位是“RAG 开发友好”
+
+Chroma 几乎是 Faiss 的反面：
+
+- 它是一个轻量级、开发者友好的向量数据库
+- 能同时存向量、原始文档、metadata
+- 原生支持 metadata filter
+- 支持嵌入式运行，也支持服务模式
+
+这意味着 Chroma 的核心价值不是极限性能，而是：
+
+- 快速原型
+- 本地开发
+- 小到中规模 RAG
+- 和 LangChain / LlamaIndex 等框架的无痛集成
+
+所以它更像：
+
+> **让你几行代码就能把 RAG 跑起来的工程化工具**。
+
+### 3. Faiss vs Chroma，本质上是在“极致性能”与“开箱即用”之间取舍
+
+如果压成最短对比，大概就是：
+
+- **Faiss**：低级索引库，性能极强，但数据库功能要自己补
+- **Chroma**：完整轻量向量数据库，易用性高，但规模和灵活度不如 Faiss 底层方案
+
+这次分享给出的对比点里，我觉得最值得保留的是这些：
+
+- 类型：Faiss 是索引库，Chroma 更像完整 DB
+- 易用性：Faiss 陡峭，Chroma 几行代码上手
+- 性能：Faiss 在大规模与 GPU 上更强
+- 持久化：Faiss 偏手动，Chroma 内置
+- 元数据：Faiss 要外部搭配，Chroma 原生支持
+- 典型用法：Faiss 偏底层高性能搜索，Chroma 偏 LLM / RAG 快速开发
+
+一句话总结就是：
+
+- **Faiss 是性能怪兽**
+- **Chroma 是开发利器**
+
+### 4. 真正做生产选型时，不能只看 Faiss 和 Chroma
+
+这次分享后半段其实把问题拉到了更真实的范围，也就是和这些系统一起看：
+
+- **Milvus**：分布式完整向量数据库，适合大规模生产
+- **pgvector**：如果业务已经在 Postgres 上，集成成本最低
+- **Qdrant**：过滤能力很强，实时更新和 payload filter 表现突出
+- **Weaviate**：更强调混合搜索、语义模块、图结构能力
+
+这个对比很重要，因为很多团队真实遇到的问题不是“Faiss 还是 Chroma”，而是：
+
+- 我只是要快速做个 RAG demo 吗
+- 我已经有 Postgres 吗
+- 我需要强过滤吗
+- 我是百万级、千万级还是亿级向量
+- 我能不能接受单独运维一套向量系统
+
+### 5. 一个很实用的选型心智模型
+
+这次内容可以压成下面这个选择框架：
+
+#### 想最快上手
+- **Chroma**
+- 或者已有 Postgres 时直接 **pgvector**
+
+#### 想极致性能 / 大规模
+- **Faiss**（底层）
+- 或 **Milvus**（更完整的生产方案）
+
+#### 想要强过滤 / payload 检索
+- **Qdrant**
+
+#### 想做混合搜索 / 图结构语义检索
+- **Weaviate**
+
+所以真正的现实不是“谁最好”，而是：
+
+> **谁最贴合你现在的数据规模、过滤需求、部署方式和团队栈。**
+
+### 6. 向量库的真正核心，不是“存向量”，而是 ANN 索引算法
+
+这次分享里最值得继续保留的一大块，是它把重点落在了 **Approximate Nearest Neighbor, ANN**。
+
+精确搜索（Flat / brute-force）在数据量上来后会变成 O(N)，所以生产里几乎都要走 ANN。
+
+这里最重要的几个索引路线是：
+
+#### Flat
+- 最简单，逐个比对
+- 100% recall
+- 但规模稍大就太慢
+- 更像小规模基线或其他索引的子模块
+
+#### IVF
+核心思路是：
+
+- 先把向量聚类成多个簇
+- 查询时先找到最近的簇
+- 再在这些簇里做更细搜索
+
+它的特点是：
+
+- 更省内存
+- 规模化能力强
+- 适合大数据量
+- 但 recall 与调参更依赖 `nlist / nprobe`
+
+这条路线和：
+
+- **Faiss**
+- **Milvus**
+- **pgvector 的 IVFFlat**
+
+关系尤其密切。
+
+#### HNSW
+核心思路是：
+
+- 把向量空间组织成分层图
+- 查询时从高层快速跳到低层
+- 在底层找到最近邻
+
+它的特点是：
+
+- recall 很高
+- 查询很快
+- 实时插入也友好
+- 但更吃内存
+- 复杂过滤场景有时会退化
+
+这条路线和：
+
+- **Qdrant**
+- **Weaviate**
+- **Chroma**
+- **pgvector 的 HNSW**
+
+更直接相关。
+
+### 7. 算法选型，实际上决定了库的风格差异
+
+如果再往下压一层，我觉得这次分享真正说明的是：
+
+- **Faiss / Milvus** 更像“索引系统工程”视角
+- **Chroma / Qdrant / Weaviate** 更像“产品化向量数据库”视角
+- **pgvector** 更像“把向量检索并入现有 OLTP / SQL 世界”
+
+而背后差异，很多时候不是 marketing，而是：
+
+- 用 HNSW 还是 IVF
+- 有没有 PQ / SQ 量化能力
+- 是否支持 on-disk / DiskANN / SPANN 类方案
+- metadata filter 和 ANN 检索怎么耦合
+- 持久化、分布式、服务化是不是内建的
 
 ## 当前理解 / 结论
 
-即使还没拿到这次分享的完整正文，这个主题本身也值得单独立一张卡，因为它和已有 archive 的边界很清楚：
+如果按工程落地视角来记，这次内容最值得保留的结论是：
 
-- 它不是 provider-specific embedding 模型选型
-- 它也不只是通用 retrieval pipeline 设计
-- 它更像 **vector store / index layer** 的工程取舍
+1. **Faiss 不是完整向量数据库，而是高性能索引引擎**
+2. **Chroma 更适合本地开发、原型验证和中小规模 RAG**
+3. **Milvus 更像大规模生产级向量数据库**
+4. **pgvector 适合已经把业务建立在 Postgres 上的团队**
+5. **Qdrant / Weaviate 的价值主要体现在过滤、混合搜索、语义系统能力上**
+6. 真正决定系统气质的，往往不是数据库名字，而是背后的 **ANN 索引路线**
 
-这层问题通常包括：
+所以更准确的问题通常不是：
 
-- Faiss 更偏 library 还是 service
-- Chroma 更偏开发体验还是生产能力
-- 本地原型、单机部署、嵌入式使用时怎么选
-- 真正进入 production RAG 时，Faiss / Chroma 和其他向量库的边界在哪
+> “Faiss 和 Chroma 谁更强？”
 
-所以它适合作为一张独立卡，后面再补完整内容。
+而是：
+
+> “我现在需要的是底层索引能力、开发效率、过滤能力、还是大规模生产系统能力？”
 
 ## 待补充
 
-1. Faiss 的定位，本质上是 ANN library、index engine，还是可直接当作向量数据库使用
-2. Chroma 的定位，更适合 local-first prototyping 还是中小规模 production
-3. 两者在数据持久化、过滤、元数据、服务化能力上的差异
-4. 与 production RAG 常见向量库的职责边界
-5. 适合用 Faiss 的场景
-6. 适合用 Chroma 的场景
-7. 什么时候不该在这两者之间纠结，而应该直接换别的系统
+1. Faiss、Milvus、Qdrant、Weaviate、pgvector 在真实 production RAG 中的迁移路径
+2. HNSW 与 IVF 在不同过滤条件下的性能边界
+3. PQ / SQ / Binary Quantization 的实际 recall 损失
+4. Chroma 云端 SPANN、pgvector 扩展 DiskANN 这类磁盘友好索引路线
+5. 一个面向不同规模（10万 / 1000万 / 1亿）的向量库选型表
+6. 与 hybrid search、reranker、metadata filtering 联动时的系统设计方式
 
 ## 相关链接 / 来源
 
-- Grok 分享原文（本次正文未成功抓取，仅确认标题）：<https://grok.com/share/c2hhcmQtMw_b7e297d7-8c50-4cb8-8e2b-cf958a287c0b>
+- Grok 分享原文（本次已实际浏览阅读）：<https://grok.com/share/c2hhcmQtMw_b7e297d7-8c50-4cb8-8e2b-cf958a287c0b>
 - 相关 archive：<./0426-rag-retrieval-details-and-pipeline-design>
 
 ## 备注
 
-- 这张卡目前是一个占位型 archive card，不是完整总结。
-- 之所以先建，是为了避免只记一个裸链接，后面忘了它讲的是什么。
-- 这次浏览器和网页提取都没稳定拿到分享正文，只确认到页面标题，所以内容状态标记为 `incomplete`。
+- 这次重新抓取后，浏览器成功读取到了分享页正文；之前失败更像是 hydration / 动态渲染时机问题，不是链接本身无效。
+- 当前内容更偏系统选型与索引结构理解，后面如果继续补，最好拆出一张更专门的 ANN / vector index 卡。


### PR DESCRIPTION
## Summary
- replace the temporary Faiss vs Chroma stub with an actual summary from the recovered Grok share
- capture the broader comparison across Milvus, pgvector, Qdrant, and Weaviate
- add the ANN index algorithm framing around Flat, IVF, and HNSW

## Validation
- bun run check