### PR TITLE
Match /en homepage + blog list styling to the zh versions

### DIFF
--- a/src/components/HeroEn.astro
+++ b/src/components/HeroEn.astro
@@ -1,0 +1,157 @@
+---
+import { Image } from 'astro:assets'
+import type { InferEntrySchema } from 'astro:content'
+
+import { PageInfo } from 'astro-pure/components/pages'
+import { FormattedDate, Icon } from 'astro-pure/user'
+
+// English mirror of astro-pure's Hero: identical markup/styles, but tag links
+// point to /en/tags/<tag> instead of the hardcoded /tags/<tag>.
+interface Props {
+  data: InferEntrySchema<'blog'>
+  remarkPluginFrontmatter: Record<string, unknown>
+}
+
+const {
+  data: {
+    title,
+    description,
+    draft,
+    heroImage,
+    publishDate,
+    updatedDate,
+    comment: enableComment,
+    tags,
+    language
+  },
+  remarkPluginFrontmatter
+} = Astro.props
+
+const dateTimeOptions: Intl.DateTimeFormatOptions = {
+  month: 'short'
+}
+---
+
+{
+  heroImage && (
+    <div class='hero-image relative mb-6'>
+      <Image
+        alt={heroImage.alt || title}
+        class='cover-image relative z-10 h-auto w-full max-w-[65ch] rounded-2xl object-contain'
+        fetchpriority='high'
+        loading='eager'
+        {...heroImage}
+      />
+      <Image
+        alt='Blur image'
+        fetchpriority='high'
+        loading='eager'
+        id='blurImage'
+        class='absolute end-0 top-4 z-0 mt-0 h-full max-w-[65ch] rounded-3xl opacity-60 transition-opacity duration-300'
+        {...heroImage}
+      />
+    </div>
+  )
+}
+
+{draft ? <span class='text-red-500'>(Draft)</span> : null}
+
+<div class='article-info max-lg:mx-auto'>
+  <div class='flex flex-wrap gap-x-4 gap-y-2 text-xs leading-6 text-muted-foreground'>
+    {/* Article date */}
+    <div class='flex items-center gap-1'>
+      <Icon name='calendar' class='size-5' />
+      <FormattedDate class='font-sans' date={publishDate} dateTimeOptions={dateTimeOptions} />
+      {
+        updatedDate && (
+          <div class='flex items-center gap-1'>
+            <span> / </span>
+            <span>
+              Update
+              <FormattedDate
+                class='font-sans'
+                date={updatedDate}
+                dateTimeOptions={dateTimeOptions}
+              />
+            </span>
+          </div>
+        )
+      }
+    </div>
+    {/* Times read */}
+    <div class='flex items-center gap-1'>
+      <Icon name='time' class='size-5' />
+      {remarkPluginFrontmatter.minutesRead}
+    </div>
+    {
+      // Language
+      language && (
+        <span class='flex items-center gap-1'>
+          <Icon name='earth' class='size-5' />
+          {language}
+        </span>
+      )
+    }
+    {
+      // Tags
+      !!tags?.length && (
+        <span class='flex items-center gap-1'>
+          <Icon name='hashtag' class='size-5' />
+          {tags.map((tag: string, i: number) => (
+            <div>
+              <a
+                aria-label={`View more blogs with the tag ${tag}`}
+                class='hover:underline hover:underline-offset-4'
+                data-pagefind-filter='tag'
+                href={`/en/tags/${tag}`}
+              >
+                {tag}
+              </a>
+              {i < tags.length - 1 && '/'}
+            </div>
+          ))}
+        </span>
+      )
+    }
+  </div>
+
+  <h1 class='mt-4 text-2xl font-medium sm:mb-2 sm:mt-6 sm:text-3xl'>
+    {title}
+  </h1>
+
+  <div class='mt-3 italic'>
+    <blockquote class='text-sm text-muted-foreground'><q>{description}</q></blockquote>
+    {!draft && enableComment && <PageInfo class='mt-1' />}
+  </div>
+</div>
+
+{/* Dividing line */}
+<div class='mt-4 w-1/2 border-t max-lg:mx-auto sm:mt-6 sm:w-1/3'></div>
+
+<script>
+  const viewportHeight = window.innerHeight
+  const threshold1 = viewportHeight / 9
+  const threshold2 = (viewportHeight * 2) / 9
+  const threshold3 = (viewportHeight * 3) / 9
+  const image = document.getElementById('blurImage') as HTMLImageElement
+
+  if (image) {
+    window.addEventListener('scroll', () => {
+      const scrollDistance = window.scrollY
+      if (scrollDistance >= threshold3) {
+        image.style.opacity = '0.15'
+      } else if (scrollDistance >= threshold2) {
+        image.style.opacity = '0.3'
+      } else if (scrollDistance >= threshold1) {
+        image.style.opacity = '0.45'
+      }
+    })
+  }
+</script>
+
+<style>
+  #blurImage {
+    --un-blur: blur(24px);
+    filter: var(--un-blur);
+  }
+</style>

