### PR TITLE
merge: enrich vectordb archive card with 6-db comparison and ANN details

### DIFF
--- a/src/content/archive/0426-faiss-vs-chroma-vector-store-tradeoffs.md
+++ b/src/content/archive/0426-faiss-vs-chroma-vector-store-tradeoffs.md
@@ -2,6 +2,7 @@
 title: Faiss vs Chroma 向量库选型取舍
 description: 围绕 Faiss、Chroma 及相关向量库在 RAG / 向量检索场景中的定位差异与索引算法取舍整理。
 date: 2026-04-16
+updatedDate: 2026-05-20
 tags:
   - ai
   - llm
@@ -10,6 +11,11 @@ tags:
   - vector database
   - faiss
   - chroma
+  - milvus
+  - qdrant
+  - weaviate
+  - pgvector
+  - ann
 type: research
 status: ready
 relatedArchive:
@@ -82,19 +88,21 @@ Chroma 几乎是 Faiss 的反面：
 - **Faiss**：低级索引库，性能极强，但数据库功能要自己补
 - **Chroma**：完整轻量向量数据库，易用性高，但规模和灵活度不如 Faiss 底层方案
 
-这次分享给出的对比点里，我觉得最值得保留的是这些：
+这次分享给出的对比维度里，最值得保留的包括：
 
 - 类型：Faiss 是索引库，Chroma 更像完整 DB
 - 易用性：Faiss 陡峭，Chroma 几行代码上手
 - 性能：Faiss 在大规模与 GPU 上更强
-- 持久化：Faiss 偏手动，Chroma 内置
-- 元数据：Faiss 要外部搭配，Chroma 原生支持
+- 持久化：Faiss 偏手动，Chroma 内置（DuckDB + Parquet）
+- 元数据：Faiss 要外部搭配，Chroma 原生支持 + SQL-like 过滤
 - 典型用法：Faiss 偏底层高性能搜索，Chroma 偏 LLM / RAG 快速开发
 
 一句话总结就是：
 
 - **Faiss 是性能怪兽**
 - **Chroma 是开发利器**
+
+2025 年 Chroma 用 Rust 重写后跑分提升了 4 倍，但本质上仍定位于中小规模（<1000 万向量），不是生产级 IoT 场景的竞争者。Chroma 云端则支持 SPANN（磁盘友好 HNSW 变体），算是对大规模的一个补充补丁。
 
 ### 4. 真正做生产选型时，不能只看 Faiss 和 Chroma
 
@@ -113,7 +121,31 @@ Chroma 几乎是 Faiss 的反面：
 - 我是百万级、千万级还是亿级向量
 - 我能不能接受单独运维一套向量系统
 
