### PR TITLE
feat: add waline views and comments to talks page

### DIFF
--- a/src/components/talks/TalksSeries.astro
+++ b/src/components/talks/TalksSeries.astro
@@ -37,6 +37,10 @@ const takeawayHtml = (title: string, desc?: string) =>
         <span>已记录 <b>{talks.length}</b> 期</span>
         <span><b>每周</b> 一次</span>
         <span>自 <b>{sinceLabel}</b></span>
+        <span>浏览 <b class='waline-pageview-count' data-path='/talks'></b> 次</span>
+        <a class='tk-stat-link' href='#waline'>
+          <b class='waline-comment-count' data-path='/talks'></b> 条留言
+        </a>
       </div>
       <a class='tk-join' href='/contact'>想来参加？→</a>
     </div>
@@ -283,6 +287,13 @@ const takeawayHtml = (title: string, desc?: string) =>
   .tk-stats b {
     color: var(--tk-accent);
     font-weight: 600;
+  }
+  .tk-stat-link {
+    color: inherit;
+    text-decoration: none;
+  }
+  .tk-stat-link:hover {
+    color: var(--tk-accent);
   }
   .tk-join {
     font-size: 13px;

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content'
 
 import { Button } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
+import Comment from '@/components/comment/Comment.astro'
 import TalksSeries from '@/components/talks/TalksSeries.astro'
 import { sortTalks } from '@/lib/talks'
 
@@ -23,4 +24,5 @@ const talks = sortTalks(
   <Button title='Back' href='/' style='back' />
   <h1 class='sr-only'>分享会 / Talks</h1>
   <TalksSeries talks={talks} />
+  <Comment class='mt-10' path='/talks' />
 </PageLayout>


### PR DESCRIPTION
## What

Adds Waline page-view counting and a comment thread to the `/talks` page, matching the rest of the site (blog posts, projects).

- **[src/components/talks/TalksSeries.astro](src/components/talks/TalksSeries.astro)** — adds `浏览 N 次` and `N 条留言` to the hero stats row, keyed to `data-path='/talks'`. The comment count links to the thread anchor (`#waline`). Added a small `.tk-stat-link` style so it sits consistently with the existing `.tk-stats`.
- **[src/pages/talks/index.astro](src/pages/talks/index.astro)** — renders `<Comment path='/talks'>` at the bottom of the page.

## Why

The talks page was the only main content page without view stats or comments. The user asked for parity with the other pages.

## How it works

`BaseLayout` already mounts a global `ViewCounter`, which populates any `.waline-pageview-count` / `.waline-comment-count` span by `data-path`. When the `Comment` component is present it initializes Waline and takes over driving both counters (the `ViewCounter` script detects the comment widget and skips, avoiding a double fetch). This is the same mechanism the blog-post and projects pages use.

## Verification

- `bun run check` — 0 errors, 0 warnings.
- Local preview of `/talks`: hero shows `浏览 56 次 · 0 条留言`, comment thread renders at the bottom, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)