### PR TITLE
feat: 新增 curated 精选模块

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -62,4 +62,29 @@ const archive = defineCollection({
   })
 })
 
-export const collections = { blog, archive }
+const curated = defineCollection({
+  loader: glob({ base: './src/content/curated', pattern: '**/*.{md,mdx}' }),
+  schema: ({ image }) =>
+    z.object({
+      title: z.string(),
+      description: z.string().max(200),
+      date: z.coerce.date(),
+      updatedDate: z.coerce.date().optional(),
+      source: z.string().url(), // link to the original paper/blog/article
+      sourceTitle: z.string().optional(), // original title
+      sourceAuthor: z.string().optional(), // author / organization
+      tags: z.array(z.string()).default([]).transform(removeDupsAndLowerCase),
+      type: z.enum(['paper', 'blog', 'article', 'report']).default('blog'),
+      status: z.enum(['curated', 'digested']).default('curated'),
+      relatedArchive: z.array(z.string()).optional(),
+      heroImage: z
+        .object({
+          src: image(),
+          alt: z.string().optional(),
+        })
+        .optional(),
+      draft: z.boolean().default(false),
+    })
+})
+
+export const collections = { blog, archive, curated }

--- a/src/content/curated/hermes-fts5-session-search.md
+++ b/src/content/curated/hermes-fts5-session-search.md
@@ -1,0 +1,23 @@
+---
+title: Hermes FTS5 会话检索——搜索与理解的解耦
+description: Hermes Agent 用 SQLite FTS5 + LLM query-focused summary 替代向量检索做会话搜索，把"召回"和"理解"拆成两个独立系统。单用户场景下比 vector RAG 更便宜、更稳、零运维。
+date: 2026-05-24
+source: https://claude.ai/share/3b628472-9217-41bb-90a0-2c9ea0129ced
+sourceTitle: Hermes Agent L2 记忆层——FTS5 会话全文检索设计讨论
+type: blog
+status: digested
+tags:
+  - agent
+  - llm
+  - search
+  - retrieval
+relatedArchive:
+  - 0526-hermes-fts5-session-search
+draft: false
+---
+
+双 FTS5 表（unicode61 + trigram）做词法召回 → Gemini Flash 并行做 query-focused 摘要，替代传统的 vector + rerank pipeline。
+
+**为什么值得看**：这不是一篇论文，而是 Hermes 实际在跑的架构。它对"什么时候不用向量"给出了一个很有说服力的工程论证——单用户场景下 BM25 的召回质量被低估了，而且 trigram 在中英混杂场景比 jieba 分词更稳。
+
+**可落地**：如果你在做单用户 Agent 的搜索功能，可以直接参考这套 FTS5 + LLM 两阶段方案。代码在 Hermes 的 `hermes_state.py` + `session_search_tool.py`。

--- a/src/content/curated/prompt-caching-engineering.md
+++ b/src/content/curated/prompt-caching-engineering.md
@@ -1,0 +1,25 @@
+---
+title: Prompt Caching 设计哲学——缓存不是优化，是约束
+description: 从 Claude Code 的 prompt caching 实践出发，整理"动态信息放 messages 不放 system prompt"、defer_loading 模式、以及三家 LLM 厂商的缓存策略对比。对做 agent 的人来说是必读的工程纪律。
+date: 2026-05-24
+source: https://claude.ai/share/e3a7dc4a-7f40-4a2f-b015-6c7a83f9dba9
+sourceTitle: Claude Code Prompt Caching 深度讨论
+type: blog
+status: digested
+tags:
+  - agent
+  - llm
+  - prompt
+  - performance
+relatedArchive:
+  - 0526-prompt-caching-engineering
+draft: false
+---
+
+核心三件事：
+
+1. **Use messages for updates**——所有动态信息（时间、文件状态）放 user message，不要改 system prompt，否则整个对话 cache 全废
+2. **Never add/remove tools mid-session**——工具定义是 cached prefix 的一部分，增删 = cache miss。用 defer_loading stub 解决 MCP 工具太多的问题
+3. **Anthropic 的显式 breakpoint 设计更适合 agent loop**——90% 读取折扣、100% 命中率、明确的 TTL 控制
+
+**为什么值得看**：对于做长期运行 agent 的人，这直接决定了成本结构。一个 agent loop 动辄几十轮调用，正确组织 prefix 和动态信息的差别是 10x 成本。

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -4,6 +4,7 @@ export const prerender = true
 import { Image } from 'astro:assets'
 import avatar from 'src/assets/avatar.png'
 