-### 5. 一个很实用的选型心智模型
+### 5. 六库全景对比：每个库的核心差异表
+
+如果要做一次完整的选型对比，下面是 6 个主流方案在关键维度上的差异：
+
+**Faiss**：低级索引库（非完整 DB），BSD 许可。嵌入代码中使用，需要自行封装持久化。适用百万~十亿级以上（GPU 加速极致）。默认索引支 HNSW 和全部 IVF 变体。性能：原始速度最快，GPU 下亿级 QPS 极高。元数据过滤需要外部实现。持久化需手动管理索引。易用性陡峭。最佳场景：研究、自定义亿级搜索。
+
+**Chroma**：轻量级嵌入式向量数据库，Apache 2.0。支持嵌入模式或服务器模式。适用小~中规模（<1000 万向量）。默认索引 HNSW（云端 SPANN）。2025 Rust 重写后 4x 更快，但非生产极致。原生支持 SQL-like 元数据过滤。内置 DuckDB + Parquet 持久化。易用性最高。最佳场景：RAG 原型、本地开发。
+
+**Milvus**：分布式完整向量数据库，Apache 2.0。自托管/Zilliz Cloud 部署。适用亿级~十亿级以上。支持 HNSW 和全系 IVF。低延迟（<30ms p95），亿级稳定。元数据过滤强大（动态 schema）。持久化内置 + 分布式。易用性功能全但运维较重。最佳场景：生产级大规模 AI。
+
+**pgvector**：PostgreSQL 扩展，PostgreSQL 许可。装在 Postgres 中即可。适用中规模（<1 亿向量）。支持 HNSW + IVFFlat（部分 DiskANN）。471 QPS@50M（99% recall，pgvectorscale 扩展）。元数据过滤最强（与 SQL 完全融合）。持久化原生 Postgres。易用性最高（已有 Postgres 零成本）。最佳场景：已用 Postgres 的团队。
+
+**Qdrant**：Rust 编写完整向量数据库，Apache 2.0。自托管/Qdrant Cloud。适用中规模（高效到 5000 万）。默认 HNSW（高度优化）。1ms p99 小规模，过滤极强。payload 过滤能力极强。持久化内置 + on-disk 支持。易用性好（Rust 性能 + 简单 API）。最佳场景：需要强过滤的中型项目。
+
+**Weaviate**：Go 编写完整向量数据库，BSD 许可。自托管/Weaviate Cloud。适用中规模（高效到 5000 万）。默认 HNSW。混合搜索 ~50ms@768 维。支持 GraphQL + 混合搜索。持久化内置 + Kubernetes 原生。文档优秀。最佳场景：知识图谱 + 混合搜索。
+
+数据来源：2025-2026 基准测试显示，Milvus 和 Faiss 在亿级规模上领先；Chroma 和 pgvector 适合快速落地；Qdrant/Weaviate 在过滤和混合搜索上有独特优势。
+
+一句话定位：
+- 想极致快 + 大规模 → Faiss（底层）或 Milvus
+- 想最快上手 → Chroma 或 pgvector
+- 想过滤/混合搜索 → Qdrant 或 Weaviate
+- 已有 Postgres → pgvector 零成本
+
+### 6. 一个很实用的选型心智模型
 
 这次内容可以压成下面这个选择框架：
 
@@ -135,67 +167,73 @@ Chroma 几乎是 Faiss 的反面：
 
 > **谁最贴合你现在的数据规模、过滤需求、部署方式和团队栈。**
 
-### 6. 向量库的真正核心，不是“存向量”，而是 ANN 索引算法
+### 7. 向量库的真正核心，不是"存向量"，而是 ANN 索引算法
 
 这次分享里最值得继续保留的一大块，是它把重点落在了 **Approximate Nearest Neighbor, ANN**。
 
-精确搜索（Flat / brute-force）在数据量上来后会变成 O(N)，所以生产里几乎都要走 ANN。
+精确搜索（Flat / brute-force）在数据量上来后会变成 O(N)，所以生产里几乎都要走 ANN。牺牲极少准确率（Recall 通常 95%+），换取 10-1000 倍速度。主流算法有三大类：
 
-这里最重要的几个索引路线是：
+#### Flat（精确 / Brute Force）
+- 所有向量存成数组，逐维度计算余弦/欧氏距离，然后排序取 Top-k
+- 100% recall，但 O(N) 随数据量线性增长
+- 仅适合 <10 万向量，或作为 IVF/HNSW 的子模块
+- Faiss/Milvus 的 IVF_FLAT 底层就是 Flat；Chroma/Qdrant 在小集合（<1 万）会自动 fallback 到 Flat
 
-#### Flat
-- 最简单，逐个比对
-- 100% recall
-- 但规模稍大就太慢
-- 更像小规模基线或其他索引的子模块
+#### IVF（Inverted File，倒排文件索引）
+核心思想：先聚类，再倒排。
 
-#### IVF
-核心思路是：
+构建阶段：用 K-means 把所有向量分成 `nlist` 个簇（每个簇一个中心点/centroid），每个向量只记录在所属簇的倒排列表里。
 
