### PR TITLE
[codex] update homepage experience

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -142,11 +142,12 @@ const latestNotes = (await getCollection('archiveEn'))
       <Section title='About'>
         <p class='text-muted-foreground'>AI Agent & Full-Stack Developer</p>
         <p class='text-muted-foreground'>
-          Undergraduate at the University of Melbourne. Currently building atypica (a multi-agent
-          system for commercial research) at Tezign, and working on AI full-stack features and a
-          video-editing agent at fAIshion.ai and Goshu Tech. I care about how LLMs actually work
-          under the hood, and about shipping products that run in the real world. Build fast, learn
-          faster — off the clock: piano, cello, photography.
+          Undergraduate at the University of Melbourne. Currently working on Playyy.ai at Adastra
+          Labs (Shimo Docs), building atypica (a multi-agent system for commercial research) at
+          Tezign, and working on AI full-stack features and a video-editing agent at fAIshion.ai and
+          Goshu Tech. I care about how LLMs actually work under the hood, and about shipping products
+          that run in the real world. Build fast, learn faster — off the clock: piano, cello,
+          photography.
         </p>
         <Button title='More about me' class='w-fit self-end' href='/en/about' style='ahead' />
       </Section>
@@ -217,12 +218,26 @@ const latestNotes = (await getCollection('archiveEn'))
 
       <Section title='Experience'>
         <LinkCard
+          heading='Adastra Labs (Shimo Docs)'
+          subheading='AI Full-Stack Engineer'
+          href='https://playyy.ai/'
+        >
+          <ul class='ms-4 list-disc text-muted-foreground'>
+            <li>Building Playyy.ai — an AI image generation and brand design platform</li>
+          </ul>
+        </LinkCard>
+        <LinkCard
           heading='Tezign (Shanghai)'
           subheading='Full-Stack Intern, AIGC R&D'
           href='https://atypica.ai/'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>Building atypica.ai — a multi-agent system for commercial research</li>
+          </ul>
+        </LinkCard>
+        <LinkCard heading='AIXCut' subheading='AI Full-Stack Engineer' href='https://aixcut.cn/'>
+          <ul class='ms-4 list-disc text-muted-foreground'>
+            <li>Designing and shipping an AI video-editing agent</li>
           </ul>
         </LinkCard>
         <LinkCard
@@ -232,11 +247,6 @@ const latestNotes = (await getCollection('archiveEn'))
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>Full-stack development and model integration for an AI virtual try-on and outfit-matching platform</li>
-          </ul>
-        </LinkCard>
-        <LinkCard heading='AIXCut' subheading='AI Full-Stack Engineer' href='https://aixcut.cn/'>
-          <ul class='ms-4 list-disc text-muted-foreground'>
-            <li>Designing and shipping an AI video-editing agent</li>
           </ul>
         </LinkCard>
       </Section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -142,9 +142,10 @@ const latestTalk = talks[0]
       <Section title='About'>
         <p class='text-muted-foreground'>AI Agent & Full-Stack Developer</p>
         <p class='text-muted-foreground'>
-          墨尔本大学在读，目前在特赞 Tezign 做 atypica（商业研究 Multi-Agent）， 同时在 fAIshion.ai
-          与 Goshu Tech 做 AI 全栈与剪辑 Agent。 在意 LLM 的底层机制，也在意产品能不能真正跑起来。
-          Build fast, learn faster — 平时弹琴、拉大提琴、玩摄影。
+          墨尔本大学在读，目前在 Adastra Labs（石墨文档海外）参与 Playyy.ai，
+          同时在特赞 Tezign 做 atypica（商业研究 Multi-Agent），并在 fAIshion.ai 与 Goshu Tech
+          做 AI 全栈与剪辑 Agent。 在意 LLM 的底层机制，也在意产品能不能真正跑起来。 Build fast,
+          learn faster — 平时弹琴、拉大提琴、玩摄影。
         </p>
         <Button title='More about me' class='w-fit self-end' href='/about' style='ahead' />
       </Section>
@@ -233,12 +234,26 @@ const latestTalk = talks[0]
 
       <Section title='Experience'>
         <LinkCard
+          heading='Adastra Labs（石墨文档海外）'
+          subheading='AI 全栈工程师'
+          href='https://playyy.ai/'
+        >
+          <ul class='ms-4 list-disc text-muted-foreground'>
+            <li>参与 Playyy.ai —— AI 图像生成与品牌设计平台的产品与工程研发</li>
+          </ul>
+        </LinkCard>
+        <LinkCard
           heading='上海特赞 Tezign'
           subheading='AIGC 研发部门全栈实习生'
           href='https://atypica.ai/'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>参与 atypica.ai —— 面向商业研究场景的 Multi-Agent 系统</li>
+          </ul>
+        </LinkCard>
+        <LinkCard heading='AIXCut' subheading='AI 全栈研发' href='https://aixcut.cn/'>
+          <ul class='ms-4 list-disc text-muted-foreground'>
+            <li>参与 AI 视频剪辑 Agent 的设计与工程化落地</li>
           </ul>
         </LinkCard>
         <LinkCard
@@ -248,11 +263,6 @@ const latestTalk = talks[0]
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>AI 虚拟试衣与服装搭配平台的全栈开发与模型集成</li>
-          </ul>
-        </LinkCard>
-        <LinkCard heading='AIXCut' subheading='AI 全栈研发' href='https://aixcut.cn/'>
-          <ul class='ms-4 list-disc text-muted-foreground'>
-            <li>参与 AI 视频剪辑 Agent 的设计与工程化落地</li>
           </ul>
         </LinkCard>
       </Section>


### PR DESCRIPTION
## What changed

- Added Adastra Labs / Shimo Docs and Playyy.ai to the homepage About and Experience sections.
- Kept the new Experience card without dates.
- Reordered Experience so AIXCut appears before fAIshion.ai.
- Applied the same updates to Chinese and English homepages.

## Why

The homepage needed to reflect the new current work and the preferred ordering of existing roles.

## Validation

- `bun run check`