### PR TITLE
[codex] Fix sitemap canonical domain for Search Console

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,3 +1,7 @@
+import { copyFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { AstroIntegration } from 'astro'
 import { rehypeHeadingIds } from '@astrojs/markdown-remark'
 import react from '@astrojs/react'
 import sitemap from '@astrojs/sitemap'
@@ -37,10 +41,20 @@ const shouldIncludeInSitemap = (page: string) => {
   return !excludedSitemapPathPatterns.some((pattern) => pattern.test(pathname))
 }
 
+const exposeSingleSitemap = (): AstroIntegration => ({
+  name: 'expose-single-sitemap',
+  hooks: {
+    'astro:build:done': async ({ dir }) => {
+      const outputDir = fileURLToPath(dir)
+      await copyFile(join(outputDir, 'sitemap-0.xml'), join(outputDir, 'sitemap.xml'))
+    }
+  }
+})
+
 // https://astro.build/config
 export default defineConfig({
   // Top-Level Options
-  site: 'https://joyehuang.me',
+  site: 'https://www.joyehuang.me',
   // base: '/docs',
   trailingSlash: 'never',
 
@@ -73,6 +87,7 @@ export default defineConfig({
         }
       }
     }),
+    exposeSingleSitemap(),
     // astro-pure will automatically add sitemap, mdx & unocss
     AstroPureIntegration(config),
     react()

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -102,7 +102,7 @@ const hreflangAlternates = hasAlt
 <meta content={socialImageAlt} property='twitter:image:alt' />
 
 {/* Sitemap */}
-<link href='/sitemap-index.xml' rel='sitemap' type='application/xml' />
+<link href='/sitemap.xml' rel='sitemap' type='application/xml' />
 
 {/* RSS auto-discovery */}
 <link

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -9,7 +9,7 @@ const robotsTxt = [
   'Disallow: /api/',
   'Disallow: /pagefind/',
   '',
-  `Sitemap: ${new URL('/sitemap-index.xml', site).href}`
+  `Sitemap: ${new URL('/sitemap.xml', site).href}`
 ].join('\n')
 
 export const GET: APIRoute = () =>


### PR DESCRIPTION
## Summary

- Set Astro `site` to the production canonical host: `https://www.joyehuang.me`.
- Expose a direct `/sitemap.xml` URL list by copying the generated `sitemap-0.xml` during build.
- Point robots.txt and the page `<link rel="sitemap">` at `/sitemap.xml` instead of the sitemap index.

## Why

The deployed site redirects `https://joyehuang.me` to `https://www.joyehuang.me`, but the generated sitemap URLs were still using the non-www host. In Google Search Console URL-prefix properties, that mismatch can make submitted sitemaps appear to discover 0 pages. Submitting a direct URL-list sitemap also matches the shape used by the minimind wiki sitemap.

## Validation

- `bun run check`
- `bun run build`
- Verified `dist/client/sitemap.xml` exists as a direct `<urlset>` with 171 URLs.
- Verified all sitemap `<loc>` values use `https://www.joyehuang.me`.
- Verified `dist/client/robots.txt` points to `https://www.joyehuang.me/sitemap.xml`.
- Verified homepage canonical URL uses `https://www.joyehuang.me/`.