-- 先把向量聚类成多个簇
-- 查询时先找到最近的簇
-- 再在这些簇里做更细搜索
+查询阶段：
+1. 计算查询向量到所有 nlist 个中心的距离，选最近的 `nprobe` 个簇
+2. 只在这 nprobe 个簇里做精确（或压缩）搜索
 
-它的特点是：
+关键参数：
+- **nlist**：簇数，越大越细但索引越大
+- **nprobe**：查询时检查的簇数，可运行时动态调整，越大 Recall 越高
 
-- 更省内存
-- 规模化能力强
-- 适合大数据量
-- 但 recall 与调参更依赖 `nlist / nprobe`
+变体（压缩量化）：
+- **IVF_FLAT**：不压缩，最准但最占内存
+- **IVF_PQ（Product Quantization）**：把向量切成子空间，每子空间用码本编码，压缩率可达 64:1，Recall 70-90%
+- **IVF_SQ8**：标量量化（每个维度 8-bit），压缩 4:1，Recall 90%+
 
-这条路线和：
+优缺点：构建快、内存低、过滤时稳定（先过滤簇再搜索）；但 Recall 略低于 HNSW，大规模时需仔细调 nprobe。
 
-- **Faiss**
-- **Milvus**
-- **pgvector 的 IVFFlat**
+谁用：Milvus 原生支持全系 IVF（最灵活）；pgvector 的 IVFFlat；Faiss 是 IVF 的发明者。
 
-关系尤其密切。
+#### HNSW（Hierarchical Navigable Small World，分层可导航小世界图）
+2026 年最主流 ANN 算法。
 
-#### HNSW
-核心思路是：
+核心思想：把向量空间建成分层图，像"高速公路 + 乡村路"。
 
-- 把向量空间组织成分层图
-- 查询时从高层快速跳到低层
-- 在底层找到最近邻
+构建阶段：每个向量是图中的节点：
+- 最上层只有少量节点，连接很"广"（小世界特性：任意两点跳几步就到）
+- 逐层向下，每层节点数增多，连接变"密"
+- 每个节点最多 m 条边（通常 8-64）
 
-它的特点是：
+查询阶段：从顶层入口点开始，贪婪地向最近邻跳跃，一层层往下走，最终在底层精确找 Top-k。搜索复杂度 ≈ O(log N)。
 
-- recall 很高
-- 查询很快
-- 实时插入也友好
-- 但更吃内存
-- 复杂过滤场景有时会退化
+关键参数（Qdrant/Chroma/Milvus 都可调）：
+- **m**：每节点最大连接数（越大 Recall 越高，但内存↑）
+- **ef_construct**：建图时候选数（越大图质量越高，构建越慢）
+- **hnsw_ef（或 ef_search）**：查询时候选数（越大 Recall 越高，查询越慢）
 
-这条路线和：
+优缺点：Recall 最高（98%+）、查询极快、实时插入友好；但内存较高、过滤时可能退化（过滤掉太多节点后变成近全扫描）。
 
-- **Qdrant**
-- **Weaviate**
-- **Chroma**
-- **pgvector 的 HNSW**
+谁用：Qdrant（Rust 高度优化 HNSW + on-disk）；Weaviate（默认）；Chroma（默认 HNSW，云端 SPANN 是其变体）；Milvus（可选）；pgvector（HNSW）；Faiss（也支持）。
 
-更直接相关。
+#### 其他高级技巧（通用）
+- **Quantization（量化）**：PQ（乘积量化）、SQ（标量量化）、Binary Quantization（二值量化）—— 把 float32 向量压成 int8/int4/bit，内存/速度暴增，Recall 略降
+- **DiskANN / SPANN**：磁盘友好版 HNSW（Chroma 云端、pgvector 扩展），解决内存瓶颈
+- **混合索引**：很多库支持"向量 + 标量过滤"先粗筛再精搜
 