--- a/src/components/PostPreviewEn.astro
+++ b/src/components/PostPreviewEn.astro
@@ -111,7 +111,7 @@ const heroStyle =
       <ul class='tag-list mt-1 flex flex-wrap gap-2'>
         {data.tags.map((tag: string) => (
           <li>
-            <Button title={tag} href={`/tags/${tag}`} style='pill' />
+            <Button title={tag} href={`/en/tags/${tag}`} style='pill' />
           </li>
         ))}
       </ul>

--- a/src/components/PostPreviewEn.astro
+++ b/src/components/PostPreviewEn.astro
@@ -1,0 +1,159 @@
+---
+import { Image } from 'astro:assets'
+import { render, type CollectionEntry } from 'astro:content'
+
+import { Button, FormattedDate, Icon } from 'astro-pure/user'
+
+// English mirror of astro-pure's PostPreview: identical markup/styles, but links
+// to /en/blog/<translationKey> instead of the hardcoded /blog/<id>.
+interface Props {
+  post: CollectionEntry<'blogEn'>
+  detailed?: boolean
+  class?: string
+}
+
+const { post, detailed = false, class: className = '' } = Astro.props
+const { data } = post
+const href = `/en/blog/${data.translationKey}`
+const { remarkPluginFrontmatter } = await render(post)
+const postDate = data.updatedDate ?? data.publishDate
+
+const liClass = [
+  'post-preview group/card flex flex-col relative rounded-2xl border bg-background transition-colors ease-in-out px-5 py-2.5 hover:bg-muted',
+  detailed && 'max-sm:px-4 sm:py-5',
+  className
+]
+  .filter(Boolean)
+  .join(' ')
+
+const linkClass = [
+  'group/link w-full flex flex-col transition-all hover:text-primary',
+  !detailed && 'sm:flex-row',
+  detailed && data.heroImage && 'max-md:pt-24'
+]
+  .filter(Boolean)
+  .join(' ')
+
+const heroStyle =
+  detailed && data.heroImage?.color
+    ? `--preview-highlight:color-mix(in srgb,${data.heroImage.color} 40%,hsl(var(--foreground)/var(--un-text-opacity,1)));--preview-highlight-bg:hsl(from ${data.heroImage.color} h s l/20%)`
+    : undefined
+---
+
+<li class={liClass} style={heroStyle}>
+  <a class={linkClass} href={href} data-astro-prefetch>
+    {
+      detailed && data.heroImage && (
+        <Image
+          alt={data.heroImage.alt || data.title}
+          class='cover-image absolute end-0 top-0 z-0 h-2/3 w-full rounded-2xl object-cover opacity-50 transition-opacity duration-300 group-hover/card:opacity-70 md:h-full md:w-3/5'
+          loading='eager'
+          {...data.heroImage}
+        />
+      )
+    }
+
+    <FormattedDate class='min-w-[95px] py-1 text-xs' date={postDate} />
+
+    <div class='z-10 flex-grow'>
+      <div class='flex justify-between'>
+        <div class={detailed ? 'font-medium' : ''}>
+          {data.title}
+        </div>
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          width='16'
+          height='16'
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke-width='2.5'
+          stroke-linecap='round'
+          stroke-linejoin='round'
+          class='preview-redirect my-1 stroke-muted-foreground group-hover/link:stroke-primary'
+          ><line
+            x1='5'
+            y1='12'
+            x2='19'
+            y2='12'
+            class='translate-x-4 scale-x-0 transition-all duration-300 ease-in-out group-hover/link:translate-x-1 group-hover/link:scale-x-100'
+          ></line><polyline
+            points='12 5 19 12 12 19'
+            class='translate-x-0 transition-all duration-300 ease-in-out group-hover/link:translate-x-1'
+          ></polyline></svg
+        >
+      </div>
+      {
+        detailed && (
+          <>
+            <p
+              class={[
+                'line-clamp-2 pt-1 text-sm text-muted-foreground sm:line-clamp-3',
+                data.heroImage && 'sm:me-24'
+              ]
+                .filter(Boolean)
+                .join(' ')}
+            >
+              {data.description}
+            </p>
+            <div class='flex items-center gap-2 py-1.5 text-sm italic leading-4 text-muted-foreground sm:py-3'>
+              <span class='flex items-center gap-1'>
+                <Icon name='time' class='size-4' />
+                {remarkPluginFrontmatter.minutesRead}
+              </span>
+            </div>
+          </>
+        )
+      }
+    </div>
+  </a>
+  {
+    detailed && data.tags && (
+      <ul class='tag-list mt-1 flex flex-wrap gap-2'>
+        {data.tags.map((tag: string) => (
+          <li>
+            <Button title={tag} href={`/tags/${tag}`} style='pill' />
+          </li>
+        ))}
+      </ul>
+    )
+  }
+</li>
+
+<style>
+  .post-preview {
+    --preview-highlight-final: var(
+      --preview-highlight,
+      hsl(var(--primary) / var(--un-text-opacity, 1))
+    );
+  }
+  .post-preview:hover {
+    &,
+    & .tag-list a {
+      background-color: var(
+        --preview-highlight-bg,
+        hsl(var(--muted) / var(--un-bg-opacity, 1))
+      ) !important;
+    }
+    & > a,
+    & .tag-list a:hover {
+      color: var(--preview-highlight-final) !important;
+    }
+    & > a .preview-redirect {
+      stroke: var(--preview-highlight-final) !important;
+    }
+  }
+  .cover-image {
+    mask-image: linear-gradient(to right, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%);
+    -webkit-mask-image: -webkit-linear-gradient(
+      to right,
+      rgba(0, 0, 0, 0) 0%,
+      rgba(0, 0, 0, 1) 100%
+    );
+  }
+  @media (max-width: 768px) {
+    .cover-image {
+      mask-image: linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%);
+      -webkit-mask-image: -webkit-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%);
+    }
+  }
+</style>

