### PR TITLE
Fix bilingual SEO: repair dead series links + hreflang scaffold

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -3,6 +3,7 @@
 
 import type { SiteMeta } from 'astro-pure/types'
 import config from '@/site-config'
+import { getLangFromUrl, hasEnAlternate, stripLangPrefix, withLangPrefix } from '@/i18n/ui'
 
 type Props = SiteMeta
 
@@ -11,6 +12,21 @@ const { articleDate, description, ogImage, title } = Astro.props
 const siteTitle = `${title} ${config.titleDelimiter} ${config.title}`
 const canonicalURL = new URL(Astro.url.pathname, Astro.site)
 const socialImageURL = new URL(ogImage ? ogImage : '/og/default.png', Astro.url).href
+
+// Bilingual SEO: per-language og:locale, and hreflang alternates only for pages
+// that exist in both languages (never fabricate an /en URL for zh-only content).
+const lang = getLangFromUrl(Astro.url)
+const barePath = stripLangPrefix(Astro.url.pathname)
+const hasAlt = hasEnAlternate(barePath)
+const ogLocale = lang === 'en' ? 'en_US' : 'zh_CN'
+const ogLocaleAlternate = hasAlt ? (lang === 'en' ? 'zh_CN' : 'en_US') : null
+const hreflangAlternates = hasAlt
+  ? [
+      { hreflang: 'zh-CN', href: new URL(barePath, Astro.site).href },
+      { hreflang: 'en', href: new URL(withLangPrefix(barePath, 'en'), Astro.site).href },
+      { hreflang: 'x-default', href: new URL(barePath, Astro.site).href }
+    ]
+  : []
 ---
 
 <meta charset='utf-8' />
@@ -38,6 +54,13 @@ const socialImageURL = new URL(ogImage ? ogImage : '/og/default.png', Astro.url)
 {/* Canonical URL */}
 <link rel='canonical' href={canonicalURL} />
 
+{/* hreflang alternates — only for pages that exist in both languages */}
+{
+  hreflangAlternates.map((alt) => (
+    <link rel='alternate' hreflang={alt.hreflang} href={alt.href} />
+  ))
+}
+
 {/* Primary Meta Tags */}
 <meta content={siteTitle} name='title' />
 <meta content={description} name='description' />
@@ -52,7 +75,8 @@ const socialImageURL = new URL(ogImage ? ogImage : '/og/default.png', Astro.url)
 <meta content={description} property='og:description' />
 <meta content={canonicalURL} property='og:url' />
 <meta content={config.title} property='og:site_name' />
-<meta content={config.locale.attrs} property='og:locale' />
+<meta content={ogLocale} property='og:locale' />
+{ogLocaleAlternate && <meta content={ogLocaleAlternate} property='og:locale:alternate' />}
 <meta content={socialImageURL} property='og:image' />
 <meta content='1200' property='og:image:width' />
 <meta content='630' property='og:image:height' />

--- a/src/content/blog/20251216 - normalization/post.mdx
+++ b/src/content/blog/20251216 - normalization/post.mdx
@@ -498,9 +498,9 @@ python normalization_comparison.py
 - RMSNorm 实现：`model/model_minimind.py:95-105`
 
 **系列其他文章**：
-- [第2篇：RoPE位置编码](../20251217%20-%20rope-position-encoding/post.mdx)
-- [第3篇：Attention机制](../20251218%20-%20attention-mechanism/post.mdx)
-- [第4篇：FeedForward与完整架构](../20251219%20-%20feedforward-transformer-block/post.mdx)
+- [第2篇：RoPE位置编码](/blog/20251217---rope-position-encoding/post)
+- [第3篇：Attention机制](/blog/20251218---attention-mechanism/post)
+- [第4篇：FeedForward与完整架构](/blog/20251219---feedforward-transformer-block/post)
 
 ---
 

--- a/src/content/blog/20251217 - rope-position-encoding/post.mdx
+++ b/src/content/blog/20251217 - rope-position-encoding/post.mdx
@@ -542,9 +542,9 @@ python rope_why_multi_frequency.py
 - RoPE 实现：`model/model_minimind.py:108-182`
 
 **系列其他文章**：
-- [第1篇：归一化机制](../20251216%20-%20normalization/post.mdx)
-- [第3篇：Attention机制](../20251218%20-%20attention-mechanism/post.mdx)
-- [第4篇：FeedForward与完整架构](../20251219%20-%20feedforward-transformer-block/post.mdx)
+- [第1篇：归一化机制](/blog/20251216---normalization/post)
+- [第3篇：Attention机制](/blog/20251218---attention-mechanism/post)
+- [第4篇：FeedForward与完整架构](/blog/20251219---feedforward-transformer-block/post)
 
 ---
 

--- a/src/content/blog/20251218 - attention-mechanism/post.mdx
+++ b/src/content/blog/20251218 - attention-mechanism/post.mdx
@@ -627,9 +627,9 @@ python softmax_vs_rmsnorm.py
 - Attention 实现：`model/model_minimind.py:140-220`
 
 **系列其他文章**：
