### PR TITLE
[codex] Improve sitemap and robots SEO

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,5 +1,6 @@
 import { rehypeHeadingIds } from '@astrojs/markdown-remark'
 import react from '@astrojs/react'
+import sitemap from '@astrojs/sitemap'
 import vercel from '@astrojs/vercel'
 import AstroPureIntegration from 'astro-pure'
 import { defineConfig } from 'astro/config'
@@ -22,6 +23,19 @@ import {
   updateStyle
 } from './src/plugins/shiki-transformers.ts'
 import config from './src/site.config.ts'
+
+const excludedSitemapPathPatterns = [
+  /^\/(?:en\/)?404\/?$/,
+  /^\/(?:en\/)?search\/?$/,
+  /^\/api(?:\/|$)/,
+  /^\/\.well-known\/joye-manifest\.json$/,
+  /^\/pagefind(?:\/|$)/
+]
+
+const shouldIncludeInSitemap = (page: string) => {
+  const { pathname } = new URL(page)
+  return !excludedSitemapPathPatterns.some((pattern) => pattern.test(pathname))
+}
 
 // https://astro.build/config
 export default defineConfig({
@@ -49,6 +63,16 @@ export default defineConfig({
   },
 
   integrations: [
+    sitemap({
+      filter: shouldIncludeInSitemap,
+      i18n: {
+        defaultLocale: 'zh',
+        locales: {
+          zh: 'zh-CN',
+          en: 'en'
+        }
+      }
+    }),
     // astro-pure will automatically add sitemap, mdx & unocss
     AstroPureIntegration(config),
     react()

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@astrojs/check": "^0.9.4",
         "@astrojs/react": "^5.0.2",
         "@astrojs/rss": "^4.0.11",
+        "@astrojs/sitemap": "^3.4.1",
         "@astrojs/vercel": "^8.1.4",
         "@playform/compress": "^0.1.9",
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/react": "^5.0.2",
     "@astrojs/rss": "^4.0.11",
+    "@astrojs/sitemap": "^3.4.1",
     "@astrojs/vercel": "^8.1.4",
     "@playform/compress": "^0.1.9",
     "@resvg/resvg-js": "^2.6.2",

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,18 +1,22 @@
 ---
 // import { ClientRouter } from 'astro:transitions'
 
+import { hasEnVersion } from '@/i18n/translations'
+import { getLangFromUrl, stripLangPrefix, withLangPrefix } from '@/i18n/ui'
+
 import type { SiteMeta } from 'astro-pure/types'
 import config from '@/site-config'
-import { getLangFromUrl, stripLangPrefix, withLangPrefix } from '@/i18n/ui'
-import { hasEnVersion } from '@/i18n/translations'
 
-type Props = SiteMeta
+type Props = SiteMeta & {
+  noindex?: boolean
+}
 
-const { articleDate, description, ogImage, title } = Astro.props
+const { articleDate, description, noindex = false, ogImage, title } = Astro.props
 
 const siteTitle = `${title} ${config.titleDelimiter} ${config.title}`
 const canonicalURL = new URL(Astro.url.pathname, Astro.site)
 const socialImageURL = new URL(ogImage ? ogImage : '/og/default.png', Astro.url).href
+const socialImageAlt = `${title} social preview`
 
 // Bilingual SEO: per-language og:locale, and hreflang alternates only for pages
 // that exist in both languages (never fabricate an /en URL for zh-only content).
@@ -56,19 +60,17 @@ const hreflangAlternates = hasAlt
 <link rel='canonical' href={canonicalURL} />
 
 {/* hreflang alternates — only for pages that exist in both languages */}
-{
-  hreflangAlternates.map((alt) => (
-    <link rel='alternate' hreflang={alt.hreflang} href={alt.href} />
-  ))
-}
+{hreflangAlternates.map((alt) => <link rel='alternate' hreflang={alt.hreflang} href={alt.href} />)}
 
 {/* Primary Meta Tags */}
 <meta content={siteTitle} name='title' />
 <meta content={description} name='description' />
 <meta content={config.author} name='author' />
+<meta content={noindex ? 'noindex, follow' : 'index, follow'} name='robots' />
 
 {/* Theme Color */}
-<meta content='' name='theme-color' />
+<meta content='hsl(210 33% 99%)' media='(prefers-color-scheme: light)' name='theme-color' />
+<meta content='hsl(240 20.54% 5.2%)' media='(prefers-color-scheme: dark)' name='theme-color' />
 
 {/* Open Graph / Facebook */}
 <meta content={articleDate ? 'article' : 'website'} property='og:type' />
@@ -79,6 +81,7 @@ const hreflangAlternates = hasAlt
 <meta content={ogLocale} property='og:locale' />
 {ogLocaleAlternate && <meta content={ogLocaleAlternate} property='og:locale:alternate' />}
 <meta content={socialImageURL} property='og:image' />
+<meta content={socialImageAlt} property='og:image:alt' />
 <meta content='1200' property='og:image:width' />
 <meta content='630' property='og:image:height' />
 {
@@ -96,9 +99,10 @@ const hreflangAlternates = hasAlt
 <meta content={title} property='twitter:title' />
 <meta content={description} property='twitter:description' />
 <meta content={socialImageURL} property='twitter:image' />
+<meta content={socialImageAlt} property='twitter:image:alt' />
 
 {/* Sitemap */}
-<link href='/sitemap-index.xml' rel='sitemap' />
+<link href='/sitemap-index.xml' rel='sitemap' type='application/xml' />
 
 {/* RSS auto-discovery */}
 <link

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,28 +1,29 @@
 ---
-import { Footer } from 'astro-pure/components/basic'
-import type { SiteMeta } from 'astro-pure/types'
+import { getLangFromUrl } from '@/i18n/ui'
 import Analytics from '@vercel/analytics/astro'
 import SpeedInsights from '@vercel/speed-insights/astro'
+
+import { Footer } from 'astro-pure/components/basic'
+import type { SiteMeta } from 'astro-pure/types'
 import BaseHead from '@/components/BaseHead.astro'
+import ViewCounter from '@/components/comment/ViewCounter.astro'
 import Header from '@/components/Header.astro'
-import ThemeProvider from '@/components/ThemeProvider.astro'
 import DevModeHost from '@/components/terminal/DevModeHost'
 import { buildSiteFs } from '@/components/terminal/fs/server'
-import ViewCounter from '@/components/comment/ViewCounter.astro'
+import ThemeProvider from '@/components/ThemeProvider.astro'
 import config from '@/site-config'
-import { getLangFromUrl } from '@/i18n/ui'
 
 // Import the global.css file here so that it is included on
 // all pages through the use of the <BaseLayout /> component.
 import '@/assets/styles/app.css'
 
 interface Props {
-  meta: SiteMeta
+  meta: SiteMeta & { noindex?: boolean }
   highlightColor?: string
 }
 
 const {
-  meta: { articleDate, description = config.description, ogImage, title },
+  meta: { articleDate, description = config.description, noindex, ogImage, title },
   highlightColor,
   ...props
 } = Astro.props
@@ -36,7 +37,7 @@ const fs = await buildSiteFs()
 
 <html lang={htmlLang}>
   <head>
-    <BaseHead {articleDate} {description} {ogImage} {title} />
+    <BaseHead {articleDate} {description} {noindex} {ogImage} {title} />
     <ThemeProvider />
   </head>
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,11 +1,12 @@
 ---
-export const prerender = true
-
 import { Button } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
 
+export const prerender = true
+
 const meta = {
   description: 'Not found',
+  noindex: true,
   title: '404'
 }
 ---

--- a/src/pages/en/404.astro
+++ b/src/pages/en/404.astro
@@ -1,11 +1,12 @@
 ---
-export const prerender = true
-
 import { Button } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
 
+export const prerender = true
+
 const meta = {
   description: 'Not found',
+  noindex: true,
   title: '404'
 }
 ---

--- a/src/pages/en/search/index.astro
+++ b/src/pages/en/search/index.astro
@@ -1,11 +1,12 @@
 ---
 import { Button } from 'astro-pure/user'
-import PFSearch from '@/components/search/PFSearch.astro'
 import PageLayout from '@/layouts/BaseLayout.astro'
+import PFSearch from '@/components/search/PFSearch.astro'
 import { integ } from '@/site-config'
 
 const meta = {
   description: 'Search relative posts of the whole blog',
+  noindex: true,
   title: 'Search'
 }
 ---

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -2,16 +2,15 @@ import type { APIRoute } from 'astro'
 
 export const prerender = true
 
-const robotsTxt = `
-User-agent: GPTBot
-User-agent: ClaudeBot
-User-agent: Claude-Web
-
-User-agent: *
-Allow: /
-
-Sitemap: ${new URL('sitemap-index.xml', import.meta.env.SITE).href}
-`.trim()
+const site = import.meta.env.SITE
+const robotsTxt = [
+  'User-agent: *',
+  'Allow: /',
+  'Disallow: /api/',
+  'Disallow: /pagefind/',
+  '',
+  `Sitemap: ${new URL('/sitemap-index.xml', site).href}`
+].join('\n')
 
 export const GET: APIRoute = () =>
   new Response(robotsTxt, {

--- a/src/pages/search/index.astro
+++ b/src/pages/search/index.astro
@@ -1,11 +1,12 @@
 ---
 import { Button } from 'astro-pure/user'
-import PFSearch from '@/components/search/PFSearch.astro'
 import PageLayout from '@/layouts/BaseLayout.astro'
+import PFSearch from '@/components/search/PFSearch.astro'
 import { integ } from '@/site-config'
 
 const meta = {
   description: 'Search relative posts of the whole blog',
+  noindex: true,
   title: 'Search'
 }
 ---


### PR DESCRIPTION
## Summary

- Make the sitemap integration explicit and filter non-indexable routes from generated sitemap output.
- Add sitemap i18n alternates for Chinese and English routes.
- Update robots.txt to point at the sitemap index while excluding API and Pagefind assets.
- Add robots meta handling, theme-color metadata, social image alt text, and noindex metadata for 404/search pages.

## Why

The site already generated a sitemap through astro-pure, but the behavior was implicit and included routes that should not be submitted for indexing. This makes the SEO surface visible in project config and keeps Search Console submissions focused on canonical indexable pages.

## Validation

- `bun run check`
- `bun run build`
- Parsed `dist/client/sitemap-0.xml`: 171 URLs, 0 excluded routes present, `xhtml:link` alternates present.
- Verified `dist/client/robots.txt` points to `https://joyehuang.me/sitemap-index.xml`.
- Verified search and 404 pages output `noindex, follow`.