--- a/src/content/blog/20250701 - firstPR/post.en.mdx
+++ b/src/content/blog/20250701 - firstPR/post.en.mdx
@@ -2,7 +2,7 @@
 title: My First-Ever Pull Request
 description: 'A sophomore reflects on landing his first successful open-source pull request'
 publishDate: 2025-07-01 22:06:36
-tags: ['开源', '前端']
+tags: ['open source', 'frontend']
 language: en
 translationKey: '20250701---firstpr/post'
 ---

--- a/src/content/blog/20251023 - internshipExperience/post.en.mdx
+++ b/src/content/blog/20251023 - internshipExperience/post.en.mdx
@@ -2,7 +2,7 @@
 title: "Frontend Intern Interviews at Chinese Startups: A Prep Guide"
 description: "A systematic rundown of the technical topics, application data, and a complete prep checklist for frontend internship interviews at smaller Chinese companies."
 publishDate: 2025-10-23 16:00:00
-tags: ['实习', '前端', '面试', 'React']
+tags: ['internship', 'frontend', 'interview', 'React']
 language: en
 translationKey: '20251023---internshipexperience/post'
 ---

--- a/src/content/blog/20260309 - agentInterview/post.en.mdx
+++ b/src/content/blog/20260309 - agentInterview/post.en.mdx
@@ -2,7 +2,7 @@
 title: "A Sophomore Intern's Field Guide to Agent Dev Interviews"
 description: "After interviewing nearly 10 AI startups, what Agent-role interviews actually test, and the things that matter a hundred times more than memorizing answers."
 publishDate: 2026-03-09 00:00:00
-tags: ['实习', 'Agent', 'LLM', '面试', 'AI']
+tags: ['internship', 'Agent', 'LLM', 'interview', 'AI']
 language: en
 translationKey: '20260309---agentinterview/post'
 ---

--- a/src/content/blog/20260410 - openharnessPhase1/post.en.mdx
+++ b/src/content/blog/20260410 - openharnessPhase1/post.en.mdx
@@ -2,7 +2,7 @@
 title: "Reading OpenHarness: Inside an 11,733-Line Agent Harness"
 description: 'HKUDS open-sourced OpenHarness, an Agent Harness matching Claude Code. My notes from a day reading its core architecture: Phase 1, CLI startup to Agent Loop.'
 publishDate: 2026-04-10 00:00:00
-tags: ['AI Agent', 'Harness', 'Claude Code', 'OpenHarness', '源码解析', 'Python']
+tags: ['AI Agent', 'Harness', 'Claude Code', 'OpenHarness', 'source code', 'Python']
 language: en
 translationKey: '20260410---openharnessphase1/post'
 ---

--- a/src/content/blog/20260512 - agentMockInterview/post.en.mdx
+++ b/src/content/blog/20260512 - agentMockInterview/post.en.mdx
@@ -4,7 +4,7 @@ description: 'An 80-minute mock interview with a dev pivoting to Agent work. Eve
 language: en
 translationKey: '20260512---agentmockinterview/post'
 publishDate: 2026-05-12 00:00:00
-tags: ['Agent', '面试', 'LLM', 'AI', '模拟面试', '求职']
+tags: ['Agent', 'interview', 'LLM', 'AI', 'mock interview', 'job hunting']
 ---
 
 > This is a mock-interview retrospective. The candidate was a student from a 211 university, with two AI projects on his résumé: a multi-Agent healthy-eating assistant built on LangGraph, and a long-term memory engine for Agents. Another interviewer, W, and I interviewed him together for 80 minutes. Afterwards I felt this session was worth writing up as a blog post — not because the candidate did especially well or especially badly, but because it so completely exposed the problems with the mainstream "pad your résumé with AI bootcamp projects" path, while also walking through what an Agent engineer interview should test in 2026.

--- a/src/content/blog/20260517 - agentOnboardingGuide/post.en.mdx
+++ b/src/content/blog/20260517 - agentOnboardingGuide/post.en.mdx
@@ -2,7 +2,7 @@
 title: "For Everyone Who Wants Into Agents But Doesn't Know Where"
 description: "Joye's Agent Engineer Onboarding Guide v1.0: what an Agent is, why now, how to start, and how to land a job — for anyone who wants in but doesn't know where."
 publishDate: 2026-05-17 00:00:00