+import { getCollection } from 'astro:content'
 import { Quote } from 'astro-pure/advanced'
 import { Button, Icon, Label } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
@@ -101,6 +102,41 @@ const tools = ['Cursor', 'Git', 'Docker', 'Bun', 'Figma', 'ESLint/Prettier']
         <SkillLayout title='AI & Agent' skills={ai} />
         <SkillLayout title='Tools' skills={tools} />
       </Section>
+
+      {
+        (await getCollection('curated')).filter((e) => !e.data.draft).length > 0 && (
+          <Section title='Curated'>
+            <ul class='flex flex-col gap-y-3'>
+              {
+                (await getCollection('curated'))
+                  .filter((e) => !e.data.draft)
+                  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+                  .slice(0, 5)
+                  .map((item) => (
+                    <li class='flex flex-col rounded-2xl border bg-background px-5 py-4 transition-colors hover:bg-muted'>
+                      <div class='flex items-center gap-2 text-xs text-muted-foreground mb-1.5'>
+                        <span class='rounded-md border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider'>
+                          {item.data.type === 'paper' ? '📄 Paper' : item.data.type === 'blog' ? '📝 Blog' : item.data.type === 'article' ? '📰 Article' : '📋 Report'}
+                        </span>
+                        <span>{item.data.sourceTitle || item.data.source.replace(/https?:\/\//, '').split('/')[0]}</span>
+                      </div>
+                      <a
+                        href={item.data.source}
+                        target='_blank'
+                        class='font-medium hover:text-primary transition-colors'
+                      >
+                        {item.data.title}
+                      </a>
+                      <p class='mt-1 text-sm text-muted-foreground line-clamp-2'>
+                        {item.data.description}
+                      </p>
+                    </li>
+                  ))
+              }
+            </ul>
+          </Section>
+        )
+      }
 
       <SiteStats lang='en' />
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -208,6 +208,41 @@ const latestNotes = allNotes
         )
       }
 
+      {
+        (await getCollection('curated')).filter((e) => !e.data.draft).length > 0 && (
+          <Section title='精选'>
+            <ul class='flex flex-col gap-y-3'>
+              {
+                (await getCollection('curated'))
+                  .filter((e) => !e.data.draft)
+                  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+                  .slice(0, 5)
+                  .map((item) => (
+                    <li class='flex flex-col rounded-2xl border bg-background px-5 py-4 transition-colors hover:bg-muted'>
+                      <div class='flex items-center gap-2 text-xs text-muted-foreground mb-1.5'>
+                        <span class='rounded-md border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider'>
+                          {item.data.type === 'paper' ? '📄 论文' : item.data.type === 'blog' ? '📝 博客' : item.data.type === 'article' ? '📰 文章' : '📋 报告'}
+                        </span>
+                        <span>{item.data.sourceTitle || item.data.source.replace(/https?:\/\//, '').split('/')[0]}</span>
+                      </div>
+                      <a
+                        href={item.data.source}
+                        target='_blank'
+                        class='font-medium hover:text-primary transition-colors'
+                      >
+                        {item.data.title}
+                      </a>
+                      <p class='mt-1 text-sm text-muted-foreground line-clamp-2'>
+                        {item.data.description}
+                      </p>
+                    </li>
+                  ))
+              }
+            </ul>
+          </Section>
+        )
+      }
+
       <Section title='Experience'>
         <LinkCard
           heading='上海特赞 Tezign'


### PR DESCRIPTION
新功能：精选博客/论文模块

## 改动
- 新增  content collection（含完整 schema）
- 首页中文版新增「精选」模块（最新 5 条）
- 首页英文版新增「Curated」模块
- 首批两条 curated 条目（FTS5 会话检索 + Prompt Caching 工程实践）
- 关联已有 archive 卡片

## 使用方式
发链接给我 + "加精选"，我会按 curated-content-writer skill 处理：
1. 读内容 + 检查代码
2. 写推荐语 + 可落地说明
3. 自动 commit → PR → merge → deploy