-### 7. 算法选型，实际上决定了库的风格差异
+#### 算法选择口诀（2026 实战经验）
+- 数据 <10 万 → Flat 就够
+- 追求内存最低 + 过滤多 → IVF（Milvus/pgvector）
+- 追求最高 Recall + 速度 → HNSW（Qdrant/Weaviate/Chroma）
+- 规模最大 + GPU → Faiss 底层
+
+### 8. 算法选型，实际上决定了库的风格差异
 
 如果再往下压一层，我觉得这次分享真正说明的是：
 
@@ -221,23 +259,26 @@ Chroma 几乎是 Faiss 的反面：
 4. **pgvector 适合已经把业务建立在 Postgres 上的团队**
 5. **Qdrant / Weaviate 的价值主要体现在过滤、混合搜索、语义系统能力上**
 6. 真正决定系统气质的，往往不是数据库名字，而是背后的 **ANN 索引路线**
+7. **HNSW 是 2026 年最主流的 ANN 算法**，但 IVF 在内存紧张或过滤密集场景依然更有优势
+8. **量化（PQ/SQ/Binary）** 是降低内存和加速的重要手段，需在 recall 和压缩率之间权衡
+9. **DiskANN / SPANN** 是解决内存瓶颈的新方向，适合磁盘友好的大规模部署
+10. 一个经验法则选型公式：<10 万用 Flat，小~中规模选 HNSW 或 Chroma，亿级用 Milvus 或 Faiss，已有 Postgres 直接 pgvector
 
 所以更准确的问题通常不是：
 
-> “Faiss 和 Chroma 谁更强？”
+> "Faiss 和 Chroma 谁更强？"
 
 而是：
 
-> “我现在需要的是底层索引能力、开发效率、过滤能力、还是大规模生产系统能力？”
+> "我现在需要的是底层索引能力、开发效率、过滤能力、还是大规模生产系统能力？"
 
 ## 待补充
 
 1. Faiss、Milvus、Qdrant、Weaviate、pgvector 在真实 production RAG 中的迁移路径
-2. HNSW 与 IVF 在不同过滤条件下的性能边界
-3. PQ / SQ / Binary Quantization 的实际 recall 损失
-4. Chroma 云端 SPANN、pgvector 扩展 DiskANN 这类磁盘友好索引路线
-5. 一个面向不同规模（10万 / 1000万 / 1亿）的向量库选型表
-6. 与 hybrid search、reranker、metadata filtering 联动时的系统设计方式
+2. HNSW 与 IVF 在不同过滤条件下的性能边界（比如过滤掉 90% 节点后 HNSW 的退化曲线）
+3. PQ / SQ / Binary Quantization 在不同 recall 阈值下的实际压缩率与速度数据
+4. 与 hybrid search、reranker、metadata filtering 联动时的系统设计方式
+5. 各库的 GPU 加速对比（Faiss GPU vs Milvus GPU vs Qdrant on-disk）
 
 ## 相关链接 / 来源
 
@@ -248,3 +289,4 @@ Chroma 几乎是 Faiss 的反面：
 
 - 这次重新抓取后，浏览器成功读取到了分享页正文；之前失败更像是 hydration / 动态渲染时机问题，不是链接本身无效。
 - 当前内容更偏系统选型与索引结构理解，后面如果继续补，最好拆出一张更专门的 ANN / vector index 卡。
+- 2026-05-20 补充：完整抓取了同一 Grok 链接的详细内容，增加了六库全景对比、IVF/HNSW 关键参数详解、量化压缩技巧、数据规模选型公式。


### PR DESCRIPTION
Merge the deeper Grok content (same source link) into the existing vectordb archive card:

- Added 6-database full comparison (Faiss, Chroma, Milvus, pgvector, Qdrant, Weaviate)
- Deep IVF explanation with nlist/nprobe and variants (FLAT/PQ/SQ8)
- Deep HNSW explanation with m/ef_construct/hnsw_ef parameters
- Added quantization techniques (PQ, SQ, Binary Quantization)
- Added DiskANN/SPANN coverage
- Added data-size-based selection formula
- Updated tags and current understanding