-tags: ['Agent', 'LLM', '入门', '学习路线', '求职', 'AI']
+tags: ['Agent', 'LLM', 'getting started', 'learning path', 'job hunting', 'AI']
 language: en
 translationKey: '20260517---agentonboardingguide/post'
 ---

--- a/src/content/blog/20260523 - agentInterviewMindset/post.en.mdx
+++ b/src/content/blog/20260523 - agentInterviewMindset/post.en.mdx
@@ -2,7 +2,7 @@
 title: 'Interviews Aren''t Exams, They''re Mutual Selection'
 description: 'After 100+ Agent interviews, how I redefined it: apply early, calibrate constantly, review recordings, ask hard questions, and meet founders as equals.'
 publishDate: 2026-05-23 00:00:00
-tags: ['Agent', '面试', '求职', '职业发展', 'AI']
+tags: ['Agent', 'interview', 'job hunting', 'career', 'AI']
 language: en
 translationKey: '20260523---agentinterviewmindset/post'
 ---

--- a/src/content/blog/20260528 - agentMockInterviewReview/post.en.mdx
+++ b/src/content/blog/20260528 - agentMockInterviewReview/post.en.mdx
@@ -2,7 +2,7 @@
 title: 'I Grilled Another Agent Candidate: 46-Minute Mock Interview'
 description: 'A 46-minute 1v1 Agent engineer mock interview: deep-diving two personal projects, plus RAG, Agent evaluation, Skills, MCP, prefix caching, and Q&A.'
 publishDate: 2026-05-28 00:00:00
-tags: ['Agent', '面试', 'LLM', 'AI', '模拟面试', '求职', 'RAG']
+tags: ['Agent', 'interview', 'LLM', 'AI', 'mock interview', 'job hunting', 'RAG']
 language: en
 translationKey: '20260528---agentmockinterviewreview/post'
 ---

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -9,6 +9,7 @@ import { MediumZoom } from 'astro-pure/advanced'
 import { ArticleBottom, Copyright, Hero, TOC } from 'astro-pure/components/pages'
 import PageLayout from '@/layouts/ContentLayout.astro'
 import Comment from '@/components/comment/Comment.astro'