-- [第1篇：归一化机制](../20251216%20-%20normalization/post.mdx)
-- [第2篇：RoPE位置编码](../20251217%20-%20rope-position-encoding/post.mdx)
-- [第4篇：FeedForward与完整架构](../20251219%20-%20feedforward-transformer-block/post.mdx)
+- [第1篇：归一化机制](/blog/20251216---normalization/post)
+- [第2篇：RoPE位置编码](/blog/20251217---rope-position-encoding/post)
+- [第4篇：FeedForward与完整架构](/blog/20251219---feedforward-transformer-block/post)
 
 ---
 

--- a/src/content/blog/20251219 - feedforward-transformer-block/post.mdx
+++ b/src/content/blog/20251219 - feedforward-transformer-block/post.mdx
@@ -822,9 +822,9 @@ class MyMiniMind(nn.Module):
 - Transformer Block：`model/model_minimind.py:359-380`
 
 ### 相关阅读
-- [第1篇：为什么Transformer需要归一化？从梯度消失到RMSNorm](../20251216%20-%20normalization/post.mdx)
-- [第2篇：RoPE位置编码：从排列不变性到多频率机制](../20251217%20-%20rope-position-encoding/post.mdx)
-- [第3篇：Attention机制详解](../20251218%20-%20attention-mechanism/post.mdx)
+- [第1篇：为什么Transformer需要归一化？从梯度消失到RMSNorm](/blog/20251216---normalization/post)
+- [第2篇：RoPE位置编码：从排列不变性到多频率机制](/blog/20251217---rope-position-encoding/post)
+- [第3篇：Attention机制详解](/blog/20251218---attention-mechanism/post)
 
 ---
 

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -73,3 +73,22 @@ export function localizedPath(path: string, lang: Lang): string {
   if (path === '/') return '/en'
   return `/en${path.startsWith('/') ? path : `/${path}`}`
 }
+
+/**
+ * Whether a bare (zh-form) path has a real `/en` mirror page.
+ *
+ * Drives hreflang + og:locale:alternate emission: we only declare an English
+ * alternate for pages that genuinely exist in both languages. Chinese-only
+ * content — blog posts, archive entries, tag/year indexes — returns false so we
+ * never fabricate an `/en/...` URL that 404s and never claim a translation that
+ * isn't there. When a post is actually translated later, extend this.
+ */
+export function hasEnAlternate(barePath: string): boolean {
+  if (barePath === '/') return true
+  if (['/about', '/projects', '/links', '/contact', '/search', '/curated'].includes(barePath))
+    return true
+  // blog & archive: only the paginated list is mirrored under /en, not detail pages
+  if (/^\/blog(\/\d+)?$/.test(barePath)) return true
+  if (/^\/archive(\/\d+)?$/.test(barePath)) return true
+  return false
+}


### PR DESCRIPTION
## What & why

Two SEO/i18n problems on the bilingual site, fixed without touching post content/translations (scaffold-only, by design).

### 1. Repair broken internal links (`fix:` commit)
The transformer/MiniMind series (normalization → RoPE → attention → feedforward) cross-linked its "next/prev in series" navigation with **relative `../<folder>/post.mdx` paths**. Astro does not rewrite these, so they rendered as literal `href="../...post.mdx"` and **404'd** — the entire 4-post series navigation was dead (~10 links). Replaced with absolute `/blog/<id>---<slug>/post` URLs (matching the working convention used elsewhere).

### 2. Language-aware SEO `<head>` (`feat:` commit)
The bilingual site (`/` zh, `/en/*` en) emitted **zero hreflang**, a static `og:locale=zh_CN` on every page (even `/en`), and no per-language signals — so Google treated `/` and `/en/` as unrelated sites.

- `og:locale` now switches per language, with `og:locale:alternate` where a translation exists.
- `hreflang` alternates emitted **only for pages that exist in both languages** (home, about, projects, links, contact, search, curated, and the blog/archive *list* pages), via a new `hasEnAlternate()` helper.
- Chinese-only content (posts, `/tags`, archive detail) stays self-canonical with **no fabricated `/en` alternate**.

## Verified (dev server, rendered head)
- Series nav now links `/blog/.../post`, all targets return **200**, zero leftover `.mdx` links.
- `/` ↔ `/en`, `/about` ↔ `/en/about`, `/blog` ↔ `/en/blog`: reciprocal hreflang + `x-default` → zh, correct `og:locale`.
- `/blog/<post>` and `/tags`: self-canonical, **no** hreflang, `og:locale` zh_CN only.
- `bun run check`: 0 errors.

## Deliberately out of scope (rationale)
- **No `en/blog/[id]` route** — with no English post bodies, an `/en` post URL would be noindex dead-weight or duplicate content with contradictory canonical/hreflang. The `/en` blog list honestly links to the zh originals.
- **No sitemap i18n option** — `@astrojs/sitemap`'s i18n fabricates `/en` alternates for every page without existence checks (would emit 404 alternates for zh-only posts). Left on auto; on-page hreflang carries the signal.

## Possible follow-ups
- Link the series intro ("本系列包括") blocks (currently plain text).
- `/en/blog` sidebar `/tags` + `/archives` still point to zh routes.
- Actual post translation (separate, larger effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