+import HeroEn from '@/components/HeroEn.astro'
 import { integ } from '@/site-config'
 
 interface Props {
@@ -18,6 +19,7 @@ interface Props {
   remarkPluginFrontmatter: Record<string, unknown>
   back?: string
   recommend?: boolean
+  enHero?: boolean
 }
 
 const {
@@ -26,7 +28,8 @@ const {
   headings,
   remarkPluginFrontmatter,
   back = '/blog',
-  recommend = true
+  recommend = true,
+  enHero = false
 } = Astro.props
 
 const {
@@ -49,7 +52,13 @@ const primaryColor = data.heroImage?.color ?? 'hsl(var(--primary) / var(--un-tex
 >
   {!!headings.length && <TOC {headings} slot='sidebar' />}
 
-  <Hero {data} {remarkPluginFrontmatter} slot='header' />
+  {
+    enHero ? (
+      <HeroEn {data} {remarkPluginFrontmatter} slot='header' />
+    ) : (
+      <Hero {data} {remarkPluginFrontmatter} slot='header' />
+    )
+  }
 
   <slot />
 

--- a/src/pages/en/blog/[...id].astro
+++ b/src/pages/en/blog/[...id].astro
@@ -26,6 +26,6 @@ const { post, posts } = Astro.props
 const { Content, headings, remarkPluginFrontmatter } = await render(post)
 ---
 
-<PostLayout {post} {posts} {headings} {remarkPluginFrontmatter} back='/en/blog' recommend={false}>
+<PostLayout {post} {posts} {headings} {remarkPluginFrontmatter} back='/en/blog' recommend={false} enHero>
   <Content />
 </PostLayout>

--- a/src/pages/en/blog/[...page].astro
+++ b/src/pages/en/blog/[...page].astro
@@ -79,12 +79,12 @@ const paginationProps = {
               <ul class='text-bgColor flex flex-wrap gap-2'>
                 {uniqueTags.map((tag) => (
                   <li>
-                    <Button title={tag} href={`/tags/${tag}`} style='pill' />
+                    <Button title={tag} href={`/en/tags/${tag}`} style='pill' />
                   </li>
                 ))}
               </ul>
               <span class='mt-4 block sm:text-end'>
-                <a aria-label='View all blog categories' href='/tags' data-astro-prefetch>
+                <a aria-label='View all blog categories' href='/en/tags' data-astro-prefetch>
                   View all →
                 </a>
               </span>

--- a/src/pages/en/blog/[...page].astro
+++ b/src/pages/en/blog/[...page].astro
@@ -1,33 +1,38 @@
 ---
 import type { GetStaticPaths, Page } from 'astro'
-import type { CollectionEntry } from 'astro:content'
+import { getCollection, type CollectionEntry } from 'astro:content'
 
 import { Paginator } from 'astro-pure/components/pages'
-import { getBlogCollection, sortMDByDate } from 'astro-pure/server'
-import { Button } from 'astro-pure/user'
+import { Button, Icon } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
+import PostPreviewEn from '@/components/PostPreviewEn.astro'
 import config from '@/site-config'
 
 export const prerender = true
 
-// Mirror the Chinese post URL via the explicit translationKey.
-const enHref = (key?: string) => `/en/blog/${key}`
-
 export const getStaticPaths = (async ({ paginate }) => {
-  const collections = sortMDByDate(await getBlogCollection('blogEn'))
+  const collections = (await getCollection('blogEn'))
+    .filter((p) => (import.meta.env.PROD ? !p.data.draft : true))
+    .sort(
+      (a, b) =>
+        +new Date(b.data.updatedDate ?? b.data.publishDate) -
+        +new Date(a.data.updatedDate ?? a.data.publishDate)
+    )
+  const uniqueTags = [...new Set(collections.flatMap((p) => p.data.tags))]
   const collectionsCount = collections.length
   return paginate(collections, {
     pageSize: config.content.blogPageSize,
-    props: { collectionsCount }
+    props: { uniqueTags, collectionsCount }
   })
 }) satisfies GetStaticPaths
 
 interface Props {
   page: Page<CollectionEntry<'blogEn'>>
+  uniqueTags: string[]
   collectionsCount: number
 }
 
-const { page, collectionsCount } = Astro.props
+const { page, uniqueTags, collectionsCount } = Astro.props
 
 const meta = {
   description: 'English posts — agents, LLM internals, and engineering notes.',
@@ -35,8 +40,8 @@ const meta = {
 }
 
 const paginationProps = {
-  ...(page.url.prev && { prevUrl: { text: '← Previous Posts', url: page.url.prev } }),
-  ...(page.url.next && { nextUrl: { text: 'Next Posts →', url: page.url.next } })
+  ...(page.url.prev && { prevUrl: { text: `← Previous Posts`, url: page.url.prev } }),
+  ...(page.url.next && { nextUrl: { text: `Next Posts →`, url: page.url.next } })
 }
 ---
 
@@ -50,53 +55,42 @@ const paginationProps = {
       page.data.length === 0 ? (
         <p>No posts yet.</p>
       ) : (
-        <section aria-label='Blog posts list' class='animate' id='content'>
-          <div class='mb-3 flex flex-col justify-between text-sm sm:mb-5 sm:flex-row'>
-            <span class='text-muted-foreground'>
-              Page {page.currentPage} - Showing {page.data.length} of {collectionsCount} posts
-            </span>
-          </div>
-          <ul class='flex flex-col gap-y-4 text-start'>
-            {page.data.map((post) => (
-              <li>
-                <a
-                  href={enHref(post.data.translationKey)}
-                  class='group block rounded-xl border border-border bg-card px-5 py-5 transition hover:border-foreground/20 hover:shadow-sm'
-                  data-astro-prefetch
-                >
-                  <h2 class='text-lg font-medium leading-tight group-hover:text-foreground'>
-                    {post.data.title}
-                  </h2>
-                  {post.data.description && (
-                    <p class='mt-1.5 text-sm leading-6 text-muted-foreground'>
-                      {post.data.description}
-                    </p>
-                  )}
-                  <div class='mt-2 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground'>
-                    <time datetime={post.data.publishDate.toISOString()}>
-                      {post.data.publishDate.toLocaleDateString('en', {
-                        year: 'numeric',
-                        month: 'short',
-                        day: 'numeric'
-                      })}
-                    </time>
-                    {post.data.tags.length > 0 && (
-                      <>
-                        <span>·</span>
-                        <div class='flex flex-wrap gap-1.5'>
-                          {post.data.tags.map((tag: string) => (
-                            <span class='rounded-md bg-muted px-2 py-0.5'>{tag}</span>
-                          ))}
-                        </div>
-                      </>
-                    )}
-                  </div>
+        <div class='grid gap-y-16 sm:grid-cols-[3fr_1fr] sm:gap-x-8'>
+          <section aria-label='Blog posts list' class='animate' id='content'>
+            <div class='mb-3 flex flex-col justify-between text-sm sm:mb-5 sm:flex-row'>
+              <span class='text-muted-foreground'>
+                Page {page.currentPage} - Showing {page.data.length} of {collectionsCount} posts
+              </span>
+            </div>
+            <ul class='flex flex-col gap-y-4 text-start'>
+              {page.data.map((post) => (
+                <PostPreviewEn {post} detailed />
+              ))}
+            </ul>
+            <Paginator {...paginationProps} />
+          </section>
+
+          {!!uniqueTags.length && (
+            <aside class='animate' id='sidebar'>
+              <h2 class='mb-4 flex items-center text-lg font-semibold'>
+                <Icon name='tag-2' class='me-2' />
+                Tags
+              </h2>
+              <ul class='text-bgColor flex flex-wrap gap-2'>
+                {uniqueTags.map((tag) => (
+                  <li>
+                    <Button title={tag} href={`/tags/${tag}`} style='pill' />
+                  </li>
+                ))}
+              </ul>
+              <span class='mt-4 block sm:text-end'>
+                <a aria-label='View all blog categories' href='/tags' data-astro-prefetch>
+                  View all →
                 </a>
-              </li>
-            ))}
-          </ul>
-          <Paginator {...paginationProps} />
-        </section>
+              </span>
+            </aside>
+          )}
+        </div>
       )
     }
   </main>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -5,14 +5,16 @@ import { sortCuratedEntries } from '@/lib/curated'
 import avatar from 'src/assets/avatar.png'
 
 import { Quote } from 'astro-pure/advanced'
-import { Button, Icon, Label } from 'astro-pure/user'
+import { Button, Card, Icon, Label } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
 import CuratedItem from '@/components/curated/CuratedItem.astro'
+import LinkCard from '@/components/home/LinkCard.astro'
 import Section from '@/components/home/Section.astro'
 import SiteStats from '@/components/home/SiteStats.astro'
 import SkillLayout from '@/components/home/SkillLayout.astro'
+import JoJo from '@/components/mascot/JoJo'
+import PostPreviewEn from '@/components/PostPreviewEn.astro'
 import Terminal from '@/components/terminal/Terminal.astro'
-import TranslationNotice from '@/components/TranslationNotice.astro'
 import config from '@/site-config'
 
 export const prerender = true
@@ -30,6 +32,66 @@ const ai = [
   'Prompt Engineering'
 ]
 const tools = ['Cursor', 'Git', 'Docker', 'Bun', 'Figma', 'ESLint/Prettier']
+
+const MAX_POSTS = 5
+const allPostsByDate = (await getCollection('blogEn'))
+  .filter((p) => (import.meta.env.PROD ? !p.data.draft : true))
+  .sort(
+    (a, b) =>
+      +new Date(b.data.updatedDate ?? b.data.publishDate) -
+      +new Date(a.data.updatedDate ?? a.data.publishDate)
+  )
+  .slice(0, MAX_POSTS)
+
+const openSourceRepos = [
+  {
+    name: 'Learn-Open-Harness',
+    description:
+      'A from-scratch interactive OpenHarness tutorial — Agent Loop, Tools, Memory, Multi-Agent',
+    fallbackStars: 297
+  },
+  {
+    name: 'minimind-notes',
+    description:
+      'Building an LLM from scratch — the principles behind Transformer, Pretraining, and SFT, with side-by-side experiments',
+    fallbackStars: 93
+  }
+]
+
+async function fetchStars(repo: string, fallback: number) {
+  try {
+    const res = await fetch(`https://api.github.com/repos/joyehuang/${repo}`, {
+      headers: { Accept: 'application/vnd.github+json' }
+    })
+    if (!res.ok) return fallback
+    const data = (await res.json()) as { stargazers_count?: number }
+    return data.stargazers_count ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
+const openSource = await Promise.all(
+  openSourceRepos.map(async (r) => ({
+    ...r,
+    stars: await fetchStars(r.name, r.fallbackStars)
+  }))
+)
+
+const MAX_NOTES = 4
+const archiveTypeLabels: Record<string, string> = {
+  note: 'Note',
+  snippet: 'Snippet',
+  draft: 'Draft',
+  idea: 'Idea',
+  research: 'Research',
+  reference: 'Reference'
+}
+const latestNotes = (await getCollection('archiveEn'))
+  .filter((e) => !e.data.draft)
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .slice(0, MAX_NOTES)
+
 const MAX_CURATED = 2
 const latestCurated = sortCuratedEntries(
   (await getCollection('curated')).filter((entry) => !entry.data.draft)
@@ -38,8 +100,6 @@ const latestCurated = sortCuratedEntries(
 
 <PageLayout meta={{ title: 'Home' }} highlightColor='#659EB9'>
   <main class='flex w-full flex-col items-center'>
-    <TranslationNotice lang='en' />
-
     <section
       class='animate mb-10 flex flex-col items-center gap-y-7 relative z-50'
       id='content-header'
@@ -99,13 +159,69 @@ const latestCurated = sortCuratedEntries(
         <Button title='More about me' class='w-fit self-end' href='/en/about' style='ahead' />
       </Section>
 
-      <Section title='Skills'>
-        <SkillLayout title='Languages' skills={languages} />
-        <SkillLayout title='Frontend' skills={frontend} />
-        <SkillLayout title='Backend' skills={backend} />
-        <SkillLayout title='AI & Agent' skills={ai} />
-        <SkillLayout title='Tools' skills={tools} />
-      </Section>
+      {
+        allPostsByDate.length > 0 && (
+          <Section title='Blog'>
+            <ul class='flex flex-col gap-y-1.5 sm:gap-y-2'>
+              {allPostsByDate.map((p) => (
+                <PostPreviewEn post={p} />
+              ))}
+            </ul>
+            <Button title='More blogs' class='w-fit self-end' href='/en/blog' style='ahead' />
+          </Section>
+        )
+      }
+
+      {
+        latestNotes.length > 0 && (
+          <Section title='Notes'>
+            <ul class='flex flex-col gap-y-1.5 sm:gap-y-2'>
+              {latestNotes.map((note) => (
+                <li class='post-preview group/card flex flex-col relative rounded-2xl border bg-background transition-colors ease-in-out px-5 py-2.5 hover:bg-muted'>
+                  <a
+                    class='group/link w-full flex flex-col sm:flex-row transition-all hover:text-primary'
+                    href={`/en/archive/${note.data.translationKey}`}
+                    data-astro-prefetch
+                  >
+                    <span class='min-w-[95px] py-1 text-xs text-muted-foreground'>
+                      {archiveTypeLabels[note.data.type] || note.data.type}
+                    </span>
+                    <div class='z-10 flex-grow'>
+                      <div class='flex justify-between'>
+                        <div>{note.data.title}</div>
+                        <svg
+                          xmlns='http://www.w3.org/2000/svg'
+                          width='16'
+                          height='16'
+                          viewBox='0 0 24 24'
+                          fill='none'
+                          stroke-width='2.5'
+                          stroke-linecap='round'
+                          stroke-linejoin='round'
+                          class='my-1 stroke-muted-foreground group-hover/link:stroke-primary'
+                        >
+                          <line
+                            x1='5'
+                            y1='12'
+                            x2='19'
+                            y2='12'
+                            class='translate-x-4 scale-x-0 transition-all duration-300 ease-in-out group-hover/link:translate-x-1 group-hover/link:scale-x-100'
+                          />
+                          <polyline
+                            points='12 5 19 12 12 19'
+                            class='translate-x-0 transition-all duration-300 ease-in-out group-hover/link:translate-x-1'
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </a>
+                </li>
+              ))}
+            </ul>
+            <Button title='More notes' class='w-fit self-end' href='/en/archive' style='ahead' />
+          </Section>
+        )
+      }
 
       {
         latestCurated.length > 0 && (
@@ -120,8 +236,69 @@ const latestCurated = sortCuratedEntries(
         )
       }
 
+      <Section title='Experience'>
+        <LinkCard
+          heading='Tezign (Shanghai)'
+          subheading='Full-Stack Intern, AIGC R&D'
+          href='https://atypica.ai/'
+        >
+          <ul class='ms-4 list-disc text-muted-foreground'>
+            <li>Building atypica.ai — a multi-agent system for commercial research</li>
+          </ul>
+        </LinkCard>
+        <LinkCard
+          heading='fAIshion.ai'
+          subheading='AI Full-Stack Engineer (Remote)'
+          href='https://www.faishion.ai/'
+        >
+          <ul class='ms-4 list-disc text-muted-foreground'>
+            <li>Full-stack development and model integration for an AI virtual try-on and outfit-matching platform</li>
+          </ul>
+        </LinkCard>
+        <LinkCard heading='AIXCut' subheading='AI Full-Stack Engineer' href='https://aixcut.cn/'>
+          <ul class='ms-4 list-disc text-muted-foreground'>
+            <li>Designing and shipping an AI video-editing agent</li>
+          </ul>
+        </LinkCard>
+      </Section>
+      <Section title='Open Source'>
+        {
+          openSource.map((repo) => (
+            <LinkCard
+              heading={repo.name}
+              subheading={repo.description}
+              date={`⭐ ${repo.stars}`}
+              href={`https://github.com/joyehuang/${repo.name}`}
+            />
+          ))
+        }
+      </Section>
+      <Section title='Education'>
+        <Card
+          as='a'
+          heading='University of Melbourne'
+          subheading='Bachelor of Science — Computing & Software Systems'
+          date='Feb 2024 - Jun 2027'
+        />
+      </Section>
+
+      <Section title='Skills'>
+        <SkillLayout title='Languages' skills={languages} />
+        <SkillLayout title='Frontend' skills={frontend} />
+        <SkillLayout title='Backend' skills={backend} />
+        <SkillLayout title='AI & Agent' skills={ai} />
+        <SkillLayout title='Tools' skills={tools} />
+      </Section>
+
       <SiteStats lang='en' />
     </div>
     <Quote class='mt-12' />
   </main>
+
+  {/* JoJo mascot — floating companion bottom-right (hidden on mobile) */}
+  <div class='pointer-events-none fixed bottom-6 end-6 z-40 hidden md:block'>
+    <div class='pointer-events-auto'>
+      <JoJo client:load size='md' quipPool='idle' />
+    </div>
+  </div>
 </PageLayout>

--- a/src/pages/en/tags/[tag]/[...page].astro
+++ b/src/pages/en/tags/[tag]/[...page].astro
@@ -1,0 +1,63 @@
+---
+import type { GetStaticPaths, Page } from 'astro'
+import { getCollection, type CollectionEntry } from 'astro:content'
+
+import { Paginator } from 'astro-pure/components/pages'
+import { Button } from 'astro-pure/user'
+import PageLayout from '@/layouts/BaseLayout.astro'
+import PostPreviewEn from '@/components/PostPreviewEn.astro'
+import config from '@/site-config'
+
+export const prerender = true
+
+export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
+  const posts = (await getCollection('blogEn'))
+    .filter((p) => (import.meta.env.PROD ? !p.data.draft : true))
+    .sort(
+      (a, b) =>
+        +new Date(b.data.updatedDate ?? b.data.publishDate) -
+        +new Date(a.data.updatedDate ?? a.data.publishDate)
+    )
+  const uniqueTags = [...new Set(posts.flatMap((p) => p.data.tags))]
+  return uniqueTags.flatMap((tag) => {
+    const filtered = posts.filter((p) => p.data.tags.includes(tag))
+    return paginate(filtered, { pageSize: config.content.blogPageSize, params: { tag } })
+  })
+}
+
+interface Props {
+  page: Page<CollectionEntry<'blogEn'>>
+}
+
+const { page } = Astro.props
+const { tag } = Astro.params
+
+const meta = {
+  description: `View all English posts with the tag - ${tag}`,
+  title: `Tag: ${tag}`
+}
+
+const paginationProps = {
+  ...(page.url.prev && { prevUrl: { text: `← Previous`, url: page.url.prev } }),
+  ...(page.url.next && { nextUrl: { text: `Next →`, url: page.url.next } })
+}
+---
+
+<PageLayout {meta}>
+  <Button title='Back' href='/en/blog' style='back' />
+  <main class='mt-6 lg:mt-10'>
+    <div id='content-header' class='animate'>
+      <h1 class='mb-6 flex items-end gap-x-2 text-3xl font-medium'>
+        Tags:
+        <span class='text-2xl'>#{tag}</span>
+      </h1>
+    </div>
+
+    <section id='content' class='animate' aria-label='Blog post list'>
+      <ul class='flex flex-col gap-y-3 text-start'>
+        {page.data.map((post) => <PostPreviewEn {post} detailed />)}
+      </ul>
+      <Paginator {...paginationProps} />
+    </section>
+  </main>
+</PageLayout>

--- a/src/pages/en/tags/index.astro
+++ b/src/pages/en/tags/index.astro
@@ -1,0 +1,56 @@
+---
+import { getCollection } from 'astro:content'
+
+import { Button } from 'astro-pure/user'
+import { cn } from 'astro-pure/utils'
+import PageLayout from '@/layouts/BaseLayout.astro'
+
+export const prerender = true
+
+const allPosts = (await getCollection('blogEn')).filter((p) =>
+  import.meta.env.PROD ? !p.data.draft : true
+)
+const counts = new Map<string, number>()
+for (const p of allPosts) for (const t of p.data.tags) counts.set(t, (counts.get(t) ?? 0) + 1)
+const allTags = [...counts.entries()].sort((a, b) => b[1] - a[1])
+
+const meta = {
+  description: "A list of all the topics I've written about in my posts",
+  title: 'All Tags'
+}
+---
+
+<PageLayout {meta}>
+  <Button title='Back' href='/en/blog' style='back' />
+  <main class='mt-6 lg:mt-10'>
+    <div id='content-header' class='animate'>
+      <h1 class='mb-6 text-3xl font-medium'>Tags</h1>
+    </div>
+
+    <div id='content' class='animate'>
+      {
+        allTags.length > 0 ? (
+          <ul class='flex flex-wrap gap-4'>
+            {allTags.map(([tag, val]) => (
+              <li>
+                <Button
+                  href={`/en/tags/${tag}`}
+                  style='pill'
+                  class={cn(
+                    'items-start gap-x-1',
+                    val > 2 ? 'rounded-xl px-3 py-1 text-xl' : val > 1 && 'text-lg'
+                  )}
+                >
+                  {tag}
+                  <span class={val > 2 ? 'text-base' : 'text-xs'}>{val}</span>
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>Any tag yet.</p>
+        )
+      }
+    </div>
+  </main>
+</PageLayout>


### PR DESCRIPTION
## Problem

The `/en` homepage and `/en/blog` list had drifted visually from their Chinese counterparts. Root cause: both were built during the earlier *scaffold* phase (before any posts were translated), so they were intentionally stripped-down — and never brought back to parity once the translations landed.

## Fixes

**`/en/blog` list** — was a custom single-column card layout. `astro-pure`'s `PostPreview` hardcodes `/blog/<id>` + `/tags/<tag>` URLs, so it couldn't be reused for the en routes. Added **`PostPreviewEn.astro`** (mirrors PostPreview's markup + styles exactly, but links to `/en/blog/<translationKey>`) and restored the **2-column grid + Tags sidebar + detailed previews** to match `/blog`.

**`/en` homepage** — was missing the **Blog, Notes, Experience, Open Source, and Education** sections and the **JoJo mascot**, and still carried a stale "translation in progress" notice. Restored full structural parity with the zh homepage (same section order), with English copy and `/en/...` links.

## Verified
- `bun run check` + `bun run build` ✅
- Screenshotted both pages against their zh versions — layouts now match.

## Known follow-up (not in scope here)
- Post dates on `/en` render in zh-CN format (`2026年5月28日`) because `FormattedDate` uses the site locale — same as the zh pages, so it's *consistent*, but English date formatting on `/en` could be a nice polish.
- Tags shown on en cards are still the (Chinese) source tags; curated snippets remain in Chinese (curated wasn't part of the translation scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
