### PR TITLE
feat: agentic home-page intro (diffusion → landing → enter)

### DIFF
--- a/demos/intro/README.md
+++ b/demos/intro/README.md
@@ -1,0 +1,88 @@
+# 入场动画 · 设计与实现说明（Particle Constellation Intro）
+
+> 这是 Joye 个人博客首页入场动画的完整自然语言描述，作为后续复用 / 再生成 / 写作的素材。
+>
+> - 已上线版本对应组件：[`src/components/intro/IntroOverlay.astro`](../../src/components/intro/IntroOverlay.astro)，接入于首页 `src/pages/index.astro` 与 `src/pages/en/index.astro`。
+> - 本目录另有三个独立全屏 demo，是当时探索的三个方向，最终选用 **constellation**：
+>   - [`constellation.html`](./constellation.html) —— 粒子聚合（**已选用**）
+>   - [`terminal-boot.html`](./terminal-boot.html) —— 终端开机 `joye.init()`
+>   - [`kinetic-type.html`](./kinetic-type.html) —— 动态排版 Kinetic Type
+>   - [`index.html`](./index.html) —— 三方案对比画廊
+
+---
+
+## 一句话
+
+首页首次打开时，成百上千颗钢蓝 / 青色粒子从屏幕四周飞入、在中央汇聚拼出名字 **「JOYE」**，短暂停顿后炸散并整体淡出，露出底下真实的首页。
+
+## 设计意图
+
+- 给「内容已经很好、但缺视觉冲击」的博客补一记开场重拳，让路人第一眼就被抓住。
+- 借开场展示前端功底：text→particle 采样、Canvas 粒子物理、星座连线、鼠标交互，全部手写、零动画库。
+- 不喧宾夺主：约 3.5 秒、可随时跳过、每次会话只播一次；并且**不另做 hero**，而是淡出露出真实首页 —— 过渡自然、零信息重复。
+
+## 逐拍体验（时间轴）
+
+> 时间基于「粒子开始」后的相对秒数。
+
+| 时间 | 阶段 | 画面 |
+| --- | --- | --- |
+| 0.0 – 1.7s | **汇聚** | 粒子从屏幕外一圈以弹簧式缓动飞向各自目标点，边飞边连出若隐若现的星座连线；中央一团柔和的主色辉光。 |
+| 1.7 – 2.5s | **成形 / 停顿** | 粒子收束成清晰的点阵「JOYE」，做轻微呼吸式明暗闪烁；此时鼠标移动可把附近粒子推开，离开后回流复位。 |
+| 2.5s 起 | **揭幕** | 粒子获得向外（略微向上）的随机速度炸散，同时整层 overlay 在 0.9s 内淡出；淡出结束后从 DOM 移除，真实首页完全显现。 |
+
+总时长约 **3.5s**。任意时刻点击页面或右下角「跳过 →」按钮，立即淡出进站。
+
+## 视觉语言
+
+- **跟随站点主题**（读取 CSS 设计变量，不写死颜色）：
+  - 深色模式：青色粒子（≈ `hsl(195 95% 85%)`）+ 居中辉光，在深底上最「炸」。
+  - 浅色模式：钢蓝粒子（基于 `--primary`，明度下压到 ≈40%、提高饱和与不透明度），保证在近白底上依然清晰、有重量。
+- 粒子颜色沿水平方向有约 ±9% 的明度渐变，形成左深右亮的细微层次。
+- **背景与站点 `--background` 同色**（所以淡出时背景不跳色）+ 一层径向主色辉光。
+- 字形：用站点品牌字体 **Satoshi、700 字重**采样，字间距加宽到 `0.18em`，保证 J/O/Y/E 四个字母清晰可读。
+- 右下角是一颗 mono 字体的「跳过 →」胶囊按钮，配色走 `--card` / `--border` / `--muted-foreground`。
+
+## 技术实现（手写，无第三方动画库）
+
+- **text→particle 采样**：离屏 canvas 用 Satoshi 700 画出加宽字距的「JOYE」，逐像素扫描（步距 `7×DPR`），`alpha > 128` 的像素记为一个目标点；约 1500–2000 个点（随视口与 DPR 变化）。
+- **物理**：每颗粒子向目标点做弹簧吸引（汇聚 `ease≈0.07`、停顿 `ease≈0.13`），速度阻尼 `0.86`；炸散阶段改为随机外向速度。
+- **鼠标交互**：半径 `110×DPR` 内的粒子被反向推开，力随距离衰减。
+- **星座连线**：仅在成形阶段，给距离 `< 26×DPR` 的相邻粒子之间画极低透明度连线。
+- **揭幕**：给 overlay 加 `.intro-done`（`opacity → 0`，0.9s），结束后 `remove()`；因 overlay 背景与站点同色，淡出是「溶解」而非「换页」。
+- **性能**：`DPR` 上限 2；动画结束即 `cancelAnimationFrame` 并移除节点；只在首页、每会话一次。
+
+## 交互与无障碍规则
+
+- **每次会话只播一次**：`sessionStorage` 标记 `intro-seen`；同标签刷新不重播；新标签 / 新会话重播。
+- **可跳过**：点击 overlay 任意处或「跳过」按钮，立即揭幕。
+- **尊重 `prefers-reduced-motion`**：直接不渲染、零动画（首屏即真实首页）。
+- **首帧无闪**：overlay 在 HTML 里即不透明覆盖；一段同步 inline 脚本在首帧前判断「已看过 / 减少动效」并直接移除，避免老访客看到一闪。
+- **SEO / 可访问性**：真实首页 HTML 始终在底层，overlay 仅是视觉层、`aria-hidden`，淡出后移除。
+
+## 可调参数（改这些就能改观感）
+
+| 想改什么 | 调哪里 |
+| --- | --- |
+| 节奏快慢 | 汇聚 1.7s / 停顿到 2.5s / 淡出 0.9s |
+| 粒子密度 | 采样步距（默认 `7×DPR`，越小越密） |
+| 字号 / 字距 | `sampleText` 里的 `size` 与 `tracking`（0.18） |
+| 粒子大小 | `r`（0.7–1.6 × DPR） |
+| 浅色够不够「重」 | 浅色的 `baseL`(40) / `sat`(+18) / alpha 下限 |
+| 显示的文字 | 把 `'JOYE'` 换成任意词即可（采样逻辑通用） |
+| 触发频率 | `sessionStorage` → `localStorage` 可改成「永久只播一次」 |
+
+## 复用 / 再生成提示词（English — 喂给 AI 用）
+
+> A full-screen Canvas-2D intro overlay for a personal site's home page. Several hundred small
+> particles fly in from beyond the screen edges and spring toward target positions that spell the
+> word **"JOYE"** in a bold sans-serif (targets sampled from offscreen-canvas text on a ~7px grid).
+> While forming, faint constellation lines connect nearby particles and a soft radial glow sits
+> behind. Particles hold for ~0.8s with a gentle twinkle and are repelled by the cursor within
+> ~110px. Then they scatter outward while the whole overlay fades out over 0.9s and is removed,
+> revealing the real page underneath — the overlay background matches the site background so it
+> *dissolves* rather than cuts. Theme-aware: cyan particles + glow on dark; darker, more-saturated
+> steel-blue on near-white light mode (colours read from CSS custom properties `--primary` /
+> `--background`). Plays **once per session** (sessionStorage), skippable by clicking anywhere or a
+> small monospace "skip" pill, and fully disabled under `prefers-reduced-motion`. Vanilla JS, no
+> animation libraries; spring easing toward targets, velocity damping ~0.86, DPR capped at 2.

--- a/demos/intro/README.md
+++ b/demos/intro/README.md
@@ -3,27 +3,29 @@
 > 这是 Joye 个人博客首页入场动画的完整自然语言描述，作为后续复用 / 再生成 / 写作的素材。
 >
 > - 对应组件：[`src/components/intro/IntroOverlay.astro`](../../src/components/intro/IntroOverlay.astro)，接入于首页 `src/pages/index.astro` 与 `src/pages/en/index.astro`。
-> - 本目录另有三个独立全屏 demo（探索期的三个方向）：
+> - 本目录另有四个独立全屏 demo（探索期方向）：
 >   - [`constellation.html`](./constellation.html) —— 动画一 · 粒子聚合
 >   - [`terminal-boot.html`](./terminal-boot.html) —— 动画二 · 终端开机 `joye.init()`
 >   - [`kinetic-type.html`](./kinetic-type.html) —— 动画三 · 动态排版 Kinetic Type
->   - [`index.html`](./index.html) —— 三方案对比画廊
+>   - [`multi-agent.html`](./multi-agent.html) —— 动画四 · Multi-Agent 编排
+>   - [`index.html`](./index.html) —— 四方案对比画廊
 >
-> **当前状态（评审中）**：三个方向都已集成为组件里的「变体」，由左下角的 **Tweak 切换面板**（动画一 / 二 / 三 + replay）实时切换，方便对比。默认当前播放 **动画二 · 终端**。Tweak 面板是评审辅助工具，定稿前会下掉或加开关。
+> **当前状态（评审中）**：四个方向都已集成为组件里的「变体」，由左下角的 **Tweak 切换面板**（动画一 / 二 / 三 / 四 + replay）实时切换，方便对比。默认当前播放 **动画二 · 终端**。Tweak 面板是评审辅助工具，定稿前会下掉或加开关。
 >
-> 下方的「逐拍 / 视觉 / 实现」详述以 **动画一 · 粒子聚合** 为主线；动画二（终端开机）、动画三（动态排版）的描述见各自 demo 文件顶部与组件源码。
+> 下方的「逐拍 / 视觉 / 实现」详述以 **动画一 · 粒子聚合** 为主线；动画二（终端开机）、动画三（动态排版）、动画四（Multi-Agent 编排）的描述见各自 demo 文件顶部与组件源码。
 
 ---
 
 ## 一句话
 
-首页首次打开时，成百上千颗钢蓝 / 青色粒子从屏幕四周飞入、在中央汇聚拼出名字 **「JOYE」**，短暂停顿后炸散并整体淡出，露出底下真实的首页。
+首页首次打开时，一层很淡的 Agent / 内容关键词（`context`、`planner`、`tools`、`memory`、`RAG`、`OpenHarness` 等）先浮在背景里，像站点正在读取上下文。随后成百上千颗钢蓝 / 青色粒子分批、放慢地从屏幕四周汇入，在中央拼出名字 **「JOYE」**。成形后动画不急着退场，而是停在一个可互动状态：用户可以移动鼠标拨动粒子，准备好后点击 **「进入 ~/joye →」**，粒子向上自然消散并整体淡出，露出底下真实的首页。
 
 ## 设计意图
 
 - 给「内容已经很好、但缺视觉冲击」的博客补一记开场重拳，让路人第一眼就被抓住。
-- 借开场展示前端功底：text→particle 采样、Canvas 粒子物理、星座连线、鼠标交互，全部手写、零动画库。
-- 不喧宾夺主：约 3.5 秒、可随时跳过、每次会话只播一次；并且**不另做 hero**，而是淡出露出真实首页 —— 过渡自然、零信息重复。
+- 借开场展示前端功底，同时把视觉语义绑定到 Joye 平时做的事：Agent、上下文、工具、记忆、评估、内容写作，而不是一个可替换名字的通用粒子特效。
+- 技术上仍是 text→particle 采样、Canvas 粒子物理、星座连线、鼠标交互，全部手写、零动画库。
+- 不喧宾夺主：成形后把节奏交给用户，既可停留体验，也可随时进入 / 跳过；每次会话只播一次，并且**不另做 hero**，而是淡出露出真实首页 —— 过渡自然、零信息重复。
 
 ## 逐拍体验（时间轴）
 
@@ -31,11 +33,12 @@
 
 | 时间 | 阶段 | 画面 |
 | --- | --- | --- |
-| 0.0 – 1.7s | **汇聚** | 粒子从屏幕外一圈以弹簧式缓动飞向各自目标点，边飞边连出若隐若现的星座连线；中央一团柔和的主色辉光。 |
-| 1.7 – 2.5s | **成形 / 停顿** | 粒子收束成清晰的点阵「JOYE」，做轻微呼吸式明暗闪烁；此时鼠标移动可把附近粒子推开，离开后回流复位。 |
-| 2.5s 起 | **揭幕** | 粒子获得向外（略微向上）的随机速度炸散，同时整层 overlay 在 0.9s 内淡出；淡出结束后从 DOM 移除，真实首页完全显现。 |
+| 0.0 – 1.2s | **上下文浮现** | 屏幕周围出现很淡的 Agent / 内容关键词，作为“读入上下文”的氛围层。 |
+| 0.2 – 3.15s | **分批汇聚** | 粒子从屏幕外一圈以更慢的弹簧式缓动分批飞向各自目标点，边飞边连出若隐若现的星座连线；中央一团柔和的主色辉光。 |
+| 3.15 – 4.05s | **成形 / 停顿** | 粒子收束成清晰的点阵「JOYE」，做轻微呼吸式明暗闪烁；此时鼠标移动可把附近粒子推开，离开后回流复位。 |
+| 4.05s 起 | **停留 / 进入** | 「进入 ~/joye →」按钮浮现，并出现一行很淡的 trace 彩蛋：`context loaded · tools ready · welcome back`。点击按钮后粒子向上漂散约 1.35s，再让整层 overlay 在 0.9s 内淡出；淡出结束后从 DOM 移除，真实首页完全显现。 |
 
-总时长约 **3.5s**。任意时刻点击页面或右下角「跳过 →」按钮，立即淡出进站。
+主动点击时通常约 **4–5s** 后即可进站；如果用户停留观赏，按钮出现约 **12s** 后会自动进入，避免挡住首页。任意时刻点击右下角「跳过 →」按钮，立即淡出进站。
 
 ## 视觉语言
 
@@ -45,21 +48,22 @@
 - 粒子颜色沿水平方向有约 ±9% 的明度渐变，形成左深右亮的细微层次。
 - **背景与站点 `--background` 同色**（所以淡出时背景不跳色）+ 一层径向主色辉光。
 - 字形：用站点品牌字体 **Satoshi、700 字重**采样，字间距加宽到 `0.18em`，保证 J/O/Y/E 四个字母清晰可读。
-- 右下角是一颗 mono 字体的「跳过 →」胶囊按钮，配色走 `--card` / `--border` / `--muted-foreground`。
+- 「进入 ~/joye →」按钮在 JOYE 下方浮现，配色走 `--card` / `--border` / `--primary` 的半透明终端风，而不是高对比白色 CTA；右下角保留一颗更低调的 mono 字体「跳过 →」胶囊按钮，作为兜底。
 
 ## 技术实现（手写，无第三方动画库）
 
 - **text→particle 采样**：离屏 canvas 用 Satoshi 700 画出加宽字距的「JOYE」，逐像素扫描（步距 `7×DPR`），`alpha > 128` 的像素记为一个目标点；约 1500–2000 个点（随视口与 DPR 变化）。
-- **物理**：每颗粒子向目标点做弹簧吸引（汇聚 `ease≈0.07`、停顿 `ease≈0.13`），速度阻尼 `0.86`；炸散阶段改为随机外向速度。
+- **语义背景层**：DOM token 层呈现 `context / planner / tools / memory / eval / RAG / OpenHarness / frontend / design` 等关键词；汇聚中逐渐变淡，像被吸收进 JOYE。
+- **物理**：每颗粒子向目标点做弹簧吸引（汇聚 `ease≈0.045`，并按粒子延迟分批启动；停顿 `ease≈0.11`），速度阻尼 `0.87`；消散阶段改为向上漂移 + 轻微外扩，阻尼 `0.91`。
 - **鼠标交互**：半径 `110×DPR` 内的粒子被反向推开，力随距离衰减。
 - **星座连线**：仅在成形阶段，给距离 `< 26×DPR` 的相邻粒子之间画极低透明度连线。
-- **揭幕**：给 overlay 加 `.intro-done`（`opacity → 0`，0.9s），结束后 `remove()`；因 overlay 背景与站点同色，淡出是「溶解」而非「换页」。
+- **揭幕**：点击「进入 ~/joye →」后先切到 `scatter`，粒子向上消散约 1.35s，再给 overlay 加 `.intro-done`（`opacity → 0`，0.9s）；因 overlay 背景与站点同色，淡出是「溶解」而非「换页」。
 - **性能**：`DPR` 上限 2；动画结束即 `cancelAnimationFrame` 并移除节点；只在首页、每会话一次。
 
 ## 交互与无障碍规则
 
 - **每次会话只播一次**：`sessionStorage` 标记 `intro-seen`；同标签刷新不重播；新标签 / 新会话重播。
-- **可跳过**：点击 overlay 任意处或「跳过」按钮，立即揭幕。
+- **可进入 / 可跳过**：点击「进入 ~/joye →」自然揭幕；点击「跳过」按钮立即揭幕；如果用户长时间停留，按钮出现约 12s 后自动进入。
 - **尊重 `prefers-reduced-motion`**：直接不渲染、零动画（首屏即真实首页）。
 - **首帧无闪**：overlay 在 HTML 里即不透明覆盖；一段同步 inline 脚本在首帧前判断「已看过 / 减少动效」并直接移除，避免老访客看到一闪。
 - **SEO / 可访问性**：真实首页 HTML 始终在底层，overlay 仅是视觉层、`aria-hidden`，淡出后移除。
@@ -68,7 +72,7 @@
 
 | 想改什么 | 调哪里 |
 | --- | --- |
-| 节奏快慢 | 汇聚 1.7s / 停顿到 2.5s / 淡出 0.9s |
+| 节奏快慢 | 上下文 1.2s / 汇聚 3.15s / 按钮 4.05s 出现 / 点击后上浮消散 1.35s / 淡出 0.9s |
 | 粒子密度 | 采样步距（默认 `7×DPR`，越小越密） |
 | 字号 / 字距 | `sampleText` 里的 `size` 与 `tracking`（0.18） |
 | 粒子大小 | `r`（0.7–1.6 × DPR） |
@@ -78,15 +82,20 @@
 
 ## 复用 / 再生成提示词（English — 喂给 AI 用）
 
-> A full-screen Canvas-2D intro overlay for a personal site's home page. Several hundred small
-> particles fly in from beyond the screen edges and spring toward target positions that spell the
-> word **"JOYE"** in a bold sans-serif (targets sampled from offscreen-canvas text on a ~7px grid).
-> While forming, faint constellation lines connect nearby particles and a soft radial glow sits
-> behind. Particles hold for ~0.8s with a gentle twinkle and are repelled by the cursor within
-> ~110px. Then they scatter outward while the whole overlay fades out over 0.9s and is removed,
-> revealing the real page underneath — the overlay background matches the site background so it
-> *dissolves* rather than cuts. Theme-aware: cyan particles + glow on dark; darker, more-saturated
+> A full-screen Canvas-2D intro overlay for a personal site's home page. First, a very subtle layer
+> of agent/work tokens appears around the screen — `context`, `planner`, `tools`, `memory`, `eval`,
+> `RAG`, `OpenHarness`, `frontend`, `design` — like the site is loading context. Then several
+> hundred small particles fly in slowly from beyond the screen edges in staggered waves and spring
+> toward target positions that spell the word **"JOYE"** in a bold sans-serif (targets sampled from
+> offscreen-canvas text on a ~7px grid). While forming, faint constellation lines connect nearby
+> particles and a soft radial glow sits behind. Particles then hold as an interactive constellation
+> with a gentle twinkle and are repelled by the cursor within ~110px. A small glassy monospace
+> "enter ~/joye →" button appears below the word, with a faint trace line: `context loaded · tools
+> ready · welcome back`. When clicked, particles drift upward and fade for ~1.35s while the whole
+> overlay fades out over 0.9s and is removed, revealing the real page underneath — the overlay
+> background matches the site background so it *dissolves* rather than cuts. Include a low-key skip
+> button and a long fallback auto-enter timeout so the overlay never blocks the page. Theme-aware: cyan particles + glow on dark; darker, more-saturated
 > steel-blue on near-white light mode (colours read from CSS custom properties `--primary` /
-> `--background`). Plays **once per session** (sessionStorage), skippable by clicking anywhere or a
+> `--background`). Plays **once per session** (sessionStorage), exits through the enter button or a
 > small monospace "skip" pill, and fully disabled under `prefers-reduced-motion`. Vanilla JS, no
-> animation libraries; spring easing toward targets, velocity damping ~0.86, DPR capped at 2.
+> animation libraries; spring easing toward targets, velocity damping ~0.87, DPR capped at 2.

--- a/demos/intro/README.md
+++ b/demos/intro/README.md
@@ -2,12 +2,16 @@
 
 > 这是 Joye 个人博客首页入场动画的完整自然语言描述，作为后续复用 / 再生成 / 写作的素材。
 >
-> - 已上线版本对应组件：[`src/components/intro/IntroOverlay.astro`](../../src/components/intro/IntroOverlay.astro)，接入于首页 `src/pages/index.astro` 与 `src/pages/en/index.astro`。
-> - 本目录另有三个独立全屏 demo，是当时探索的三个方向，最终选用 **constellation**：
->   - [`constellation.html`](./constellation.html) —— 粒子聚合（**已选用**）
->   - [`terminal-boot.html`](./terminal-boot.html) —— 终端开机 `joye.init()`
->   - [`kinetic-type.html`](./kinetic-type.html) —— 动态排版 Kinetic Type
+> - 对应组件：[`src/components/intro/IntroOverlay.astro`](../../src/components/intro/IntroOverlay.astro)，接入于首页 `src/pages/index.astro` 与 `src/pages/en/index.astro`。
+> - 本目录另有三个独立全屏 demo（探索期的三个方向）：
+>   - [`constellation.html`](./constellation.html) —— 动画一 · 粒子聚合
+>   - [`terminal-boot.html`](./terminal-boot.html) —— 动画二 · 终端开机 `joye.init()`
+>   - [`kinetic-type.html`](./kinetic-type.html) —— 动画三 · 动态排版 Kinetic Type
 >   - [`index.html`](./index.html) —— 三方案对比画廊
+>
+> **当前状态（评审中）**：三个方向都已集成为组件里的「变体」，由左下角的 **Tweak 切换面板**（动画一 / 二 / 三 + replay）实时切换，方便对比。默认当前播放 **动画二 · 终端**。Tweak 面板是评审辅助工具，定稿前会下掉或加开关。
+>
+> 下方的「逐拍 / 视觉 / 实现」详述以 **动画一 · 粒子聚合** 为主线；动画二（终端开机）、动画三（动态排版）的描述见各自 demo 文件顶部与组件源码。
 
 ---
 

--- a/demos/intro/README.md
+++ b/demos/intro/README.md
@@ -18,12 +18,12 @@
 
 ## 一句话
 
-首页首次打开时，一层很淡的 Agent / 内容关键词（`context`、`planner`、`tools`、`memory`、`RAG`、`OpenHarness` 等）先浮在背景里，像站点正在读取上下文。随后成百上千颗钢蓝 / 青色粒子分批、放慢地从屏幕四周汇入，在中央拼出名字 **「JOYE」**。成形后动画不急着退场，而是停在一个可互动状态：用户可以移动鼠标拨动粒子，准备好后点击 **「进入 ~/joye →」**，粒子向上自然消散并整体淡出，露出底下真实的首页。
+首页首次打开时，画面不是随机展示关键词，而是像一个 Agent 正在执行“生成 joye.dev/home”的任务：`agent.runtime()` 启动 loop，`mcp.filesystem()` 加载博客和项目，`mcp.github()` 读取公开作品，`memory.search()` 找回设计 / 前端经验，`examples.unitize()` 生成内容碎片，最后 `merge_context()` 把这些碎片合并成中央的 **「JOYE」**。成形后动画停在可互动状态：用户可以移动鼠标拨动粒子，准备好后点击 **「进入 ~/joye →」**，粒子向上消散并淡出，露出底下真实首页。
 
 ## 设计意图
 
 - 给「内容已经很好、但缺视觉冲击」的博客补一记开场重拳，让路人第一眼就被抓住。
-- 借开场展示前端功底，同时把视觉语义绑定到 Joye 平时做的事：Agent、上下文、工具、记忆、评估、内容写作，而不是一个可替换名字的通用粒子特效。
+- 借开场展示前端功底，同时把视觉语义绑定到 Joye 平时做的事：Agent Runtime、Tool / MCP、记忆检索、内容写作和例子生成，而不是一个可替换名字的通用粒子特效。
 - 技术上仍是 text→particle 采样、Canvas 粒子物理、星座连线、鼠标交互，全部手写、零动画库。
 - 不喧宾夺主：成形后把节奏交给用户，既可停留体验，也可随时进入 / 跳过；每次会话只播一次，并且**不另做 hero**，而是淡出露出真实首页 —— 过渡自然、零信息重复。
 
@@ -33,10 +33,11 @@
 
 | 时间 | 阶段 | 画面 |
 | --- | --- | --- |
-| 0.0 – 1.2s | **上下文浮现** | 屏幕周围出现很淡的 Agent / 内容关键词，作为“读入上下文”的氛围层。 |
-| 0.2 – 3.15s | **分批汇聚** | 粒子从屏幕外一圈以更慢的弹簧式缓动分批飞向各自目标点，边飞边连出若隐若现的星座连线；中央一团柔和的主色辉光。 |
-| 3.15 – 4.05s | **成形 / 停顿** | 粒子收束成清晰的点阵「JOYE」，做轻微呼吸式明暗闪烁；此时鼠标移动可把附近粒子推开，离开后回流复位。 |
-| 4.05s 起 | **停留 / 进入** | 「进入 ~/joye →」按钮浮现，并出现一行很淡的 trace 彩蛋：`context loaded · tools ready · welcome back`。点击按钮后粒子向上漂散约 1.35s，再让整层 overlay 在 0.9s 内淡出；淡出结束后从 DOM 移除，真实首页完全显现。 |
+| 0.0 – 0.7s | **接收任务** | 顶部出现 `task: compose joye.dev/home`，先给出明确指令。 |
+| 0.7 – 1.55s | **调用工具** | `agent.runtime()`、`mcp.filesystem()`、`mcp.github()`、`memory.search()` 等工具面板依次出现，并用细线连接到中心。 |
+| 1.55 – 2.55s | **生成碎片** | 每个 tool 面板输出小的内容 shard，例如 `posts`、`projects`、`OpenHarness`、`design taste`、`UI case`。 |
+| 2.95 – 4.35s | **合并成形** | `merge: context shards → JOYE` 出现，粒子从各个工具位置汇入中央，拼出点阵「JOYE」。 |
+| 4.35s 起 | **停留 / 进入** | 「进入 ~/joye →」按钮浮现，并出现 trace 彩蛋：`agent loop complete · context merged`。点击后粒子向上漂散约 0.85s，再让整层 overlay 在 0.9s 内淡出。 |
 
 主动点击时通常约 **4–5s** 后即可进站；如果用户停留观赏，按钮出现约 **12s** 后会自动进入，避免挡住首页。任意时刻点击右下角「跳过 →」按钮，立即淡出进站。
 
@@ -53,11 +54,11 @@
 ## 技术实现（手写，无第三方动画库）
 
 - **text→particle 采样**：离屏 canvas 用 Satoshi 700 画出加宽字距的「JOYE」，逐像素扫描（步距 `7×DPR`），`alpha > 128` 的像素记为一个目标点；约 1500–2000 个点（随视口与 DPR 变化）。
-- **语义背景层**：DOM token 层呈现 `context / planner / tools / memory / eval / RAG / OpenHarness / frontend / design` 等关键词；汇聚中逐渐变淡，像被吸收进 JOYE。
+- **Agent run 层**：DOM 层呈现一个短任务链：`agent.runtime()`、`mcp.filesystem()`、`mcp.github()`、`memory.search()`、`examples.unitize()`、`merge_context()`；每个工具输出 1–2 个 shard，随后合并到 JOYE。
 - **物理**：每颗粒子向目标点做弹簧吸引（汇聚 `ease≈0.045`，并按粒子延迟分批启动；停顿 `ease≈0.11`），速度阻尼 `0.87`；消散阶段改为向上漂移 + 轻微外扩，阻尼 `0.91`。
 - **鼠标交互**：半径 `110×DPR` 内的粒子被反向推开，力随距离衰减。
 - **星座连线**：仅在成形阶段，给距离 `< 26×DPR` 的相邻粒子之间画极低透明度连线。
-- **揭幕**：点击「进入 ~/joye →」后先切到 `scatter`，粒子向上消散约 1.35s，再给 overlay 加 `.intro-done`（`opacity → 0`，0.9s）；因 overlay 背景与站点同色，淡出是「溶解」而非「换页」。
+- **揭幕**：点击「进入 ~/joye →」后先切到 `scatter`，粒子向上消散约 0.85s，再给 overlay 加 `.intro-done`（`opacity → 0`，0.9s）；因 overlay 背景与站点同色，淡出是「溶解」而非「换页」。
 - **性能**：`DPR` 上限 2；动画结束即 `cancelAnimationFrame` 并移除节点；只在首页、每会话一次。
 
 ## 交互与无障碍规则
@@ -72,7 +73,7 @@
 
 | 想改什么 | 调哪里 |
 | --- | --- |
-| 节奏快慢 | 上下文 1.2s / 汇聚 3.15s / 按钮 4.05s 出现 / 点击后上浮消散 1.35s / 淡出 0.9s |
+| 节奏快慢 | 任务 0.12s / 工具 0.72s / shards 1.55s / merge 2.95s / 按钮 4.35s 出现 / 点击后上浮消散 0.85s / 淡出 0.9s |
 | 粒子密度 | 采样步距（默认 `7×DPR`，越小越密） |
 | 字号 / 字距 | `sampleText` 里的 `size` 与 `tracking`（0.18） |
 | 粒子大小 | `r`（0.7–1.6 × DPR） |
@@ -82,19 +83,18 @@
 
 ## 复用 / 再生成提示词（English — 喂给 AI 用）
 
-> A full-screen Canvas-2D intro overlay for a personal site's home page. First, a very subtle layer
-> of agent/work tokens appears around the screen — `context`, `planner`, `tools`, `memory`, `eval`,
-> `RAG`, `OpenHarness`, `frontend`, `design` — like the site is loading context. Then several
-> hundred small particles fly in slowly from beyond the screen edges in staggered waves and spring
-> toward target positions that spell the word **"JOYE"** in a bold sans-serif (targets sampled from
-> offscreen-canvas text on a ~7px grid). While forming, faint constellation lines connect nearby
-> particles and a soft radial glow sits behind. Particles then hold as an interactive constellation
-> with a gentle twinkle and are repelled by the cursor within ~110px. A small glassy monospace
-> "enter ~/joye →" button appears below the word, with a faint trace line: `context loaded · tools
-> ready · welcome back`. When clicked, particles drift upward and fade for ~1.35s while the whole
-> overlay fades out over 0.9s and is removed, revealing the real page underneath — the overlay
-> background matches the site background so it *dissolves* rather than cuts. Include a low-key skip
-> button and a long fallback auto-enter timeout so the overlay never blocks the page. Theme-aware: cyan particles + glow on dark; darker, more-saturated
+> A full-screen Canvas-2D intro overlay for a personal site's home page. It plays like a tiny agent
+> run, not a decorative keyword cloud: `task: compose joye.dev/home` appears first, then tool panels
+> for `agent.runtime()`, `mcp.filesystem()`, `mcp.github()`, `memory.search()`,
+> `examples.unitize()`, and `merge_context()` invoke in sequence. Each tool emits 1-2 small content
+> shards (`posts`, `projects`, `OpenHarness`, `design taste`, `UI case`), and particles originate
+> from those tool positions before springing toward target points that spell **"JOYE"** in a bold
+> sans-serif (targets sampled from offscreen-canvas text on a ~7px grid). Faint curves connect tool
+> nodes to the center, nearby particles form subtle constellation links, and the final trace reads
+> `agent loop complete · context merged`. A small glassy monospace "enter ~/joye →" button appears
+> below the word. When clicked, particles drift upward and fade for ~0.85s while the whole overlay
+> fades out over 0.9s and is removed, revealing the real page underneath — the overlay background
+> matches the site background so it *dissolves* rather than cuts. Include a low-key skip button and a long fallback auto-enter timeout so the overlay never blocks the page. Theme-aware: cyan particles + glow on dark; darker, more-saturated
 > steel-blue on near-white light mode (colours read from CSS custom properties `--primary` /
 > `--background`). Plays **once per session** (sessionStorage), exits through the enter button or a
 > small monospace "skip" pill, and fully disabled under `prefers-reduced-motion`. Vanilla JS, no

--- a/demos/intro/agent-diffusion.html
+++ b/demos/intro/agent-diffusion.html
@@ -151,16 +151,16 @@ function frame(ts){
     const ax=p.tx+p.ox*noiseK, ay=p.ty+p.oy*noiseK;   // anchor walks noise → target as d grows
     p.x+=(ax-p.x)*(0.18+pulse*0.5); p.y+=(ay-p.y)*(0.18+pulse*0.5);  // track it; pulse tightens each step
     // turbulent shimmer while noisy (a flow field, rendered as displacement) = the agent "computing"; →0 when resolved
-    const turb=noiseK*34*DPR;
-    let rx=p.x+Math.sin(p.y*0.012+el*1.7+p.seed*6.28)*turb;
-    let ry=p.y+Math.cos(p.x*0.012-el*1.4+p.seed*4)*turb;
-    // hover lens — magnify + brighten the patch under the cursor (放大 + 光亮)
+    // hover — particles disperse (扩散) away from the cursor + enlarge + light up; spring back when it leaves
     let hb=0;
-    if(d>0.5){const mdx=rx-mouse.x,mdy=ry-mouse.y,m2=mdx*mdx+mdy*mdy,RR=(135*DPR)**2;
-      if(m2<RR){ hb=1-m2/RR; const mag=hb*0.6; rx+=mdx*mag; ry+=mdy*mag; }}  // push outward from cursor = zoom
-    const tw=0.55+Math.sin(p.tw=(p.tw||0)+0.05)*0.2;
-    const a=(0.30+d*0.6)*tw*(1+pulse*1.1)*(1-dim*0.72)*(1+hb*1.7);  // recede on reveal; glow under hover
-    const s=p.r*(7.5-d*4.6)*(1+pulse*0.5+hb*1.25);                  // dots enlarge under the lens
+    if(d>0.5){const mdx=p.x-mouse.x,mdy=p.y-mouse.y,m2=mdx*mdx+mdy*mdy,RR=(118*DPR)**2;
+      if(m2<RR){ hb=1-m2/RR; const dd=Math.sqrt(m2)||1, f=hb*26*DPR; p.x+=mdx/dd*f; p.y+=mdy/dd*f; }}
+    const turb=noiseK*34*DPR;
+    const rx=p.x+Math.sin(p.y*0.012+el*1.7+p.seed*6.28)*turb;
+    const ry=p.y+Math.cos(p.x*0.012-el*1.4+p.seed*4)*turb;
+    const tw=0.55+Math.sin(p.tw=(p.tw||0)+0.04)*0.2*(1-dim*0.92);   // calm the flicker as the avatar emerges → steady
+    const a=(0.30+d*0.6)*tw*(1+pulse*1.1)*(1-dim*0.72)*(1+hb*1.6);  // recede on reveal; glow under hover
+    const s=p.r*(7.5-d*4.6)*(1+pulse*0.5+hb*1.0);                   // dots enlarge under hover
     ctx.globalAlpha=Math.min(1,a);
     ctx.drawImage(sprite,rx-s/2,ry-s/2,s,s);
   }

--- a/demos/intro/agent-diffusion.html
+++ b/demos/intro/agent-diffusion.html
@@ -152,14 +152,15 @@ function frame(ts){
     p.x+=(ax-p.x)*(0.18+pulse*0.5); p.y+=(ay-p.y)*(0.18+pulse*0.5);  // track it; pulse tightens each step
     // turbulent shimmer while noisy (a flow field, rendered as displacement) = the agent "computing"; →0 when resolved
     const turb=noiseK*34*DPR;
-    const rx=p.x+Math.sin(p.y*0.012+el*1.7+p.seed*6.28)*turb;
-    const ry=p.y+Math.cos(p.x*0.012-el*1.4+p.seed*4)*turb;
-    // hover spotlight — only the patch under the cursor lights up
+    let rx=p.x+Math.sin(p.y*0.012+el*1.7+p.seed*6.28)*turb;
+    let ry=p.y+Math.cos(p.x*0.012-el*1.4+p.seed*4)*turb;
+    // hover lens — magnify + brighten the patch under the cursor (放大 + 光亮)
     let hb=0;
-    if(d>0.5){const mdx=rx-mouse.x,mdy=ry-mouse.y,m2=mdx*mdx+mdy*mdy,RR=(120*DPR)**2; if(m2<RR) hb=1-m2/RR;}
+    if(d>0.5){const mdx=rx-mouse.x,mdy=ry-mouse.y,m2=mdx*mdx+mdy*mdy,RR=(135*DPR)**2;
+      if(m2<RR){ hb=1-m2/RR; const mag=hb*0.6; rx+=mdx*mag; ry+=mdy*mag; }}  // push outward from cursor = zoom
     const tw=0.55+Math.sin(p.tw=(p.tw||0)+0.05)*0.2;
-    const a=(0.30+d*0.6)*tw*(1+pulse*1.1)*(1-dim*0.72)*(1+hb*1.9);  // recede on reveal; glow under hover
-    const s=p.r*(7.5-d*4.6)*(1+pulse*0.5+hb*0.7);
+    const a=(0.30+d*0.6)*tw*(1+pulse*1.1)*(1-dim*0.72)*(1+hb*1.7);  // recede on reveal; glow under hover
+    const s=p.r*(7.5-d*4.6)*(1+pulse*0.5+hb*1.25);                  // dots enlarge under the lens
     ctx.globalAlpha=Math.min(1,a);
     ctx.drawImage(sprite,rx-s/2,ry-s/2,s,s);
   }

--- a/demos/intro/agent-diffusion.html
+++ b/demos/intro/agent-diffusion.html
@@ -19,11 +19,16 @@
   .hud{position:fixed;left:50%;top:8.5%;transform:translateX(-50%);text-align:center;z-index:4;
     font-family:var(--mono);opacity:0;transition:opacity .9s ease;white-space:nowrap}
   .hud.show{opacity:1}
-  .hud .lab{font-size:clamp(10px,1.15vw,12.5px);letter-spacing:.26em;color:rgba(125,211,252,.5);text-transform:lowercase}
-  .hud .bar{margin-top:10px;display:flex;gap:6px;justify-content:center;align-items:center}
-  .hud .pip{width:22px;height:3px;border-radius:2px;background:rgba(125,211,252,.16);transition:background .3s ease,box-shadow .3s ease}
-  .hud .pip.on{background:var(--cyan);box-shadow:0 0 10px rgba(125,211,252,.8)}
-  .hud .cnt{margin-top:8px;font-size:10px;letter-spacing:.18em;color:rgba(154,166,178,.6)}
+  .hud .pipe{display:flex;align-items:center;justify-content:center}
+  .hud .stage{display:flex;align-items:center;gap:7px;opacity:.36;transition:opacity .45s ease}
+  .hud .stage.on{opacity:1}
+  .hud .stage.done{opacity:.64}
+  .hud .stage i{width:7px;height:7px;border-radius:50%;background:rgba(125,211,252,.28);transition:.45s ease}
+  .hud .stage.on i{background:var(--cyan);box-shadow:0 0 12px rgba(125,211,252,.95)}
+  .hud .stage.done i{background:rgba(125,211,252,.7)}
+  .hud .stage span{font-size:11px;letter-spacing:.2em;color:var(--cyan)}
+  .hud .seg{width:44px;height:1px;margin:0 12px;background:rgba(125,211,252,.16);position:relative}
+  .hud .seg b{position:absolute;inset:0 auto 0 0;width:0;background:var(--cyan);box-shadow:0 0 8px rgba(125,211,252,.7)}
 
   .hero{position:fixed;inset:0;display:grid;place-items:center;opacity:0;pointer-events:none}
   .hero.show{opacity:1;pointer-events:auto;transition:opacity 1s ease}
@@ -50,7 +55,13 @@
 <body>
   <canvas id="c"></canvas>
   <div class="hud" id="hud">
-    <div class="bar" id="bar"></div>
+    <div class="pipe">
+      <div class="stage"><i></i><span>sample</span></div>
+      <div class="seg"><b></b></div>
+      <div class="stage"><i></i><span>refine</span></div>
+      <div class="seg"><b></b></div>
+      <div class="stage"><i></i><span>decode</span></div>
+    </div>
   </div>
 
   <div class="hero" id="hero">
@@ -68,7 +79,7 @@
 
 <script>
 const cv=document.getElementById('c'),ctx=cv.getContext('2d');
-const hud=document.getElementById('hud'),barEl=document.getElementById('bar'),hero=document.getElementById('hero');
+const hud=document.getElementById('hud'),hero=document.getElementById('hero');
 const reduce=matchMedia('(prefers-reduced-motion:reduce)').matches;
 let W,H,DPR,raf,t0=0,parts=[],pulse=0,mouse={x:-1e9,y:-1e9},d=0,dTarget=0,stepShown=-1,doneAt=0,heroShown=false;
 
@@ -125,9 +136,12 @@ function frame(ts){
   let step=-1;
   for(let i=0;i<STEPS.length;i++) if(el>=STEPS[i].t){ dTarget=STEPS[i].d; step=i; }
   d+=(dTarget-d)*0.13;
-  if(step!==stepShown){ stepShown=step; renderHud(step); if(step>=0) pulse=1; }
+  if(step!==stepShown){ stepShown=step; if(step>=0) pulse=1; }
   if(d>0.985 && !doneAt && el>STEPS[STEPS.length-1].t+0.5){ doneAt=ts; }
   if(doneAt && ts-doneAt>800 && !heroShown){ heroShown=true; hero.classList.add('show'); }
+  const dim = doneAt ? Math.min(1,(ts-doneAt)/900) : 0;   // particles recede as the avatar emerges
+  updateStages();
+  if(doneAt) hud.style.opacity = String(1-dim);            // fade the stage pipeline out with the reveal
 
   const noiseK=Math.pow(1-d,2);          // how much noise remains
   pulse*=0.86;                            // per-step refine surge decays
@@ -136,15 +150,16 @@ function frame(ts){
   for(const p of parts){
     const ax=p.tx+p.ox*noiseK, ay=p.ty+p.oy*noiseK;   // anchor walks noise → target as d grows
     p.x+=(ax-p.x)*(0.18+pulse*0.5); p.y+=(ay-p.y)*(0.18+pulse*0.5);  // track it; pulse tightens each step
-    if(d>0.55){const mdx=p.x-mouse.x,mdy=p.y-mouse.y,m2=mdx*mdx+mdy*mdy,RR=(105*DPR)**2;
-      if(m2<RR){const f=(1-m2/RR)*24*DPR,dd=Math.sqrt(m2)||1;p.x+=mdx/dd*f;p.y+=mdy/dd*f;}}
     // turbulent shimmer while noisy (a flow field, rendered as displacement) = the agent "computing"; →0 when resolved
     const turb=noiseK*34*DPR;
     const rx=p.x+Math.sin(p.y*0.012+el*1.7+p.seed*6.28)*turb;
     const ry=p.y+Math.cos(p.x*0.012-el*1.4+p.seed*4)*turb;
+    // hover spotlight — only the patch under the cursor lights up
+    let hb=0;
+    if(d>0.5){const mdx=rx-mouse.x,mdy=ry-mouse.y,m2=mdx*mdx+mdy*mdy,RR=(120*DPR)**2; if(m2<RR) hb=1-m2/RR;}
     const tw=0.55+Math.sin(p.tw=(p.tw||0)+0.05)*0.2;
-    const a=(0.30+d*0.6)*tw*(1+pulse*1.1);            // brightness surges on each refine step
-    const s=p.r*(7.5-d*4.6)*(1+pulse*0.5);            // soft when noisy → tight dot; pops on each step
+    const a=(0.30+d*0.6)*tw*(1+pulse*1.1)*(1-dim*0.72)*(1+hb*1.9);  // recede on reveal; glow under hover
+    const s=p.r*(7.5-d*4.6)*(1+pulse*0.5+hb*0.7);
     ctx.globalAlpha=Math.min(1,a);
     ctx.drawImage(sprite,rx-s/2,ry-s/2,s,s);
   }
@@ -163,16 +178,22 @@ function frame(ts){
   raf=requestAnimationFrame(frame);
 }
 
-function renderHud(step){
-  barEl.innerHTML='';
-  for(let i=0;i<STEPS.length;i++){const pip=document.createElement('span');pip.className='pip'+(i<=step?' on':'');barEl.appendChild(pip);}
+// 3 agent stages mapped onto the denoise progress: sample → refine → decode
+let STAGE_EL=null, SEG_EL=null;
+function updateStages(){
+  if(!STAGE_EL){ STAGE_EL=hud.querySelectorAll('.stage'); SEG_EL=hud.querySelectorAll('.seg b'); }
+  if(!STAGE_EL.length) return;
+  const cur = d<0.30 ? 0 : d<0.82 ? 1 : 2;
+  for(let i=0;i<STAGE_EL.length;i++){ STAGE_EL[i].classList.toggle('on',i===cur); STAGE_EL[i].classList.toggle('done',i<cur); }
+  if(SEG_EL[0]) SEG_EL[0].style.width=(d<0.30 ? d/0.30 : 1)*100+'%';
+  if(SEG_EL[1]) SEG_EL[1].style.width=(d<0.30 ? 0 : d<0.82 ? (d-0.30)/0.52 : 1)*100+'%';
 }
 
 function start(){
   cancelAnimationFrame(raf);resize();build();
   if(parts.length===0){setTimeout(start,120);return;}
   d=0;dTarget=0;stepShown=-2;t0=0;doneAt=0;heroShown=false;pulse=0;
-  ctx.clearRect(0,0,W,H);hud.classList.remove('show');hero.classList.remove('show');
+  ctx.clearRect(0,0,W,H);hud.classList.remove('show');hud.style.opacity='';hero.classList.remove('show');
   if(reduce){hero.classList.add('show');return;}
   raf=requestAnimationFrame(frame);
 }

--- a/demos/intro/agent-diffusion.html
+++ b/demos/intro/agent-diffusion.html
@@ -50,9 +50,7 @@
 <body>
   <canvas id="c"></canvas>
   <div class="hud" id="hud">
-    <div class="lab" id="lab">joye-agent · sampling from noise</div>
     <div class="bar" id="bar"></div>
-    <div class="cnt" id="cnt"></div>
   </div>
 
   <div class="hero" id="hero">
@@ -70,9 +68,9 @@
 
 <script>
 const cv=document.getElementById('c'),ctx=cv.getContext('2d');
-const hud=document.getElementById('hud'),labEl=document.getElementById('lab'),barEl=document.getElementById('bar'),cntEl=document.getElementById('cnt'),hero=document.getElementById('hero');
+const hud=document.getElementById('hud'),barEl=document.getElementById('bar'),hero=document.getElementById('hero');
 const reduce=matchMedia('(prefers-reduced-motion:reduce)').matches;
-let W,H,DPR,raf,t0=0,parts=[],mouse={x:-1e9,y:-1e9},d=0,dTarget=0,stepShown=-1,doneAt=0,heroShown=false;
+let W,H,DPR,raf,t0=0,parts=[],rings=[],mouse={x:-1e9,y:-1e9},d=0,dTarget=0,stepShown=-1,doneAt=0,heroShown=false;
 
 // soft glow sprite
 const sprite=document.createElement('canvas');sprite.width=sprite.height=64;
@@ -127,12 +125,22 @@ function frame(ts){
   let step=-1;
   for(let i=0;i<STEPS.length;i++) if(el>=STEPS[i].t){ dTarget=STEPS[i].d; step=i; }
   d+=(dTarget-d)*0.13;
-  if(step!==stepShown){ stepShown=step; renderHud(step); }
-  if(d>0.985 && !doneAt && el>STEPS[STEPS.length-1].t+0.5){ doneAt=ts; labEl.textContent='joye · sampled'; }
+  if(step!==stepShown){ stepShown=step; renderHud(step); if(step>=0) rings.push({born:ts}); }
+  if(d>0.985 && !doneAt && el>STEPS[STEPS.length-1].t+0.5){ doneAt=ts; }
   if(doneAt && ts-doneAt>800 && !heroShown){ heroShown=true; hero.classList.add('show'); }
 
   const noiseK=Math.pow(1-d,2);          // how much noise remains
   ctx.globalCompositeOperation='lighter';
+
+  // refine pulse — a wavefront ripples out on each denoise step (process, shown not told)
+  const ccx=W/2, ccy=H*0.46;
+  for(const ring of rings){
+    const age=(ts-ring.born)/1000; if(age>1.25) continue;
+    const rr=age*Math.max(W,H)*0.4, al=(1-age/1.25)*0.26;
+    ctx.strokeStyle=`rgba(125,211,252,${al})`; ctx.lineWidth=DPR*1.1;
+    ctx.beginPath(); ctx.arc(ccx,ccy,rr,0,7); ctx.stroke();
+  }
+
   for(const p of parts){
     // anchor walks from noise-home toward the JOYE target as d grows
     const ax=p.tx+p.ox*noiseK, ay=p.ty+p.oy*noiseK;
@@ -157,15 +165,12 @@ function frame(ts){
 function renderHud(step){
   barEl.innerHTML='';
   for(let i=0;i<STEPS.length;i++){const pip=document.createElement('span');pip.className='pip'+(i<=step?' on':'');barEl.appendChild(pip);}
-  if(step<0){ labEl.textContent='joye-agent · sampling from noise'; cntEl.textContent=''; }
-  else if(step<STEPS.length-1){ labEl.textContent='denoising'; cntEl.textContent=`step ${step+1} / ${STEPS.length}`; }
-  else { cntEl.textContent=`step ${STEPS.length} / ${STEPS.length}`; }
 }
 
 function start(){
   cancelAnimationFrame(raf);resize();build();
   if(parts.length===0){setTimeout(start,120);return;}
-  d=0;dTarget=0;stepShown=-2;t0=0;doneAt=0;heroShown=false;
+  d=0;dTarget=0;stepShown=-2;t0=0;doneAt=0;heroShown=false;rings=[];
   ctx.clearRect(0,0,W,H);hud.classList.remove('show');hero.classList.remove('show');
   if(reduce){hero.classList.add('show');return;}
   raf=requestAnimationFrame(frame);

--- a/demos/intro/agent-diffusion.html
+++ b/demos/intro/agent-diffusion.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Intro · agent denoises Joye</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --fg:#faf9f8;--muted:#9aa6b2;--cyan:#7dd3fc;--steel:#659eb9;--ok:#41d18a;
+    --mono:'JetBrains Mono',ui-monospace,Menlo,monospace;--sans:'Inter','Satoshi',system-ui,sans-serif;
+  }
+  *{box-sizing:border-box} html,body{height:100%;margin:0}
+  body{background:#07090d;color:var(--fg);font-family:var(--sans);overflow:hidden}
+  canvas{position:fixed;inset:0;display:block}
+
+  .hud{position:fixed;left:50%;top:8.5%;transform:translateX(-50%);text-align:center;z-index:4;
+    font-family:var(--mono);opacity:0;transition:opacity .9s ease;white-space:nowrap}
+  .hud.show{opacity:1}
+  .hud .lab{font-size:clamp(10px,1.15vw,12.5px);letter-spacing:.26em;color:rgba(125,211,252,.5);text-transform:lowercase}
+  .hud .bar{margin-top:10px;display:flex;gap:6px;justify-content:center;align-items:center}
+  .hud .pip{width:22px;height:3px;border-radius:2px;background:rgba(125,211,252,.16);transition:background .3s ease,box-shadow .3s ease}
+  .hud .pip.on{background:var(--cyan);box-shadow:0 0 10px rgba(125,211,252,.8)}
+  .hud .cnt{margin-top:8px;font-size:10px;letter-spacing:.18em;color:rgba(154,166,178,.6)}
+
+  .hero{position:fixed;inset:0;display:grid;place-items:center;opacity:0;pointer-events:none}
+  .hero.show{opacity:1;pointer-events:auto;transition:opacity 1s ease}
+  .card{display:flex;flex-direction:column;align-items:center;gap:18px;text-align:center}
+  .avatar{width:112px;height:112px;border-radius:50%;padding:4px;border:1px solid rgba(255,255,255,.14);object-fit:cover;background:conic-gradient(from 210deg,var(--steel),var(--cyan),var(--steel));box-shadow:0 0 50px rgba(125,211,252,.3)}
+  .name{font-weight:800;font-size:34px;letter-spacing:-.02em;margin:0}
+  .meta{color:var(--muted);font-family:var(--mono);font-size:13px;display:flex;gap:14px}
+  .ital{color:var(--cyan);font-style:italic;font-size:15px}
+  .pill{display:inline-flex;align-items:center;gap:9px;padding:9px 16px;border-radius:999px;border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.03);font-size:14px;color:var(--fg);text-decoration:none}
+  .ping{position:relative;width:9px;height:9px}.ping i{position:absolute;inset:0;border-radius:50%;background:var(--ok)}
+  .ping i:first-child{animation:ping 1.4s cubic-bezier(0,0,.2,1) infinite}@keyframes ping{75%,100%{transform:scale(2.4);opacity:0}}
+  .card>*{opacity:0;transform:translateY(14px)}
+  .hero.show .card>*{animation:up .7s cubic-bezier(.2,.7,.2,1) forwards}
+  .hero.show .card>*:nth-child(1){animation-delay:.05s}.hero.show .card>*:nth-child(2){animation-delay:.16s}
+  .hero.show .card>*:nth-child(3){animation-delay:.26s}.hero.show .card>*:nth-child(4){animation-delay:.36s}.hero.show .card>*:nth-child(5){animation-delay:.46s}
+  @keyframes up{to{opacity:1;transform:none}}
+
+  .ctl{position:fixed;bottom:18px;right:18px;display:flex;gap:10px;z-index:20;font-family:var(--mono);font-size:12px}
+  .ctl button{background:rgba(255,255,255,.04);color:var(--muted);border:1px solid rgba(255,255,255,.1);padding:7px 12px;border-radius:8px;cursor:pointer;transition:.2s}
+  .ctl button:hover{color:var(--fg);border-color:rgba(125,211,252,.4)}
+  .hint{position:fixed;bottom:20px;left:20px;font-family:var(--mono);font-size:12px;color:rgba(154,166,178,.45);z-index:20}
+</style>
+</head>
+<body>
+  <canvas id="c"></canvas>
+  <div class="hud" id="hud">
+    <div class="lab" id="lab">joye-agent · sampling from noise</div>
+    <div class="bar" id="bar"></div>
+    <div class="cnt" id="cnt"></div>
+  </div>
+
+  <div class="hero" id="hero">
+    <div class="card">
+      <img class="avatar" src="../../src/assets/avatar.png" alt="Joye" onerror="this.removeAttribute('src')" />
+      <h1 class="name">Joye</h1>
+      <div class="meta"><span>📍 Melbourne, Australia</span><span>· GitHub</span></div>
+      <div class="ital">“Stay hungry, stay foolish.”</div>
+      <a class="pill" href="javascript:void 0"><span class="ping"><i></i><i></i></span> Connect Me!</a>
+    </div>
+  </div>
+
+  <div class="hint">动画一（重做）· 一个 agent 把 Joye 从噪声里去噪生成</div>
+  <div class="ctl"><button id="skip">跳过 →</button><button id="replay">重播 ↻</button></div>
+
+<script>
+const cv=document.getElementById('c'),ctx=cv.getContext('2d');
+const hud=document.getElementById('hud'),labEl=document.getElementById('lab'),barEl=document.getElementById('bar'),cntEl=document.getElementById('cnt'),hero=document.getElementById('hero');
+const reduce=matchMedia('(prefers-reduced-motion:reduce)').matches;
+let W,H,DPR,raf,t0=0,parts=[],mouse={x:-1e9,y:-1e9},d=0,dTarget=0,stepShown=-1,doneAt=0,heroShown=false;
+
+// soft glow sprite
+const sprite=document.createElement('canvas');sprite.width=sprite.height=64;
+{const g=sprite.getContext('2d');const r=g.createRadialGradient(32,32,0,32,32,32);
+ r.addColorStop(0,'rgba(214,243,255,1)');r.addColorStop(.25,'rgba(138,214,255,.6)');r.addColorStop(.6,'rgba(110,190,240,.14)');r.addColorStop(1,'rgba(110,190,240,0)');
+ g.fillStyle=r;g.fillRect(0,0,64,64);}
+
+// denoise schedule: noise → ... → form. Each entry is a refinement step.
+const STEPS=[ {t:0.55,d:0.14}, {t:1.05,d:0.32}, {t:1.55,d:0.52}, {t:2.05,d:0.72}, {t:2.5,d:0.88}, {t:2.95,d:1.0} ];
+
+function vw(){return innerWidth||document.documentElement.clientWidth||1280}
+function vh(){return innerHeight||document.documentElement.clientHeight||800}
+function resize(){DPR=Math.min(devicePixelRatio||1,2);W=cv.width=Math.round(vw()*DPR);H=cv.height=Math.round(vh()*DPR);cv.style.width=vw()+'px';cv.style.height=vh()+'px';}
+addEventListener('mousemove',e=>{mouse.x=e.clientX*DPR;mouse.y=e.clientY*DPR});
+addEventListener('mouseleave',()=>{mouse.x=mouse.y=-1e9});
+
+function sampleJOYE(){
+  if(!W||!H)return[];
+  const off=document.createElement('canvas');off.width=W;off.height=H;
+  const o=off.getContext('2d');o.fillStyle='#fff';o.textBaseline='middle';o.textAlign='left';
+  const tracking=0.18;let size=Math.min(H*0.4,W*0.32);
+  const setFont=()=>o.font=`700 ${size}px Inter, system-ui, sans-serif`;setFont();
+  const adv=()=>{let w=0;for(const ch of 'JOYE')w+=o.measureText(ch).width+size*tracking;return w-size*tracking};
+  if(adv()>W*0.72){size*=W*0.72/adv();setFont();}
+  let x=(W-adv())/2;const y=H*0.46;
+  for(const ch of 'JOYE'){o.fillText(ch,x,y);x+=o.measureText(ch).width+size*tracking;}
+  const dd=o.getImageData(0,0,W,H).data;const gap=Math.max(5,Math.round(6.5*DPR));const pts=[];
+  for(let yy=0;yy<H;yy+=gap)for(let xx=0;xx<W;xx+=gap)if(dd[(yy*W+xx)*4+3]>140)pts.push({x:xx,y:yy});
+  return pts;
+}
+
+function build(){
+  const pts=sampleJOYE();
+  const R=Math.min(W,H)*0.62; // noise radius — the JOYE signal is buried this far out
+  parts=pts.map(p=>{
+    const ang=Math.random()*6.283, mag=Math.pow(Math.random(),0.6)*R;
+    return { tx:p.x,ty:p.y, ox:Math.cos(ang)*mag, oy:Math.sin(ang)*mag,
+      x:p.x,y:p.y, ph:Math.random()*6.28, fr:0.6+Math.random()*1.4,
+      r:(Math.random()*0.8+0.7)*DPR, seed:Math.random() };
+  });
+}
+
+function frame(ts){
+  if(!t0)t0=ts;const el=(ts-t0)/1000;
+
+  // trail-fade clear (motion + dark bg)
+  ctx.globalCompositeOperation='source-over';
+  ctx.fillStyle='rgba(7,9,13,0.32)';ctx.fillRect(0,0,W,H);
+  if(el>.1) hud.classList.add('show');
+
+  // advance the denoise steps (discrete iterations → real process)
+  let step=-1;
+  for(let i=0;i<STEPS.length;i++) if(el>=STEPS[i].t){ dTarget=STEPS[i].d; step=i; }
+  d+=(dTarget-d)*0.13;
+  if(step!==stepShown){ stepShown=step; renderHud(step); }
+  if(d>0.985 && !doneAt && el>STEPS[STEPS.length-1].t+0.5){ doneAt=ts; labEl.textContent='joye · sampled'; }
+  if(doneAt && ts-doneAt>800 && !heroShown){ heroShown=true; hero.classList.add('show'); }
+
+  const noiseK=Math.pow(1-d,2);          // how much noise remains
+  ctx.globalCompositeOperation='lighter';
+  for(const p of parts){
+    // anchor walks from noise-home toward the JOYE target as d grows
+    const ax=p.tx+p.ox*noiseK, ay=p.ty+p.oy*noiseK;
+    // shimmer: large while noisy, ~0 once denoised
+    const jit=(0.5+0.5*Math.sin(el*p.fr*3+p.ph))*noiseK*46*DPR;
+    let gx=ax+Math.cos(el*p.fr+p.seed*9)*jit, gy=ay+Math.sin(el*p.fr*1.1+p.seed*9)*jit;
+    // gentle spring so it reads as settling each step
+    p.x+=(gx-p.x)*0.5; p.y+=(gy-p.y)*0.5;
+    // mouse repel once mostly formed
+    if(d>0.6){const mdx=p.x-mouse.x,mdy=p.y-mouse.y,m2=mdx*mdx+mdy*mdy,RR=(105*DPR)**2;
+      if(m2<RR){const f=(1-m2/RR)*5,dd=Math.sqrt(m2)||1;p.x+=mdx/dd*f;p.y+=mdy/dd*f;}}
+    const tw=0.55+Math.sin(p.tw=(p.tw||0)+0.05)*0.2;
+    const a=(0.34+d*0.62)*tw;            // dim/noisy early, bright when resolved
+    const s=p.r*(7.5-d*4.6);             // big soft glow when noisy → tight crisp dot when resolved
+    ctx.globalAlpha=Math.min(1,a);
+    ctx.drawImage(sprite,p.x-s/2,p.y-s/2,s,s);
+  }
+  ctx.globalAlpha=1;ctx.globalCompositeOperation='source-over';
+  raf=requestAnimationFrame(frame);
+}
+
+function renderHud(step){
+  barEl.innerHTML='';
+  for(let i=0;i<STEPS.length;i++){const pip=document.createElement('span');pip.className='pip'+(i<=step?' on':'');barEl.appendChild(pip);}
+  if(step<0){ labEl.textContent='joye-agent · sampling from noise'; cntEl.textContent=''; }
+  else if(step<STEPS.length-1){ labEl.textContent='denoising'; cntEl.textContent=`step ${step+1} / ${STEPS.length}`; }
+  else { cntEl.textContent=`step ${STEPS.length} / ${STEPS.length}`; }
+}
+
+function start(){
+  cancelAnimationFrame(raf);resize();build();
+  if(parts.length===0){setTimeout(start,120);return;}
+  d=0;dTarget=0;stepShown=-2;t0=0;doneAt=0;heroShown=false;
+  ctx.clearRect(0,0,W,H);hud.classList.remove('show');hero.classList.remove('show');
+  if(reduce){hero.classList.add('show');return;}
+  raf=requestAnimationFrame(frame);
+}
+function boot(){if(document.fonts&&document.fonts.ready){Promise.race([document.fonts.ready,new Promise(r=>setTimeout(r,800))]).then(start);}else start();}
+function skip(){cancelAnimationFrame(raf);ctx.clearRect(0,0,W,H);hud.classList.remove('show');hero.classList.add('show');}
+
+document.getElementById('skip').onclick=skip;
+document.getElementById('replay').onclick=start;
+addEventListener('resize',()=>{if(!heroShown){resize();build();}});
+boot();
+</script>
+</body>
+</html>

--- a/demos/intro/agent-diffusion.html
+++ b/demos/intro/agent-diffusion.html
@@ -70,7 +70,7 @@
 const cv=document.getElementById('c'),ctx=cv.getContext('2d');
 const hud=document.getElementById('hud'),barEl=document.getElementById('bar'),hero=document.getElementById('hero');
 const reduce=matchMedia('(prefers-reduced-motion:reduce)').matches;
-let W,H,DPR,raf,t0=0,parts=[],rings=[],mouse={x:-1e9,y:-1e9},d=0,dTarget=0,stepShown=-1,doneAt=0,heroShown=false;
+let W,H,DPR,raf,t0=0,parts=[],pulse=0,mouse={x:-1e9,y:-1e9},d=0,dTarget=0,stepShown=-1,doneAt=0,heroShown=false;
 
 // soft glow sprite
 const sprite=document.createElement('canvas');sprite.width=sprite.height=64;
@@ -81,8 +81,8 @@ const sprite=document.createElement('canvas');sprite.width=sprite.height=64;
 // denoise schedule: noise → ... → form. Each entry is a refinement step.
 const STEPS=[ {t:0.55,d:0.14}, {t:1.05,d:0.32}, {t:1.55,d:0.52}, {t:2.05,d:0.72}, {t:2.5,d:0.88}, {t:2.95,d:1.0} ];
 
-function vw(){return innerWidth||document.documentElement.clientWidth||1280}
-function vh(){return innerHeight||document.documentElement.clientHeight||800}
+function vw(){var w=innerWidth||document.documentElement.clientWidth||0;return w>20?w:1280}
+function vh(){var h=innerHeight||document.documentElement.clientHeight||0;return h>20?h:800}
 function resize(){DPR=Math.min(devicePixelRatio||1,2);W=cv.width=Math.round(vw()*DPR);H=cv.height=Math.round(vh()*DPR);cv.style.width=vw()+'px';cv.style.height=vh()+'px';}
 addEventListener('mousemove',e=>{mouse.x=e.clientX*DPR;mouse.y=e.clientY*DPR});
 addEventListener('mouseleave',()=>{mouse.x=mouse.y=-1e9});
@@ -108,7 +108,7 @@ function build(){
   parts=pts.map(p=>{
     const ang=Math.random()*6.283, mag=Math.pow(Math.random(),0.6)*R;
     return { tx:p.x,ty:p.y, ox:Math.cos(ang)*mag, oy:Math.sin(ang)*mag,
-      x:p.x,y:p.y, ph:Math.random()*6.28, fr:0.6+Math.random()*1.4,
+      x:p.x+Math.cos(ang)*mag, y:p.y+Math.sin(ang)*mag, ph:Math.random()*6.28, fr:0.6+Math.random()*1.4,
       r:(Math.random()*0.8+0.7)*DPR, seed:Math.random() };
   });
 }
@@ -125,38 +125,39 @@ function frame(ts){
   let step=-1;
   for(let i=0;i<STEPS.length;i++) if(el>=STEPS[i].t){ dTarget=STEPS[i].d; step=i; }
   d+=(dTarget-d)*0.13;
-  if(step!==stepShown){ stepShown=step; renderHud(step); if(step>=0) rings.push({born:ts}); }
+  if(step!==stepShown){ stepShown=step; renderHud(step); if(step>=0) pulse=1; }
   if(d>0.985 && !doneAt && el>STEPS[STEPS.length-1].t+0.5){ doneAt=ts; }
   if(doneAt && ts-doneAt>800 && !heroShown){ heroShown=true; hero.classList.add('show'); }
 
   const noiseK=Math.pow(1-d,2);          // how much noise remains
+  pulse*=0.86;                            // per-step refine surge decays
   ctx.globalCompositeOperation='lighter';
 
-  // refine pulse — a wavefront ripples out on each denoise step (process, shown not told)
-  const ccx=W/2, ccy=H*0.46;
-  for(const ring of rings){
-    const age=(ts-ring.born)/1000; if(age>1.25) continue;
-    const rr=age*Math.max(W,H)*0.4, al=(1-age/1.25)*0.26;
-    ctx.strokeStyle=`rgba(125,211,252,${al})`; ctx.lineWidth=DPR*1.1;
-    ctx.beginPath(); ctx.arc(ccx,ccy,rr,0,7); ctx.stroke();
+  for(const p of parts){
+    const ax=p.tx+p.ox*noiseK, ay=p.ty+p.oy*noiseK;   // anchor walks noise → target as d grows
+    p.x+=(ax-p.x)*(0.18+pulse*0.5); p.y+=(ay-p.y)*(0.18+pulse*0.5);  // track it; pulse tightens each step
+    if(d>0.55){const mdx=p.x-mouse.x,mdy=p.y-mouse.y,m2=mdx*mdx+mdy*mdy,RR=(105*DPR)**2;
+      if(m2<RR){const f=(1-m2/RR)*24*DPR,dd=Math.sqrt(m2)||1;p.x+=mdx/dd*f;p.y+=mdy/dd*f;}}
+    // turbulent shimmer while noisy (a flow field, rendered as displacement) = the agent "computing"; →0 when resolved
+    const turb=noiseK*34*DPR;
+    const rx=p.x+Math.sin(p.y*0.012+el*1.7+p.seed*6.28)*turb;
+    const ry=p.y+Math.cos(p.x*0.012-el*1.4+p.seed*4)*turb;
+    const tw=0.55+Math.sin(p.tw=(p.tw||0)+0.05)*0.2;
+    const a=(0.30+d*0.6)*tw*(1+pulse*1.1);            // brightness surges on each refine step
+    const s=p.r*(7.5-d*4.6)*(1+pulse*0.5);            // soft when noisy → tight dot; pops on each step
+    ctx.globalAlpha=Math.min(1,a);
+    ctx.drawImage(sprite,rx-s/2,ry-s/2,s,s);
   }
 
-  for(const p of parts){
-    // anchor walks from noise-home toward the JOYE target as d grows
-    const ax=p.tx+p.ox*noiseK, ay=p.ty+p.oy*noiseK;
-    // shimmer: large while noisy, ~0 once denoised
-    const jit=(0.5+0.5*Math.sin(el*p.fr*3+p.ph))*noiseK*46*DPR;
-    let gx=ax+Math.cos(el*p.fr+p.seed*9)*jit, gy=ay+Math.sin(el*p.fr*1.1+p.seed*9)*jit;
-    // gentle spring so it reads as settling each step
-    p.x+=(gx-p.x)*0.5; p.y+=(gy-p.y)*0.5;
-    // mouse repel once mostly formed
-    if(d>0.6){const mdx=p.x-mouse.x,mdy=p.y-mouse.y,m2=mdx*mdx+mdy*mdy,RR=(105*DPR)**2;
-      if(m2<RR){const f=(1-m2/RR)*5,dd=Math.sqrt(m2)||1;p.x+=mdx/dd*f;p.y+=mdy/dd*f;}}
-    const tw=0.55+Math.sin(p.tw=(p.tw||0)+0.05)*0.2;
-    const a=(0.34+d*0.62)*tw;            // dim/noisy early, bright when resolved
-    const s=p.r*(7.5-d*4.6);             // big soft glow when noisy → tight crisp dot when resolved
-    ctx.globalAlpha=Math.min(1,a);
-    ctx.drawImage(sprite,p.x-s/2,p.y-s/2,s,s);
+  // structure mesh — faint links weave between neighbouring particles as JOYE resolves
+  if(d>0.5){
+    const R2=(16*DPR)**2;
+    ctx.strokeStyle=`rgba(125,211,252,${(d-0.5)*0.42})`; ctx.lineWidth=DPR*0.5;
+    ctx.beginPath();
+    for(let i=0;i<parts.length;i++){ const p=parts[i];
+      for(let j=i+1;j<=i+2 && j<parts.length;j++){ const q=parts[j];
+        const dx=p.x-q.x,dy=p.y-q.y; if(dx*dx+dy*dy<R2){ ctx.moveTo(p.x,p.y); ctx.lineTo(q.x,q.y); } } }
+    ctx.stroke();
   }
   ctx.globalAlpha=1;ctx.globalCompositeOperation='source-over';
   raf=requestAnimationFrame(frame);
@@ -170,7 +171,7 @@ function renderHud(step){
 function start(){
   cancelAnimationFrame(raf);resize();build();
   if(parts.length===0){setTimeout(start,120);return;}
-  d=0;dTarget=0;stepShown=-2;t0=0;doneAt=0;heroShown=false;rings=[];
+  d=0;dTarget=0;stepShown=-2;t0=0;doneAt=0;heroShown=false;pulse=0;
   ctx.clearRect(0,0,W,H);hud.classList.remove('show');hero.classList.remove('show');
   if(reduce){hero.classList.add('show');return;}
   raf=requestAnimationFrame(frame);

--- a/demos/intro/agent-story.html
+++ b/demos/intro/agent-story.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Intro · an agent produces Joye</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --fg:#faf9f8;--muted:#9aa6b2;--cyan:#7dd3fc;--steel:#659eb9;--ok:#41d18a;
+    --mono:'JetBrains Mono',ui-monospace,Menlo,monospace;
+    --sans:'Inter','Satoshi',system-ui,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%;margin:0}
+  body{background:#080b0f;color:var(--fg);font-family:var(--sans);overflow:hidden}
+  canvas{position:fixed;inset:0;display:block}
+
+  /* minimal story text — one line top, one line under the agent */
+  .task{position:fixed;left:50%;top:8.5%;transform:translateX(-50%);font-family:var(--mono);
+    font-size:clamp(10px,1.15vw,12.5px);letter-spacing:.26em;text-transform:lowercase;
+    color:rgba(125,211,252,.42);opacity:0;transition:opacity 1s ease;white-space:nowrap;z-index:4}
+  .task.show{opacity:1}
+  .verb{position:fixed;left:50%;top:calc(50% + 96px);transform:translate(-50%,6px);
+    font-family:var(--mono);font-size:12px;letter-spacing:.2em;color:rgba(250,249,248,.5);
+    opacity:0;transition:opacity .5s ease,transform .5s ease;white-space:nowrap;z-index:4}
+  .verb.show{opacity:1;transform:translate(-50%,0)}
+  .verb b{color:var(--cyan);font-weight:500}
+
+  /* hero */
+  .hero{position:fixed;inset:0;display:grid;place-items:center;opacity:0;pointer-events:none}
+  .hero.show{opacity:1;pointer-events:auto;transition:opacity 1s ease}
+  .card{display:flex;flex-direction:column;align-items:center;gap:18px;text-align:center}
+  .avatar{width:112px;height:112px;border-radius:50%;padding:4px;border:1px solid rgba(255,255,255,.14);
+    object-fit:cover;background:conic-gradient(from 210deg,var(--steel),var(--cyan),var(--steel));box-shadow:0 0 50px rgba(125,211,252,.3)}
+  .name{font-weight:800;font-size:34px;letter-spacing:-.02em;margin:0}
+  .meta{color:var(--muted);font-family:var(--mono);font-size:13px;display:flex;gap:14px}
+  .ital{color:var(--cyan);font-style:italic;font-size:15px}
+  .pill{display:inline-flex;align-items:center;gap:9px;padding:9px 16px;border-radius:999px;border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.03);font-size:14px;color:var(--fg);text-decoration:none}
+  .ping{position:relative;width:9px;height:9px}.ping i{position:absolute;inset:0;border-radius:50%;background:var(--ok)}
+  .ping i:first-child{animation:ping 1.4s cubic-bezier(0,0,.2,1) infinite}
+  @keyframes ping{75%,100%{transform:scale(2.4);opacity:0}}
+  .card>*{opacity:0;transform:translateY(14px)}
+  .hero.show .card>*{animation:up .7s cubic-bezier(.2,.7,.2,1) forwards}
+  .hero.show .card>*:nth-child(1){animation-delay:.05s}.hero.show .card>*:nth-child(2){animation-delay:.16s}
+  .hero.show .card>*:nth-child(3){animation-delay:.26s}.hero.show .card>*:nth-child(4){animation-delay:.36s}
+  .hero.show .card>*:nth-child(5){animation-delay:.46s}
+  @keyframes up{to{opacity:1;transform:none}}
+
+  .ctl{position:fixed;bottom:18px;right:18px;display:flex;gap:10px;z-index:20;font-family:var(--mono);font-size:12px}
+  .ctl button{background:rgba(255,255,255,.04);color:var(--muted);border:1px solid rgba(255,255,255,.1);padding:7px 12px;border-radius:8px;cursor:pointer;transition:.2s}
+  .ctl button:hover{color:var(--fg);border-color:rgba(125,211,252,.4)}
+  .hint{position:fixed;bottom:20px;left:20px;font-family:var(--mono);font-size:12px;color:rgba(154,166,178,.45);z-index:20}
+</style>
+</head>
+<body>
+  <canvas id="c"></canvas>
+  <div class="task" id="task">an agent is composing</div>
+  <div class="verb" id="verb"></div>
+
+  <div class="hero" id="hero">
+    <div class="card">
+      <img class="avatar" src="../../src/assets/avatar.png" alt="Joye" onerror="this.removeAttribute('src')" />
+      <h1 class="name">Joye</h1>
+      <div class="meta"><span>📍 Melbourne, Australia</span><span>· GitHub</span></div>
+      <div class="ital">“Stay hungry, stay foolish.”</div>
+      <a class="pill" href="javascript:void 0"><span class="ping"><i></i><i></i></span> Connect Me!</a>
+    </div>
+  </div>
+
+  <div class="hint">动画一（重做）· 一个 agent 生产出 Joye</div>
+  <div class="ctl"><button id="skip">跳过 →</button><button id="replay">重播 ↻</button></div>
+
+<script>
+const cv=document.getElementById('c'), ctx=cv.getContext('2d');
+const taskEl=document.getElementById('task'), verbEl=document.getElementById('verb'), hero=document.getElementById('hero');
+const reduce=matchMedia('(prefers-reduced-motion:reduce)').matches;
+let W,H,DPR,raf,t0=0,parts=[],rings=[],mouse={x:-1e9,y:-1e9},phase='wake',doneAt=0,heroShown=false;
+let cx,cy,nuke=0; // nucleus brightness
+
+// soft round glow sprite (cheap bloom)
+const sprite=document.createElement('canvas');sprite.width=sprite.height=64;
+{const g=sprite.getContext('2d');const rad=g.createRadialGradient(32,32,0,32,32,32);
+ rad.addColorStop(0,'rgba(212,242,255,1)');rad.addColorStop(.22,'rgba(140,216,255,.65)');
+ rad.addColorStop(.55,'rgba(110,190,240,.18)');rad.addColorStop(1,'rgba(110,190,240,0)');
+ g.fillStyle=rad;g.fillRect(0,0,64,64);}
+
+// three think→produce waves; a skill whispered per wave
+const WAVES=[ {t:0.85,skill:'frontend·design'}, {t:1.5,skill:'ai·agent'}, {t:2.15,skill:'compose'} ];
+
+function vw(){return innerWidth||document.documentElement.clientWidth||1280}
+function vh(){return innerHeight||document.documentElement.clientHeight||800}
+function resize(){DPR=Math.min(devicePixelRatio||1,2);W=cv.width=Math.round(vw()*DPR);H=cv.height=Math.round(vh()*DPR);cv.style.width=vw()+'px';cv.style.height=vh()+'px';cx=W/2;cy=H*0.46;}
+addEventListener('mousemove',e=>{mouse.x=e.clientX*DPR;mouse.y=e.clientY*DPR});
+addEventListener('mouseleave',()=>{mouse.x=mouse.y=-1e9});
+
+function sampleJOYE(){
+  if(!W||!H)return[];
+  const off=document.createElement('canvas');off.width=W;off.height=H;
+  const o=off.getContext('2d');o.fillStyle='#fff';o.textBaseline='middle';o.textAlign='left';
+  const tracking=0.18;let size=Math.min(H*0.4,W*0.32);
+  const setFont=()=>o.font=`700 ${size}px Inter, system-ui, sans-serif`;setFont();
+  const adv=()=>{let w=0;for(const ch of 'JOYE')w+=o.measureText(ch).width+size*tracking;return w-size*tracking};
+  if(adv()>W*0.72){size*=W*0.72/adv();setFont();}
+  let x=(W-adv())/2;const y=cy;
+  for(const ch of 'JOYE'){o.fillText(ch,x,y);x+=o.measureText(ch).width+size*tracking;}
+  const d=o.getImageData(0,0,W,H).data;const gap=Math.max(5,Math.round(6.5*DPR));const pts=[];
+  for(let yy=0;yy<H;yy+=gap)for(let xx=0;xx<W;xx+=gap)if(d[(yy*W+xx)*4+3]>140)pts.push({x:xx,y:yy});
+  return pts;
+}
+
+function build(){
+  const pts=sampleJOYE();
+  parts=pts.map(p=>({
+    tx:p.x,ty:p.y, x:cx,y:cy, vx:0,vy:0,
+    wave:(Math.random()*WAVES.length)|0, emitted:false,
+    r:(Math.random()*0.8+0.7)*DPR, tw:Math.random()*6.28, seed:Math.random()
+  }));
+  rings=[];
+}
+
+function emit(p){
+  const ang=Math.random()*6.283, sp=(Math.random()*2.4+1.2)*DPR;
+  p.x=cx+(Math.random()-.5)*10*DPR; p.y=cy+(Math.random()-.5)*10*DPR;
+  p.vx=Math.cos(ang)*sp; p.vy=Math.sin(ang)*sp; p.emitted=true;
+}
+
+function frame(ts){
+  if(!t0)t0=ts;const el=(ts-t0)/1000;
+
+  // trail-fade clear (motion streaks + keeps bg dark)
+  ctx.globalCompositeOperation='source-over';
+  ctx.fillStyle='rgba(8,11,15,0.34)';ctx.fillRect(0,0,W,H);
+
+  if(el>.15) taskEl.classList.add('show');
+
+  // fire waves
+  if(phase==='wake'||phase==='produce'){
+    for(let i=0;i<WAVES.length;i++){
+      if(el>=WAVES[i].t && !WAVES[i].fired){
+        WAVES[i].fired=true; phase='produce'; nuke=1;
+        rings.push({born:ts});
+        verbEl.innerHTML=`<b>${WAVES[i].skill}</b>`; verbEl.classList.add('show');
+        for(const p of parts) if(p.wave===i && !p.emitted) emit(p);
+      }
+    }
+    const last=WAVES[WAVES.length-1];
+    if(last.fired && el>last.t+1.0 && phase==='produce'){ phase='hold'; verbEl.innerHTML='<b>joye</b>'; }
+  }
+  if(phase==='hold' && el> (WAVES[WAVES.length-1].t+1.7) && !doneAt){ doneAt=ts; }
+  if(doneAt && ts-doneAt>700 && !heroShown){ heroShown=true; hero.classList.add('show'); }
+
+  nuke*=0.94;
+  ctx.globalCompositeOperation='lighter';
+
+  // expanding pulse rings (the agent "exhaling")
+  for(const ring of rings){
+    const age=(ts-ring.born)/1000; if(age>1.1) continue;
+    const rr=age*Math.max(W,H)*0.34, a=(1-age/1.1)*0.5;
+    ctx.strokeStyle=`rgba(125,211,252,${a})`; ctx.lineWidth=DPR*1.2;
+    ctx.beginPath(); ctx.arc(cx,cy,rr,0,7); ctx.stroke();
+  }
+
+  // the agent nucleus — a breathing core of light (the protagonist)
+  if(phase!=='hold' || el < WAVES[WAVES.length-1].t+1.6){
+    const breathe=1+Math.sin(el*3.2)*0.12;
+    const coreS=(46+nuke*70)*DPR*breathe;
+    ctx.globalAlpha=0.9; ctx.drawImage(sprite,cx-coreS/2,cy-coreS/2,coreS,coreS);
+    ctx.globalAlpha=1; ctx.drawImage(sprite,cx-12*DPR,cy-12*DPR,24*DPR,24*DPR);
+  }
+
+  // particles produced by the agent → fly out → become JOYE
+  for(const p of parts){
+    if(!p.emitted) continue;
+    const ease=0.10;
+    p.vx+=(p.tx-p.x)*ease; p.vy+=(p.ty-p.y)*ease;
+    const mdx=p.x-mouse.x,mdy=p.y-mouse.y,md2=mdx*mdx+mdy*mdy,R=(105*DPR)**2;
+    if(md2<R){const f=(1-md2/R)*4,d=Math.sqrt(md2)||1;p.vx+=mdx/d*f;p.vy+=mdy/d*f;}
+    p.vx*=0.82; p.vy*=0.82; p.x+=p.vx; p.y+=p.vy; p.tw+=0.05;
+    const near=(p.x-p.tx)**2+(p.y-p.ty)**2<(7*DPR)**2;
+    const tw=0.7+Math.sin(p.tw+p.seed*6)*0.3;
+    const a=(near?0.95:0.8)*tw;
+    const s=p.r*(near?5.5:7.5); // glow sprite size
+    ctx.globalAlpha=Math.min(1,a);
+    ctx.drawImage(sprite,p.x-s/2,p.y-s/2,s,s);
+  }
+  ctx.globalAlpha=1; ctx.globalCompositeOperation='source-over';
+  raf=requestAnimationFrame(frame);
+}
+
+function start(){
+  cancelAnimationFrame(raf); resize(); build();
+  if(parts.length===0){ setTimeout(start,120); return; }
+  WAVES.forEach(w=>w.fired=false);
+  phase='wake'; t0=0; doneAt=0; heroShown=false; nuke=0;
+  ctx.clearRect(0,0,W,H);
+  hero.classList.remove('show'); taskEl.classList.remove('show'); verbEl.classList.remove('show'); verbEl.innerHTML='';
+  if(reduce){ hero.classList.add('show'); return; }
+  raf=requestAnimationFrame(frame);
+}
+function boot(){ if(document.fonts&&document.fonts.ready){Promise.race([document.fonts.ready,new Promise(r=>setTimeout(r,800))]).then(start);}else start(); }
+function skip(){ cancelAnimationFrame(raf); ctx.clearRect(0,0,W,H); taskEl.classList.remove('show'); verbEl.classList.remove('show'); hero.classList.add('show'); }
+
+document.getElementById('skip').onclick=skip;
+document.getElementById('replay').onclick=start;
+addEventListener('resize',()=>{ if(!heroShown){ resize(); build(); } });
+boot();
+</script>
+</body>
+</html>

--- a/demos/intro/constellation-emit.html
+++ b/demos/intro/constellation-emit.html
@@ -1,0 +1,249 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Intro · Agent emits JOYE</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --bg:#0f1419;--fg:#faf9f8;--muted:#9aa6b2;--cyan:#7dd3fc;--steel:#659eb9;--ok:#41d18a;
+    --mono:'JetBrains Mono',ui-monospace,Menlo,monospace;
+    --sans:'Inter','Satoshi',system-ui,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%;margin:0}
+  body{background:radial-gradient(120% 120% at 50% 32%,#121a22,#0a0e13 70%);color:var(--fg);
+    font-family:var(--sans);overflow:hidden}
+  canvas{position:fixed;inset:0;display:block}
+
+  .task{position:fixed;left:50%;top:7.5%;transform:translateX(-50%);font-family:var(--mono);
+    font-size:clamp(10px,1.2vw,13px);letter-spacing:.12em;color:rgba(125,211,252,.62);
+    opacity:0;transition:opacity .8s ease;white-space:nowrap;z-index:4}
+  .task.show{opacity:.62}
+  .step{position:fixed;left:50%;bottom:13%;transform:translateX(-50%);font-family:var(--mono);
+    font-size:11px;letter-spacing:.14em;color:var(--muted);opacity:0;transition:opacity .5s ease;
+    white-space:nowrap;z-index:4;text-transform:uppercase}
+  .step.show{opacity:.6}
+  .step b{color:var(--cyan);font-weight:500}
+
+  .enter{position:fixed;left:50%;top:calc(50% + 140px);transform:translate(-50%,10px);
+    opacity:0;pointer-events:none;z-index:18;font-family:var(--mono);font-size:13px;color:var(--fg);
+    background:rgba(255,255,255,.06);border:1px solid rgba(125,211,252,.34);border-radius:8px;
+    padding:10px 15px;cursor:pointer;backdrop-filter:blur(10px);transition:.35s ease}
+  .enter.show{opacity:1;pointer-events:auto;transform:translate(-50%,0)}
+  .enter:hover{background:rgba(125,211,252,.11);border-color:rgba(125,211,252,.65)}
+
+  /* hero */
+  .hero{position:fixed;inset:0;display:grid;place-items:center;opacity:0;pointer-events:none}
+  .hero.show{opacity:1;pointer-events:auto;transition:opacity 1s ease}
+  .card{display:flex;flex-direction:column;align-items:center;gap:18px;text-align:center}
+  .avatar{width:112px;height:112px;border-radius:50%;padding:4px;border:1px solid rgba(255,255,255,.14);
+    object-fit:cover;background:conic-gradient(from 210deg,var(--steel),var(--cyan),var(--steel));
+    box-shadow:0 0 50px rgba(125,211,252,.3)}
+  .name{font-weight:800;font-size:34px;letter-spacing:-.02em;margin:0}
+  .meta{color:var(--muted);font-family:var(--mono);font-size:13px;display:flex;gap:14px}
+  .ital{color:var(--cyan);font-style:italic;font-size:15px}
+  .pill{display:inline-flex;align-items:center;gap:9px;padding:9px 16px;border-radius:999px;
+    border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.03);font-size:14px;color:var(--fg);text-decoration:none}
+  .ping{position:relative;width:9px;height:9px}.ping i{position:absolute;inset:0;border-radius:50%;background:var(--ok)}
+  .ping i:first-child{animation:ping 1.4s cubic-bezier(0,0,.2,1) infinite}
+  @keyframes ping{75%,100%{transform:scale(2.4);opacity:0}}
+  .card>*{opacity:0;transform:translateY(14px)}
+  .hero.show .card>*{animation:up .7s cubic-bezier(.2,.7,.2,1) forwards}
+  .hero.show .card>*:nth-child(1){animation-delay:.05s}.hero.show .card>*:nth-child(2){animation-delay:.16s}
+  .hero.show .card>*:nth-child(3){animation-delay:.26s}.hero.show .card>*:nth-child(4){animation-delay:.36s}
+  .hero.show .card>*:nth-child(5){animation-delay:.46s}
+  @keyframes up{to{opacity:1;transform:none}}
+
+  .ctl{position:fixed;bottom:18px;right:18px;display:flex;gap:10px;z-index:20;font-family:var(--mono);font-size:12px}
+  .ctl button{background:rgba(255,255,255,.04);color:var(--muted);border:1px solid rgba(255,255,255,.1);
+    padding:7px 12px;border-radius:8px;cursor:pointer;transition:.2s}
+  .ctl button:hover{color:var(--fg);border-color:rgba(125,211,252,.4)}
+  .hint{position:fixed;bottom:20px;left:20px;font-family:var(--mono);font-size:12px;color:rgba(154,166,178,.5);z-index:20}
+</style>
+</head>
+<body>
+  <canvas id="c"></canvas>
+  <div class="task" id="task">task: compose joye.dev/home</div>
+  <div class="step" id="step"></div>
+  <button class="enter" id="enter">进入 ~/joye →</button>
+
+  <div class="hero" id="hero">
+    <div class="card">
+      <img class="avatar" src="../../src/assets/avatar.png" alt="Joye" onerror="this.removeAttribute('src')" />
+      <h1 class="name">Joye</h1>
+      <div class="meta"><span>📍 Melbourne, Australia</span><span>· GitHub</span></div>
+      <div class="ital">“Stay hungry, stay foolish.”</div>
+      <a class="pill" href="javascript:void 0"><span class="ping"><i></i><i></i></span> Connect Me!</a>
+    </div>
+  </div>
+
+  <div class="hint">动画一（重做）· agent loop 当场产出粒子 → JOYE</div>
+  <div class="ctl"><button id="skip">跳过 →</button><button id="replay">重播 ↻</button></div>
+
+<script>
+const cv=document.getElementById('c'), ctx=cv.getContext('2d');
+const taskEl=document.getElementById('task'), stepEl=document.getElementById('step');
+const enterEl=document.getElementById('enter'), hero=document.getElementById('hero');
+const reduce=matchMedia('(prefers-reduced-motion:reduce)').matches;
+
+// skill → tool steps. Each step FIRES once and emits its band of JOYE particles.
+const STEPS=[
+  { skill:'frontend·design', tool:'fs.read(posts)',      pos:[19,26] },
+  { skill:'ai·agent',        tool:'github(OpenHarness)',  pos:[81,26] },
+  { skill:'full-stack',      tool:'mcp.fs(projects)',     pos:[15,62] },
+  { skill:'design·taste',    tool:'memory.search(taste)', pos:[85,62] },
+  { skill:'compose',         tool:'merge_context()',      pos:[50,84] },
+];
+const CORE=[50,13];
+
+let W,H,DPR,raf,t0=0,particles=[],nodes=[],core,phase='run',mouse={x:-1e9,y:-1e9},enterShown=false,exitAt=0;
+
+function vw(){return innerWidth||document.documentElement.clientWidth||1280}
+function vh(){return innerHeight||document.documentElement.clientHeight||800}
+function resize(){DPR=Math.min(devicePixelRatio||1,2);W=cv.width=Math.round(vw()*DPR);H=cv.height=Math.round(vh()*DPR);cv.style.width=vw()+'px';cv.style.height=vh()+'px';}
+addEventListener('mousemove',e=>{mouse.x=e.clientX*DPR;mouse.y=e.clientY*DPR});
+addEventListener('mouseleave',()=>{mouse.x=mouse.y=-1e9});
+
+function sampleJOYE(){
+  if(!W||!H) return [];
+  const off=document.createElement('canvas');off.width=W;off.height=H;
+  const o=off.getContext('2d');o.fillStyle='#fff';o.textBaseline='middle';o.textAlign='left';
+  const tracking=0.18;let size=Math.min(H*0.42,W*0.34);
+  const setFont=()=>o.font=`700 ${size}px Inter, system-ui, sans-serif`;setFont();
+  const adv=()=>{let w=0;for(const ch of 'JOYE')w+=o.measureText(ch).width+size*tracking;return w-size*tracking};
+  if(adv()>W*0.74){size*=W*0.74/adv();setFont();}
+  let x=(W-adv())/2;const y=H*0.46;
+  for(const ch of 'JOYE'){o.fillText(ch,x,y);x+=o.measureText(ch).width+size*tracking;}
+  const d=o.getImageData(0,0,W,H).data;const gap=Math.max(5,Math.round(7*DPR));const pts=[];
+  for(let yy=0;yy<H;yy+=gap)for(let xx=0;xx<W;xx+=gap)if(d[(yy*W+xx)*4+3]>128)pts.push({x:xx,y:yy});
+  return pts;
+}
+
+function build(){
+  // nodes
+  core={x:W*CORE[0]/100,y:H*CORE[1]/100,act:0};
+  nodes=STEPS.map(s=>({x:W*s.pos[0]/100,y:H*s.pos[1]/100,act:0,fired:false,skill:s.skill,tool:s.tool}));
+  // partition JOYE into contiguous x-bands, one per step → builds left→right
+  const pts=sampleJOYE().sort((a,b)=>a.x-b.x);
+  const per=Math.ceil(pts.length/STEPS.length);
+  nodes.forEach((n,i)=>{ n.band=pts.slice(i*per,(i+1)*per); });
+  particles=[];
+}
+
+// when a step fires: light node, emit its band of particles FROM the node
+function fire(i){
+  const n=nodes[i]; if(!n||n.fired) return; n.fired=true; n.act=1; core.act=1;
+  stepEl.innerHTML=`step ${i+1}/${STEPS.length} · <b>${n.skill}</b> › ${n.tool}`;
+  stepEl.classList.add('show');
+  for(const t of n.band){
+    const ang=Math.random()*6.283, sp=(Math.random()*1.2+0.4)*DPR;
+    particles.push({
+      x:n.x+(Math.random()-.5)*14*DPR, y:n.y+(Math.random()-.5)*14*DPR,
+      vx:Math.cos(ang)*sp, vy:Math.sin(ang)*sp, tx:t.x, ty:t.y,
+      r:(Math.random()*0.9+0.7)*DPR, born:performance.now(), src:i, tw:Math.random()*6.28
+    });
+  }
+}
+
+function color(p,a){const k=p.x/W;const r=Math.round(101+(125-101)*k),g=Math.round(158+(211-158)*k),b=Math.round(185+(252-185)*k);return `rgba(${r},${g},${b},${a})`;}
+
+const FIRE0=0.7, GAP=0.46;
+function frame(ts){
+  if(!t0)t0=ts;const el=(ts-t0)/1000;ctx.clearRect(0,0,W,H);
+  if(el>.25) taskEl.classList.add('show');
+
+  // schedule tool firings (the loop iterating)
+  if(phase==='run'){
+    for(let i=0;i<STEPS.length;i++) if(el>=FIRE0+i*GAP) fire(i);
+    const lastDone=FIRE0+(STEPS.length-1)*GAP+1.0;
+    if(el>lastDone && !enterShown) showEnter();
+  }
+
+  core.act*=0.93;
+
+  // emission streams: faint line node → its freshly-born particles
+  for(const p of particles){
+    const age=(ts-p.born)/1000;
+    if(age<0.42 && phase!=='exit'){
+      const n=nodes[p.src];
+      ctx.strokeStyle=`rgba(125,211,252,${0.16*(1-age/0.42)})`;ctx.lineWidth=DPR*0.6;
+      ctx.beginPath();ctx.moveTo(n.x,n.y);ctx.lineTo(p.x,p.y);ctx.stroke();
+    }
+  }
+
+  // particles seek their targets (or scatter on exit)
+  for(const p of particles){
+    if(phase==='exit'){
+      p.vx+=((Math.random()-.5)*.16 + (p.x-W/2)/W*.09)*DPR;
+      p.vy+=((Math.random()-.5)*.08 - .11)*DPR;
+    }else{
+      const ease=0.12;
+      p.vx+=(p.tx-p.x)*ease; p.vy+=(p.ty-p.y)*ease;
+      const mdx=p.x-mouse.x,mdy=p.y-mouse.y,md2=mdx*mdx+mdy*mdy,R=(110*DPR)**2;
+      if(md2<R){const f=(1-md2/R)*4,d=Math.sqrt(md2)||1;p.vx+=mdx/d*f;p.vy+=mdy/d*f;}
+    }
+    p.vx*=phase==='exit'?.91:.84; p.vy*=phase==='exit'?.91:.84;
+    p.x+=p.vx; p.y+=p.vy; p.tw+=0.05;
+    const near=(p.x-p.tx)**2+(p.y-p.ty)**2<(8*DPR)**2;
+    const tw=0.6+Math.sin(p.tw)*0.22;
+    const fade=phase==='exit'?Math.max(0,1-(ts-exitAt)/1300):1;
+    const a=(near?0.95:0.72)*tw*fade;
+    ctx.beginPath();ctx.fillStyle=color(p,Math.min(1,a));ctx.arc(p.x,p.y,p.r*(near?1.25:1),0,7);ctx.fill();
+  }
+
+  // draw the agent core + tool nodes (so you see WHO emitted)
+  if(phase!=='exit'){
+    drawNode(core, 'agent.runtime()', true);
+    nodes.forEach(n=>drawNode(n, n.tool, false, n.skill));
+    // core → active node link
+    nodes.forEach(n=>{ if(n.act>0.04){
+      ctx.strokeStyle=`rgba(125,211,252,${0.18*n.act})`;ctx.lineWidth=DPR*0.8;
+      ctx.beginPath();ctx.moveTo(core.x,core.y);ctx.lineTo(n.x,n.y);ctx.stroke();
+    }});
+    nodes.forEach(n=>n.act*=0.92);
+  }
+
+  if(phase==='exit' && ts-exitAt>900 && !hero.classList.contains('show')) hero.classList.add('show');
+  raf=requestAnimationFrame(frame);
+}
+
+function drawNode(n, label, isCore, skill){
+  const r=(isCore?7:5.5)*DPR*(1+n.act*0.5);
+  if(n.act>0.02){ctx.beginPath();ctx.fillStyle=`rgba(125,211,252,${0.14*n.act})`;ctx.arc(n.x,n.y,r*3.6,0,7);ctx.fill();}
+  ctx.beginPath();ctx.fillStyle='rgba(13,20,28,0.92)';ctx.arc(n.x,n.y,r,0,7);ctx.fill();
+  ctx.lineWidth=(isCore?2:1.4)*DPR;ctx.strokeStyle=`rgba(125,211,252,${0.5+n.act*0.5})`;
+  ctx.beginPath();ctx.arc(n.x,n.y,r,0,7);ctx.stroke();
+  ctx.textAlign='center';ctx.textBaseline='middle';
+  if(skill){ctx.font=`${10*DPR}px ${'JetBrains Mono, monospace'}`;ctx.fillStyle=`rgba(125,211,252,${0.5+n.act*0.5})`;ctx.fillText(skill,n.x,n.y-r-9*DPR);}
+  ctx.font=`${(isCore?11:10)*DPR}px ${'JetBrains Mono, monospace'}`;
+  ctx.fillStyle=`rgba(${n.act>0.3?'200,235,255':'150,166,178'},${0.55+n.act*0.45})`;
+  ctx.fillText(label, n.x, n.y+r+10*DPR);
+  if(n.fired){ctx.fillStyle=`rgba(65,209,138,.9)`;ctx.font=`${9*DPR}px monospace`;ctx.fillText('ok',n.x+r+10*DPR,n.y);}
+}
+
+function showEnter(){ if(enterShown||phase==='exit')return; enterShown=true; stepEl.innerHTML='merge: context → <b>JOYE</b> · agent loop complete'; enterEl.classList.add('show'); }
+function enterSite(){ if(phase==='exit')return; phase='exit'; exitAt=performance.now(); enterEl.classList.remove('show'); stepEl.classList.remove('show'); taskEl.classList.remove('show'); }
+
+function start(){
+  cancelAnimationFrame(raf); resize(); build();
+  if(nodes[0] && nodes[0].band && nodes[0].band.length===0){ setTimeout(start,120); return; }
+  phase='run'; t0=0; enterShown=false; exitAt=0;
+  hero.classList.remove('show'); enterEl.classList.remove('show'); stepEl.classList.remove('show'); taskEl.classList.remove('show');
+  if(reduce){ hero.classList.add('show'); return; }
+  raf=requestAnimationFrame(frame);
+}
+function boot(){ if(document.fonts&&document.fonts.ready){Promise.race([document.fonts.ready,new Promise(r=>setTimeout(r,800))]).then(start);}else start(); }
+function skip(){ cancelAnimationFrame(raf); ctx.clearRect(0,0,W,H); enterEl.classList.remove('show'); stepEl.classList.remove('show'); taskEl.classList.remove('show'); hero.classList.add('show'); }
+
+enterEl.onclick=enterSite;
+document.getElementById('skip').onclick=skip;
+document.getElementById('replay').onclick=start;
+addEventListener('resize',()=>{ if(phase!=='exit'){ resize(); build(); } });
+boot();
+</script>
+</body>
+</html>

--- a/demos/intro/constellation.html
+++ b/demos/intro/constellation.html
@@ -23,6 +23,24 @@
     font-size:14px;letter-spacing:.18em;color:var(--cyan);opacity:0;text-transform:uppercase}
   .tag.show{animation:fade .9s ease forwards}
   @keyframes fade{to{opacity:.9}}
+  .context{position:fixed;inset:0;pointer-events:none;overflow:hidden;font-family:var(--mono);z-index:3}
+  .token{position:absolute;opacity:0;transform:translateY(12px) scale(.98);color:rgba(125,211,252,.56);
+    font-size:clamp(10px,1.2vw,13px);letter-spacing:.08em;text-transform:lowercase;
+    text-shadow:0 0 18px rgba(125,211,252,.16);transition:opacity .9s ease,transform 1.2s cubic-bezier(.16,1,.3,1),filter .9s ease;white-space:nowrap}
+  .context.show .token{opacity:.46;transform:translateY(0) scale(1)}
+  .context.folding .token{opacity:.16;transform:translateY(-12px) scale(.96);filter:blur(.5px)}
+  .context.leaving .token{opacity:0;transform:translateY(-34px) scale(.94);filter:blur(2px)}
+  .enter{position:fixed;left:50%;top:calc(50% + 150px);transform:translate(-50%,10px);
+    opacity:0;pointer-events:none;z-index:18;font-family:var(--mono);font-size:13px;
+    color:var(--fg);background:rgba(255,255,255,.06);border:1px solid rgba(125,211,252,.34);
+    border-radius:8px;padding:10px 15px;cursor:pointer;backdrop-filter:blur(10px);
+    box-shadow:0 14px 36px -18px rgba(250,249,248,.38),inset 0 1px 0 rgba(250,249,248,.08);transition:.35s ease}
+  .enter.show{opacity:1;pointer-events:auto;transform:translate(-50%,0)}
+  .enter:hover{background:rgba(125,211,252,.11);border-color:rgba(125,211,252,.65);box-shadow:0 18px 48px -20px rgba(125,211,252,.75)}
+  .trace{position:fixed;left:50%;top:calc(50% + 210px);z-index:18;transform:translate(-50%,8px);
+    opacity:0;pointer-events:none;color:var(--muted);font-family:var(--mono);font-size:10px;
+    letter-spacing:.08em;text-align:center;white-space:nowrap;transition:.55s ease}
+  .trace.show{opacity:.46;transform:translate(-50%,0)}
 
   /* hero reveal */
   .hero{position:fixed;inset:0;display:grid;place-items:center;opacity:0;pointer-events:none}
@@ -61,7 +79,10 @@
 </head>
 <body>
   <canvas id="c"></canvas>
+  <div class="context" id="context"></div>
   <div class="tag" id="tag">frontend · design · ai-agent</div>
+  <button class="enter" id="enter">进入 ~/joye →</button>
+  <div class="trace" id="trace">context loaded · tools ready · welcome back</div>
 
   <div class="hero" id="hero">
     <div class="card">
@@ -74,16 +95,24 @@
     </div>
   </div>
 
-  <div class="hint">这是入场动画演示 · 鼠标移动可与粒子互动</div>
+  <div class="hint">这是入场动画演示 · 成形后可互动，点击进入 ~/joye</div>
   <div class="ctl"><button id="skip">跳过 →</button><button id="replay">重播 ↻</button></div>
 
 <script>
 const cv = document.getElementById('c');
 const ctx = cv.getContext('2d');
+const context = document.getElementById('context');
 const tag = document.getElementById('tag');
+const enter = document.getElementById('enter');
+const trace = document.getElementById('trace');
 const hero = document.getElementById('hero');
 const reduce = matchMedia('(prefers-reduced-motion:reduce)').matches;
-let W,H,DPR, particles=[], mouse={x:-1e9,y:-1e9}, phase='gather', raf, t0;
+let W,H,DPR, particles=[], mouse={x:-1e9,y:-1e9}, phase='gather', raf, t0, scatterAt=0, enterShown=false, autoExit=0, contextTimer=0;
+
+const TOKENS=['context','planner','tools','memory','eval','rag','multi-agent','openharness','frontend','design','ship','notes','search','trace','typescript','cursor'];
+const POS=[[10,18],[24,12],[43,16],[62,11],[80,19],[14,38],[30,31],[68,34],[84,42],[18,66],[36,76],[55,71],[75,66],[8,82],[48,88],[87,82]];
+TOKENS.forEach((text,i)=>{ const s=document.createElement('span'); s.className='token'; s.textContent=text;
+  s.style.left=POS[i][0]+'%'; s.style.top=POS[i][1]+'%'; s.style.transitionDelay=(i*.045)+'s'; context.appendChild(s); });
 
 function vw(){ return innerWidth || document.documentElement.clientWidth || 1280; }
 function vh(){ return innerHeight || document.documentElement.clientHeight || 800; }
@@ -142,13 +171,14 @@ function buildTargets(){
       x: Math.random()*W, y: Math.random()*H,
       vx:0, vy:0, tx:0, ty:0,
       r: (Math.random()*0.9+0.7)*DPR,
-      hue: Math.random(), tw: Math.random()*Math.PI*2
+      hue: Math.random(), tw: Math.random()*Math.PI*2,
+      delay:0, drift:Math.random()*Math.PI*2
     });
   }
   particles.length = pts.length;
   // assign nearest-ish targets (shuffle for organic look)
   pts.sort(()=> Math.random()-0.5);
-  particles.forEach((p,i)=>{ p.tx=pts[i].x; p.ty=pts[i].y; });
+  particles.forEach((p,i)=>{ p.tx=pts[i].x; p.ty=pts[i].y; p.delay=.2+(i%6)*.18+Math.random()*1.25; });
 }
 
 function color(p, a){
@@ -166,13 +196,16 @@ function frame(ts){
   ctx.clearRect(0,0,W,H);
 
   // phase transitions
-  if(phase==='gather' && el>2.7) phase='hold';
-  if(phase==='hold' && el>4.0) phase='scatter';
-  if(phase==='scatter' && el>4.9 && !hero.classList.contains('show')){
+  if(phase==='gather' && el>3.15) phase='hold';
+  if(el>2.35 && phase!=='scatter') context.classList.add('folding');
+  if(phase==='hold' && el>4.05) showEnter();
+  if(phase==='scatter' && !scatterAt) scatterAt = ts;
+  const scatterAge = scatterAt ? (ts-scatterAt)/1000 : 0;
+  if(phase==='scatter' && ts-scatterAt>1600 && !hero.classList.contains('show')){
     hero.classList.add('show');
   }
 
-  const ease = phase==='gather' ? 0.06 : phase==='hold' ? 0.12 : 0.02;
+  const ease = phase==='gather' ? 0.045 : phase==='hold' ? 0.11 : 0.018;
 
   // constellation links (only while formed-ish)
   if(phase==='gather' || phase==='hold'){
@@ -193,28 +226,34 @@ function frame(ts){
   for(const p of particles){
     // target seeking
     if(phase==='scatter'){
-      p.vx += (Math.random()-0.5)*0.6*DPR;
-      p.vy += (Math.random()-0.5)*0.6*DPR - 0.05*DPR;
+      const odx=(p.x-W/2)/Math.max(W,1);
+      p.vx += (Math.random()-0.5)*0.16*DPR + odx*.09*DPR;
+      p.vy += ((Math.random()-0.5)*0.08 - 0.11)*DPR;
     }else{
-      p.vx += (p.tx - p.x)*ease;
-      p.vy += (p.ty - p.y)*ease;
+      const pull = phase==='hold' ? 1 : Math.max(0, Math.min(1, (el-p.delay)/1.55));
+      if(pull<1){ p.vx += Math.sin(el*.9+p.drift)*.012*DPR; p.vy += Math.cos(el*.7+p.drift)*.012*DPR; }
+      const localEase = ease * (.2 + pull*.8);
+      p.vx += (p.tx - p.x)*localEase*pull;
+      p.vy += (p.ty - p.y)*localEase*pull;
     }
     // mouse repel
     const mdx=p.x-mouse.x, mdy=p.y-mouse.y, md2=mdx*mdx+mdy*mdy;
     const R=(110*DPR)**2;
     if(md2<R){ const f=(1-md2/R)*4; const d=Math.sqrt(md2)||1; p.vx+=mdx/d*f; p.vy+=mdy/d*f; }
 
-    p.vx*=0.86; p.vy*=0.86;
+    const damp = phase==='scatter' ? .91 : .87;
+    p.vx*=damp; p.vy*=damp;
     p.x+=p.vx; p.y+=p.vy;
     p.tw+=0.05;
 
     const near = (p.x-p.tx)**2+(p.y-p.ty)**2 < (8*DPR)**2;
     const tw = 0.55 + Math.sin(p.tw)*0.25;
-    const a = phase==='scatter' ? Math.max(0, 1 - el*0.5 + 1.5) * 0.6
+    const fade = phase==='scatter' ? Math.max(0, 1 - scatterAge/2.4) : 1;
+    const a = phase==='scatter' ? 0.6 * fade
             : (near ? 0.95 : 0.7) * tw;
     ctx.beginPath();
     ctx.fillStyle = color(p, Math.min(1,a));
-    ctx.arc(p.x,p.y, p.r*(near?1.25:1), 0, 7);
+    ctx.arc(p.x,p.y, p.r*(near?1.25:1)*(phase==='scatter' ? .95 + scatterAge*.08 : 1), 0, 7);
     ctx.fill();
   }
 
@@ -228,6 +267,27 @@ function frame(ts){
   raf = requestAnimationFrame(frame);
 }
 
+function showEnter(){
+  if(enterShown || phase==='scatter') return;
+  enterShown = true;
+  context.classList.add('folding');
+  enter.classList.add('show');
+  trace.classList.add('show');
+  clearTimeout(autoExit);
+  autoExit = setTimeout(enterSite, 12000);
+}
+
+function enterSite(){
+  if(phase==='scatter') return;
+  phase='scatter';
+  scatterAt=0;
+  context.classList.remove('show');
+  context.classList.add('leaving');
+  enter.classList.remove('show');
+  trace.classList.remove('show');
+  clearTimeout(autoExit);
+}
+
 function start(){
   cancelAnimationFrame(raf);
   resize(); particles=[]; buildTargets();
@@ -235,7 +295,10 @@ function start(){
   // scatter start positions outward
   particles.forEach(p=>{ const ang=Math.random()*7; const rad=Math.max(W,H);
     p.x=W/2+Math.cos(ang)*rad; p.y=H/2+Math.sin(ang)*rad; });
-  phase='gather'; t0=0; hero.classList.remove('show'); tag.classList.remove('show');
+  phase='gather'; t0=0; scatterAt=0; enterShown=false; clearTimeout(autoExit); clearTimeout(contextTimer);
+  hero.classList.remove('show'); tag.classList.remove('show'); enter.classList.remove('show'); trace.classList.remove('show');
+  context.classList.remove('show','folding','leaving');
+  contextTimer=setTimeout(()=>context.classList.add('show'),120);
   if(reduce){ hero.classList.add('show'); return; }
   raf=requestAnimationFrame(frame);
 }
@@ -246,8 +309,9 @@ function boot(){
   } else start();
 }
 
-function skip(){ cancelAnimationFrame(raf); ctx.clearRect(0,0,W,H); tag.classList.remove('show'); hero.classList.add('show'); }
+function skip(){ cancelAnimationFrame(raf); clearTimeout(autoExit); clearTimeout(contextTimer); ctx.clearRect(0,0,W,H); tag.classList.remove('show'); enter.classList.remove('show'); trace.classList.remove('show'); context.classList.remove('show','folding','leaving'); hero.classList.add('show'); }
 
+enter.onclick = enterSite;
 document.getElementById('skip').onclick = skip;
 document.getElementById('replay').onclick = start;
 boot();

--- a/demos/intro/constellation.html
+++ b/demos/intro/constellation.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Intro · Constellation</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --bg:#0f1419;--fg:#faf9f8;--muted:#9aa6b2;--cyan:#7dd3fc;--steel:#659eb9;--ok:#41d18a;
+    --mono:'JetBrains Mono',ui-monospace,Menlo,monospace;
+    --sans:'Inter','Satoshi',system-ui,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%;margin:0}
+  body{background:radial-gradient(120% 120% at 50% 30%,#121a22,#0b0f14 70%);color:var(--fg);
+    font-family:var(--sans);overflow:hidden}
+  canvas{position:fixed;inset:0;display:block}
+
+  .tag{position:fixed;left:0;right:0;top:62%;text-align:center;font-family:var(--mono);
+    font-size:14px;letter-spacing:.18em;color:var(--cyan);opacity:0;text-transform:uppercase}
+  .tag.show{animation:fade .9s ease forwards}
+  @keyframes fade{to{opacity:.9}}
+
+  /* hero reveal */
+  .hero{position:fixed;inset:0;display:grid;place-items:center;opacity:0;pointer-events:none}
+  .hero.show{opacity:1;pointer-events:auto;transition:opacity 1s ease}
+  .card{display:flex;flex-direction:column;align-items:center;gap:18px;text-align:center}
+  .avatar{width:112px;height:112px;border-radius:50%;padding:4px;
+    border:1px solid rgba(255,255,255,.14);object-fit:cover;
+    background:conic-gradient(from 210deg,var(--steel),var(--cyan),var(--steel));
+    box-shadow:0 0 50px rgba(125,211,252,.3)}
+  .name{font-weight:800;font-size:34px;letter-spacing:-.02em;margin:0}
+  .meta{color:var(--muted);font-family:var(--mono);font-size:13px;display:flex;gap:14px}
+  .ital{color:var(--cyan);font-style:italic;font-size:15px}
+  .pill{display:inline-flex;align-items:center;gap:9px;padding:9px 16px;border-radius:999px;
+    border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.03);font-size:14px;
+    color:var(--fg);text-decoration:none;transition:.2s}
+  .pill:hover{border-color:rgba(125,211,252,.4);box-shadow:0 0 0 4px rgba(125,211,252,.08)}
+  .ping{position:relative;width:9px;height:9px}
+  .ping i{position:absolute;inset:0;border-radius:50%;background:var(--ok)}
+  .ping i:first-child{animation:ping 1.4s cubic-bezier(0,0,.2,1) infinite}
+  @keyframes ping{75%,100%{transform:scale(2.4);opacity:0}}
+  .card>*{opacity:0;transform:translateY(14px)}
+  .hero.show .card>*{animation:up .7s cubic-bezier(.2,.7,.2,1) forwards}
+  .hero.show .card>*:nth-child(1){animation-delay:.05s}
+  .hero.show .card>*:nth-child(2){animation-delay:.16s}
+  .hero.show .card>*:nth-child(3){animation-delay:.26s}
+  .hero.show .card>*:nth-child(4){animation-delay:.36s}
+  .hero.show .card>*:nth-child(5){animation-delay:.46s}
+  @keyframes up{to{opacity:1;transform:none}}
+
+  .ctl{position:fixed;bottom:18px;right:18px;display:flex;gap:10px;z-index:20;font-family:var(--mono);font-size:12px}
+  .ctl button{background:rgba(255,255,255,.04);color:var(--muted);border:1px solid rgba(255,255,255,.1);
+    padding:7px 12px;border-radius:8px;cursor:pointer;transition:.2s}
+  .ctl button:hover{color:var(--fg);border-color:rgba(125,211,252,.4)}
+  .hint{position:fixed;bottom:20px;left:20px;font-family:var(--mono);font-size:12px;color:rgba(154,166,178,.5);z-index:20}
+</style>
+</head>
+<body>
+  <canvas id="c"></canvas>
+  <div class="tag" id="tag">frontend · design · ai-agent</div>
+
+  <div class="hero" id="hero">
+    <div class="card">
+      <img class="avatar" src="../../src/assets/avatar.png" alt="Joye"
+           onerror="this.removeAttribute('src')" />
+      <h1 class="name">Joye</h1>
+      <div class="meta"><span>📍 Melbourne, Australia</span><span>· GitHub</span></div>
+      <div class="ital">“Stay hungry, stay foolish.”</div>
+      <a class="pill" href="javascript:void 0"><span class="ping"><i></i><i></i></span> Connect Me!</a>
+    </div>
+  </div>
+
+  <div class="hint">这是入场动画演示 · 鼠标移动可与粒子互动</div>
+  <div class="ctl"><button id="skip">跳过 →</button><button id="replay">重播 ↻</button></div>
+
+<script>
+const cv = document.getElementById('c');
+const ctx = cv.getContext('2d');
+const tag = document.getElementById('tag');
+const hero = document.getElementById('hero');
+const reduce = matchMedia('(prefers-reduced-motion:reduce)').matches;
+let W,H,DPR, particles=[], mouse={x:-1e9,y:-1e9}, phase='gather', raf, t0;
+
+function vw(){ return innerWidth || document.documentElement.clientWidth || 1280; }
+function vh(){ return innerHeight || document.documentElement.clientHeight || 800; }
+function resize(){
+  DPR = Math.min(devicePixelRatio||1, 2);
+  const w=vw(), h=vh();
+  W = cv.width = w*DPR; H = cv.height = h*DPR;
+  cv.style.width=w+'px'; cv.style.height=h+'px';
+}
+addEventListener('resize', ()=>{ resize(); buildTargets(); });
+addEventListener('mousemove', e=>{ mouse.x=e.clientX*DPR; mouse.y=e.clientY*DPR; });
+addEventListener('mouseleave', ()=>{ mouse.x=mouse.y=-1e9; });
+
+// sample the word "JOYE" into target points (manual letter-spacing for legibility)
+function sampleText(text){
+  if(!W || !H) return [];
+  const off = document.createElement('canvas');
+  const o = off.getContext('2d');
+  off.width = W; off.height = H;
+  o.fillStyle = '#fff';
+  o.textBaseline = 'middle';
+  o.textAlign = 'left';
+
+  const tracking = 0.18;                 // extra space between letters (× font size)
+  let size = Math.min(H * 0.42, W * 0.34);
+  const setFont = () => o.font = `700 ${size}px Inter, system-ui, sans-serif`;
+  setFont();
+  const advance = () => {
+    let w = 0; for (const ch of text) w += o.measureText(ch).width + size * tracking;
+    return w - size * tracking;
+  };
+  const maxW = W * 0.74;
+  if (advance() > maxW) { size *= maxW / advance(); setFont(); }
+
+  let x = (W - advance()) / 2;
+  const y = H * 0.46;
+  for (const ch of text) {
+    o.fillText(ch, x, y);
+    x += o.measureText(ch).width + size * tracking;
+  }
+
+  const data = o.getImageData(0, 0, W, H).data;
+  const gap = Math.max(5, Math.round(7 * DPR));   // sparser → letters breathe
+  const pts = [];
+  for (let yy = 0; yy < H; yy += gap)
+    for (let xx = 0; xx < W; xx += gap)
+      if (data[(yy * W + xx) * 4 + 3] > 128) pts.push({ x: xx, y: yy });
+  return pts;
+}
+
+function buildTargets(){
+  const pts = sampleText('JOYE');
+  // grow/shrink the particle pool to match
+  while(particles.length < pts.length){
+    particles.push({
+      x: Math.random()*W, y: Math.random()*H,
+      vx:0, vy:0, tx:0, ty:0,
+      r: (Math.random()*0.9+0.7)*DPR,
+      hue: Math.random(), tw: Math.random()*Math.PI*2
+    });
+  }
+  particles.length = pts.length;
+  // assign nearest-ish targets (shuffle for organic look)
+  pts.sort(()=> Math.random()-0.5);
+  particles.forEach((p,i)=>{ p.tx=pts[i].x; p.ty=pts[i].y; });
+}
+
+function color(p, a){
+  // steel -> cyan gradient by x position
+  const k = p.x / W;
+  const r = Math.round(101 + (125-101)*k);
+  const g = Math.round(158 + (211-158)*k);
+  const b = Math.round(185 + (252-185)*k);
+  return `rgba(${r},${g},${b},${a})`;
+}
+
+function frame(ts){
+  if(!t0) t0=ts;
+  const el = (ts - t0)/1000;
+  ctx.clearRect(0,0,W,H);
+
+  // phase transitions
+  if(phase==='gather' && el>2.7) phase='hold';
+  if(phase==='hold' && el>4.0) phase='scatter';
+  if(phase==='scatter' && el>4.9 && !hero.classList.contains('show')){
+    hero.classList.add('show');
+  }
+
+  const ease = phase==='gather' ? 0.06 : phase==='hold' ? 0.12 : 0.02;
+
+  // constellation links (only while formed-ish)
+  if(phase==='gather' || phase==='hold'){
+    ctx.lineWidth = DPR*0.6;
+    for(let i=0;i<particles.length;i+=2){
+      const p=particles[i];
+      for(let j=i+2;j<i+10 && j<particles.length;j++){
+        const q=particles[j];
+        const dx=p.x-q.x, dy=p.y-q.y; const d2=dx*dx+dy*dy;
+        if(d2 < (26*DPR)**2){
+          ctx.strokeStyle = `rgba(125,211,252,${0.10*(1-d2/((26*DPR)**2))})`;
+          ctx.beginPath(); ctx.moveTo(p.x,p.y); ctx.lineTo(q.x,q.y); ctx.stroke();
+        }
+      }
+    }
+  }
+
+  for(const p of particles){
+    // target seeking
+    if(phase==='scatter'){
+      p.vx += (Math.random()-0.5)*0.6*DPR;
+      p.vy += (Math.random()-0.5)*0.6*DPR - 0.05*DPR;
+    }else{
+      p.vx += (p.tx - p.x)*ease;
+      p.vy += (p.ty - p.y)*ease;
+    }
+    // mouse repel
+    const mdx=p.x-mouse.x, mdy=p.y-mouse.y, md2=mdx*mdx+mdy*mdy;
+    const R=(110*DPR)**2;
+    if(md2<R){ const f=(1-md2/R)*4; const d=Math.sqrt(md2)||1; p.vx+=mdx/d*f; p.vy+=mdy/d*f; }
+
+    p.vx*=0.86; p.vy*=0.86;
+    p.x+=p.vx; p.y+=p.vy;
+    p.tw+=0.05;
+
+    const near = (p.x-p.tx)**2+(p.y-p.ty)**2 < (8*DPR)**2;
+    const tw = 0.55 + Math.sin(p.tw)*0.25;
+    const a = phase==='scatter' ? Math.max(0, 1 - el*0.5 + 1.5) * 0.6
+            : (near ? 0.95 : 0.7) * tw;
+    ctx.beginPath();
+    ctx.fillStyle = color(p, Math.min(1,a));
+    ctx.arc(p.x,p.y, p.r*(near?1.25:1), 0, 7);
+    ctx.fill();
+  }
+
+  // glow pass
+  ctx.globalCompositeOperation='lighter';
+  ctx.globalCompositeOperation='source-over';
+
+  if(el>1.6 && !tag.classList.contains('show') && phase!=='scatter') tag.classList.add('show');
+  if(phase==='scatter') tag.classList.remove('show');
+
+  raf = requestAnimationFrame(frame);
+}
+
+function start(){
+  cancelAnimationFrame(raf);
+  resize(); particles=[]; buildTargets();
+  if(particles.length === 0){ setTimeout(start, 120); return; } // viewport not ready yet
+  // scatter start positions outward
+  particles.forEach(p=>{ const ang=Math.random()*7; const rad=Math.max(W,H);
+    p.x=W/2+Math.cos(ang)*rad; p.y=H/2+Math.sin(ang)*rad; });
+  phase='gather'; t0=0; hero.classList.remove('show'); tag.classList.remove('show');
+  if(reduce){ hero.classList.add('show'); return; }
+  raf=requestAnimationFrame(frame);
+}
+function boot(){
+  // sample text only once the real font is ready, so "JOYE" has the right shape
+  if(document.fonts && document.fonts.ready){
+    Promise.race([document.fonts.ready, new Promise(r=>setTimeout(r,800))]).then(start);
+  } else start();
+}
+
+function skip(){ cancelAnimationFrame(raf); ctx.clearRect(0,0,W,H); tag.classList.remove('show'); hero.classList.add('show'); }
+
+document.getElementById('skip').onclick = skip;
+document.getElementById('replay').onclick = start;
+boot();
+</script>
+</body>
+</html>

--- a/demos/intro/constellation.html
+++ b/demos/intro/constellation.html
@@ -24,12 +24,40 @@
   .tag.show{animation:fade .9s ease forwards}
   @keyframes fade{to{opacity:.9}}
   .context{position:fixed;inset:0;pointer-events:none;overflow:hidden;font-family:var(--mono);z-index:3}
-  .token{position:absolute;opacity:0;transform:translateY(12px) scale(.98);color:rgba(125,211,252,.56);
-    font-size:clamp(10px,1.2vw,13px);letter-spacing:.08em;text-transform:lowercase;
-    text-shadow:0 0 18px rgba(125,211,252,.16);transition:opacity .9s ease,transform 1.2s cubic-bezier(.16,1,.3,1),filter .9s ease;white-space:nowrap}
-  .context.show .token{opacity:.46;transform:translateY(0) scale(1)}
-  .context.folding .token{opacity:.16;transform:translateY(-12px) scale(.96);filter:blur(.5px)}
-  .context.leaving .token{opacity:0;transform:translateY(-34px) scale(.94);filter:blur(2px)}
+  .task{position:absolute;top:8%;left:50%;opacity:0;transform:translate(-50%,12px);
+    color:rgba(125,211,252,.56);font-size:clamp(10px,1.2vw,13px);letter-spacing:.08em;
+    text-shadow:0 0 18px rgba(125,211,252,.16);transition:opacity .9s ease,transform 1.2s cubic-bezier(.16,1,.3,1);
+    white-space:nowrap}
+  .context.start .task{opacity:.56;transform:translate(-50%,0)}
+  .tool{position:absolute;width:clamp(132px,16vw,212px);max-width:42vw;opacity:0;
+    transform:translate(-50%,10px) scale(.98);padding:8px 10px;color:var(--muted);
+    background:rgba(255,255,255,.05);border:1px solid rgba(255,255,255,.12);border-radius:8px;
+    box-shadow:0 14px 36px -24px rgba(0,0,0,.8);backdrop-filter:blur(8px);
+    transition:opacity .65s ease,transform .8s cubic-bezier(.16,1,.3,1),filter .5s ease,border-color .5s ease}
+  .context.invoke .tool{opacity:.58;transform:translate(-50%,0) scale(1)}
+  .head{display:flex;align-items:center;justify-content:space-between;gap:12px;color:rgba(250,249,248,.75);
+    font-size:11px;white-space:nowrap}
+  .call{min-width:0;overflow:hidden;text-overflow:ellipsis}
+  .status{color:rgba(125,211,252,.8);font-size:10px}
+  .shards{display:flex;flex-wrap:wrap;gap:5px;margin-top:7px}
+  .shard{opacity:0;transform:translateY(6px);color:rgba(125,211,252,.74);font-size:10px;line-height:1;
+    padding:4px 6px;border-radius:6px;background:rgba(125,211,252,.08);border:1px solid rgba(125,211,252,.14);
+    transition:opacity .55s ease,transform .55s ease}
+  .context.compose .shard{opacity:.72;transform:translateY(0)}
+  .context.merge .tool{opacity:.2;transform:translate(-50%,-10px) scale(.97);filter:blur(.5px)}
+  .merge{position:absolute;left:50%;top:65%;opacity:0;transform:translate(-50%,10px);
+    color:rgba(125,211,252,.62);font-size:11px;letter-spacing:.08em;white-space:nowrap;
+    transition:opacity .7s ease,transform .7s ease}
+  .context.merge .merge{opacity:.58;transform:translate(-50%,0)}
+  .context.leaving .task,.context.leaving .tool,.context.leaving .merge{
+    opacity:0;transform:translate(-50%,-34px) scale(.94);filter:blur(2px)}
+  @media (max-width:700px){
+    .task,.merge{max-width:calc(100vw - 32px);overflow:hidden;text-overflow:ellipsis}
+    .tool{width:138px;max-width:44vw;padding:7px 8px}
+    .head{gap:8px;font-size:10px}
+    .shard{font-size:9px;padding:3px 5px}
+    .merge{top:56%}
+  }
   .enter{position:fixed;left:50%;top:calc(50% + 150px);transform:translate(-50%,10px);
     opacity:0;pointer-events:none;z-index:18;font-family:var(--mono);font-size:13px;
     color:var(--fg);background:rgba(255,255,255,.06);border:1px solid rgba(125,211,252,.34);
@@ -80,9 +108,9 @@
 <body>
   <canvas id="c"></canvas>
   <div class="context" id="context"></div>
-  <div class="tag" id="tag">frontend · design · ai-agent</div>
+  <div class="tag" id="tag">agent runtime · tool loop · content merge</div>
   <button class="enter" id="enter">进入 ~/joye →</button>
-  <div class="trace" id="trace">context loaded · tools ready · welcome back</div>
+  <div class="trace" id="trace">agent loop complete · context merged</div>
 
   <div class="hero" id="hero">
     <div class="card">
@@ -107,12 +135,52 @@ const enter = document.getElementById('enter');
 const trace = document.getElementById('trace');
 const hero = document.getElementById('hero');
 const reduce = matchMedia('(prefers-reduced-motion:reduce)').matches;
-let W,H,DPR, particles=[], mouse={x:-1e9,y:-1e9}, phase='gather', raf, t0, scatterAt=0, enterShown=false, autoExit=0, contextTimer=0;
+let W,H,DPR, particles=[], mouse={x:-1e9,y:-1e9}, phase='gather', raf, t0, scatterAt=0, enterShown=false, autoExit=0;
 
-const TOKENS=['context','planner','tools','memory','eval','rag','multi-agent','openharness','frontend','design','ship','notes','search','trace','typescript','cursor'];
-const POS=[[10,18],[24,12],[43,16],[62,11],[80,19],[14,38],[30,31],[68,34],[84,42],[18,66],[36,76],[55,71],[75,66],[8,82],[48,88],[87,82]];
-TOKENS.forEach((text,i)=>{ const s=document.createElement('span'); s.className='token'; s.textContent=text;
-  s.style.left=POS[i][0]+'%'; s.style.top=POS[i][1]+'%'; s.style.transitionDelay=(i*.045)+'s'; context.appendChild(s); });
+const TOOLS=[
+  { call:'agent.runtime()', shards:['plan','loop'], pos:[50,15] },
+  { call:'mcp.filesystem()', shards:['posts','projects'], pos:[22,27] },
+  { call:'mcp.github()', shards:['OpenHarness','ship log'], pos:[78,29] },
+  { call:'memory.search()', shards:['design taste','frontend'], pos:[22,56] },
+  { call:'examples.unitize()', shards:['tool call','UI case'], pos:[78,56] },
+  { call:'merge_context()', shards:['identity','JOYE'], pos:[50,82] }
+];
+const task=document.createElement('div');
+task.className='task';
+task.textContent='task: compose joye.dev/home';
+context.appendChild(task);
+TOOLS.forEach((item,i)=>{
+  const tool=document.createElement('div');
+  tool.className='tool';
+  tool.style.left=item.pos[0]+'%';
+  tool.style.top=item.pos[1]+'%';
+  tool.style.transitionDelay=(.12+i*.08)+'s';
+  const head=document.createElement('div');
+  head.className='head';
+  const call=document.createElement('span');
+  call.className='call';
+  call.textContent=item.call;
+  const status=document.createElement('span');
+  status.className='status';
+  status.textContent='ok';
+  head.append(call,status);
+  tool.appendChild(head);
+  const shards=document.createElement('div');
+  shards.className='shards';
+  item.shards.forEach((text,j)=>{
+    const shard=document.createElement('span');
+    shard.className='shard';
+    shard.textContent=text;
+    shard.style.transitionDelay=(.24+i*.07+j*.08)+'s';
+    shards.appendChild(shard);
+  });
+  tool.appendChild(shards);
+  context.appendChild(tool);
+});
+const merge=document.createElement('div');
+merge.className='merge';
+merge.textContent='merge: context shards → JOYE';
+context.appendChild(merge);
 
 function vw(){ return innerWidth || document.documentElement.clientWidth || 1280; }
 function vh(){ return innerHeight || document.documentElement.clientHeight || 800; }
@@ -169,7 +237,7 @@ function buildTargets(){
   while(particles.length < pts.length){
     particles.push({
       x: Math.random()*W, y: Math.random()*H,
-      vx:0, vy:0, tx:0, ty:0,
+      vx:0, vy:0, tx:0, ty:0, sx:0, sy:0,
       r: (Math.random()*0.9+0.7)*DPR,
       hue: Math.random(), tw: Math.random()*Math.PI*2,
       delay:0, drift:Math.random()*Math.PI*2
@@ -178,7 +246,13 @@ function buildTargets(){
   particles.length = pts.length;
   // assign nearest-ish targets (shuffle for organic look)
   pts.sort(()=> Math.random()-0.5);
-  particles.forEach((p,i)=>{ p.tx=pts[i].x; p.ty=pts[i].y; p.delay=.2+(i%6)*.18+Math.random()*1.25; });
+  particles.forEach((p,i)=>{
+    const source = TOOLS[i % TOOLS.length].pos;
+    p.tx=pts[i].x; p.ty=pts[i].y;
+    p.sx=W*source[0]/100+(Math.random()-.5)*150*DPR;
+    p.sy=H*source[1]/100+(Math.random()-.5)*76*DPR;
+    p.delay=.9+(i%TOOLS.length)*.16+Math.random()*.85;
+  });
 }
 
 function color(p, a){
@@ -196,16 +270,32 @@ function frame(ts){
   ctx.clearRect(0,0,W,H);
 
   // phase transitions
-  if(phase==='gather' && el>3.15) phase='hold';
-  if(el>2.35 && phase!=='scatter') context.classList.add('folding');
-  if(phase==='hold' && el>4.05) showEnter();
+  if(el>.12) context.classList.add('start');
+  if(el>.72) context.classList.add('invoke');
+  if(el>1.55) context.classList.add('compose');
+  if(el>2.95 && phase!=='scatter') context.classList.add('merge');
+  if(phase==='gather' && el>3.7) phase='hold';
+  if(phase==='hold' && el>4.35) showEnter();
   if(phase==='scatter' && !scatterAt) scatterAt = ts;
   const scatterAge = scatterAt ? (ts-scatterAt)/1000 : 0;
-  if(phase==='scatter' && ts-scatterAt>1600 && !hero.classList.contains('show')){
+  if(phase==='scatter' && ts-scatterAt>900 && !hero.classList.contains('show')){
     hero.classList.add('show');
   }
 
   const ease = phase==='gather' ? 0.045 : phase==='hold' ? 0.11 : 0.018;
+  if(phase!=='scatter' && el>.72){
+    let linkFade = Math.min(1, (el-.72)/.75);
+    if(el>2.85) linkFade *= Math.max(.18, 1-(el-2.85)/1.2);
+    ctx.lineWidth = DPR*.7;
+    for(const tool of TOOLS){
+      const [x,y]=tool.pos;
+      ctx.strokeStyle = `rgba(125,211,252,${.085*linkFade})`;
+      ctx.beginPath();
+      ctx.moveTo(W*x/100,H*y/100);
+      ctx.quadraticCurveTo(W/2,H*.35,W/2,H*.47);
+      ctx.stroke();
+    }
+  }
 
   // constellation links (only while formed-ish)
   if(phase==='gather' || phase==='hold'){
@@ -230,7 +320,7 @@ function frame(ts){
       p.vx += (Math.random()-0.5)*0.16*DPR + odx*.09*DPR;
       p.vy += ((Math.random()-0.5)*0.08 - 0.11)*DPR;
     }else{
-      const pull = phase==='hold' ? 1 : Math.max(0, Math.min(1, (el-p.delay)/1.55));
+      const pull = phase==='hold' ? 1 : Math.max(0, Math.min(1, (el-p.delay)/2.05));
       if(pull<1){ p.vx += Math.sin(el*.9+p.drift)*.012*DPR; p.vy += Math.cos(el*.7+p.drift)*.012*DPR; }
       const localEase = ease * (.2 + pull*.8);
       p.vx += (p.tx - p.x)*localEase*pull;
@@ -248,9 +338,10 @@ function frame(ts){
 
     const near = (p.x-p.tx)**2+(p.y-p.ty)**2 < (8*DPR)**2;
     const tw = 0.55 + Math.sin(p.tw)*0.25;
-    const fade = phase==='scatter' ? Math.max(0, 1 - scatterAge/2.4) : 1;
+    const fade = phase==='scatter' ? Math.max(0, 1 - scatterAge/1.45) : 1;
+    const born = (phase==='scatter' || phase==='hold') ? 1 : Math.max(0, Math.min(1, (el-p.delay+.28)/.55));
     const a = phase==='scatter' ? 0.6 * fade
-            : (near ? 0.95 : 0.7) * tw;
+            : (near ? 0.95 : 0.7) * tw * born;
     ctx.beginPath();
     ctx.fillStyle = color(p, Math.min(1,a));
     ctx.arc(p.x,p.y, p.r*(near?1.25:1)*(phase==='scatter' ? .95 + scatterAge*.08 : 1), 0, 7);
@@ -270,7 +361,7 @@ function frame(ts){
 function showEnter(){
   if(enterShown || phase==='scatter') return;
   enterShown = true;
-  context.classList.add('folding');
+  context.classList.add('merge');
   enter.classList.add('show');
   trace.classList.add('show');
   clearTimeout(autoExit);
@@ -281,7 +372,6 @@ function enterSite(){
   if(phase==='scatter') return;
   phase='scatter';
   scatterAt=0;
-  context.classList.remove('show');
   context.classList.add('leaving');
   enter.classList.remove('show');
   trace.classList.remove('show');
@@ -292,13 +382,10 @@ function start(){
   cancelAnimationFrame(raf);
   resize(); particles=[]; buildTargets();
   if(particles.length === 0){ setTimeout(start, 120); return; } // viewport not ready yet
-  // scatter start positions outward
-  particles.forEach(p=>{ const ang=Math.random()*7; const rad=Math.max(W,H);
-    p.x=W/2+Math.cos(ang)*rad; p.y=H/2+Math.sin(ang)*rad; });
-  phase='gather'; t0=0; scatterAt=0; enterShown=false; clearTimeout(autoExit); clearTimeout(contextTimer);
+  particles.forEach(p=>{ p.x=p.sx; p.y=p.sy; p.vx=(Math.random()-.5)*DPR; p.vy=(Math.random()-.5)*DPR; });
+  phase='gather'; t0=0; scatterAt=0; enterShown=false; clearTimeout(autoExit);
   hero.classList.remove('show'); tag.classList.remove('show'); enter.classList.remove('show'); trace.classList.remove('show');
-  context.classList.remove('show','folding','leaving');
-  contextTimer=setTimeout(()=>context.classList.add('show'),120);
+  context.classList.remove('start','invoke','compose','merge','leaving');
   if(reduce){ hero.classList.add('show'); return; }
   raf=requestAnimationFrame(frame);
 }
@@ -309,7 +396,7 @@ function boot(){
   } else start();
 }
 
-function skip(){ cancelAnimationFrame(raf); clearTimeout(autoExit); clearTimeout(contextTimer); ctx.clearRect(0,0,W,H); tag.classList.remove('show'); enter.classList.remove('show'); trace.classList.remove('show'); context.classList.remove('show','folding','leaving'); hero.classList.add('show'); }
+function skip(){ cancelAnimationFrame(raf); clearTimeout(autoExit); ctx.clearRect(0,0,W,H); tag.classList.remove('show'); enter.classList.remove('show'); trace.classList.remove('show'); context.classList.remove('start','invoke','compose','merge','leaving'); hero.classList.add('show'); }
 
 enter.onclick = enterSite;
 document.getElementById('skip').onclick = skip;

--- a/demos/intro/index.html
+++ b/demos/intro/index.html
@@ -80,6 +80,16 @@
           <div class="play">▶ 全屏播放</div>
         </div>
       </a>
+
+      <a class="card" href="./multi-agent.html">
+        <div class="thumb t2"><div class="dots"></div><span class="mono">orchestrator ◦ planner ◦ judge</span></div>
+        <div class="meta">
+          <div class="tagk">动画三（新）· 最对口</div>
+          <h3>Multi-Agent · 编排</h3>
+          <p>带标签的 agent 节点冒出、连边、消息沿边流动「协作」，收敛后炸成粒子拼出 JOYE。把你做 Multi-Agent 这件事本身变成片头。</p>
+          <div class="play">▶ 全屏播放</div>
+        </div>
+      </a>
     </div>
 
     <div class="note">

--- a/demos/intro/index.html
+++ b/demos/intro/index.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Joye · 入场动画方案</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --bg:#0f1419;--fg:#faf9f8;--muted:#9aa6b2;--cyan:#7dd3fc;--steel:#659eb9;
+    --mono:'JetBrains Mono',ui-monospace,Menlo,monospace;--sans:'Inter','Satoshi',system-ui,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;min-height:100vh;background:radial-gradient(120% 90% at 50% 0%,#141c25,#0b0f14 65%);
+    color:var(--fg);font-family:var(--sans);padding:64px 24px 80px}
+  .wrap{max-width:1040px;margin:0 auto}
+  h1{font-size:clamp(28px,5vw,46px);font-weight:900;letter-spacing:-.03em;margin:0 0 8px}
+  .sub{color:var(--muted);font-family:var(--mono);font-size:14px;margin-bottom:42px}
+  .sub b{color:var(--cyan);font-weight:500}
+  .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:20px}
+  a.card{display:flex;flex-direction:column;text-decoration:none;color:inherit;
+    border:1px solid rgba(255,255,255,.08);border-radius:16px;overflow:hidden;
+    background:rgba(255,255,255,.02);transition:.25s;min-height:260px}
+  a.card:hover{border-color:rgba(125,211,252,.45);transform:translateY(-4px);
+    box-shadow:0 24px 60px -24px rgba(0,0,0,.7),0 0 0 1px rgba(125,211,252,.1)}
+  .thumb{height:150px;display:grid;place-items:center;position:relative;overflow:hidden;
+    border-bottom:1px solid rgba(255,255,255,.06)}
+  .t1{background:radial-gradient(60% 80% at 50% 40%,rgba(125,211,252,.12),transparent),#0d1218}
+  .t2{background:radial-gradient(60% 80% at 50% 50%,rgba(101,158,185,.18),transparent),#0b0f14}
+  .t3{background:linear-gradient(100deg,#0d1218,#101822)}
+  .thumb .mono{font-family:var(--mono);font-size:12px;color:var(--cyan)}
+  .thumb .big{font-weight:900;font-size:40px;letter-spacing:-.03em;
+    background:linear-gradient(90deg,var(--steel),var(--cyan));-webkit-background-clip:text;background-clip:text;color:transparent}
+  .dots{position:absolute;inset:0;background-image:radial-gradient(rgba(125,211,252,.5) 1px,transparent 1px);
+    background-size:13px 13px;opacity:.35;mask:radial-gradient(60% 60% at 50% 50%,#000,transparent)}
+  .meta{padding:18px 20px 20px}
+  .tagk{font-family:var(--mono);font-size:11px;color:var(--cyan);text-transform:uppercase;letter-spacing:.14em}
+  .meta h3{margin:8px 0 6px;font-size:19px;font-weight:800}
+  .meta p{margin:0;color:var(--muted);font-size:13.5px;line-height:1.6}
+  .play{margin-top:14px;font-family:var(--mono);font-size:12px;color:var(--fg);opacity:.7}
+  .note{margin-top:40px;color:var(--muted);font-size:13px;font-family:var(--mono);line-height:1.9;
+    border-top:1px solid rgba(255,255,255,.07);padding-top:22px}
+  .note b{color:var(--cyan);font-weight:500}
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>入场动画 · 三个方向</h1>
+    <div class="sub">深色模式预览 · 点任意卡片 <b>全屏播放</b> · 每个都以「化解进入真实 hero」收尾</div>
+
+    <div class="grid">
+      <a class="card" href="./terminal-boot.html">
+        <div class="thumb t1"><span class="mono">$ ./joye --init ▋</span></div>
+        <div class="meta">
+          <div class="tagk">最贴合你 · dev 气质</div>
+          <h3>joye.init() · 终端开机</h3>
+          <p>复用你已有的终端/CRT 身份：开机自检式逐行打字、ASCII 名字、扫描线，最后终端「化开」进入站点。这只可能是你的站。</p>
+          <div class="play">▶ 全屏播放</div>
+        </div>
+      </a>
+
+      <a class="card" href="./constellation.html">
+        <div class="thumb t2"><div class="dots"></div><span class="big">JOYE</span></div>
+        <div class="meta">
+          <div class="tagk">最出片 · 路人也 wow</div>
+          <h3>Constellation · 粒子聚合</h3>
+          <p>钢蓝/青色粒子从四周汇聚拼出 JOYE，带星座连线，鼠标可推开互动；停留后炸散、hero 浮现。Canvas 功底直接拉满。</p>
+          <div class="play">▶ 全屏播放</div>
+        </div>
+      </a>
+
+      <a class="card" href="./kinetic-type.html">
+        <div class="thumb t3"><span class="big" style="font-size:30px">FRONTEND × AI</span></div>
+        <div class="meta">
+          <div class="tagk">最设计师 · 编辑感</div>
+          <h3>Kinetic Type · 动态排版</h3>
+          <p>FRONTEND→DESIGN→×AI→JOYE 逐词擦入，变量字体随入场由细变粗，钢蓝光带横扫「刷」出文字。一眼「我是做设计出身的」。</p>
+          <div class="play">▶ 全屏播放</div>
+        </div>
+      </a>
+    </div>
+
+    <div class="note">
+      <b>说明</b> · 这些是独立 demo，<b>还没接进站点</b>，只为给你看方向。<br>
+      · 字体用了 Inter 顶替 Satoshi（本地 demo 加载不到站内字体），真接入时换回 Satoshi。<br>
+      · 头像引用了仓库里的真实 avatar.png（相对路径）。<br>
+      · 三个都做了：<b>跳过 / 重播</b> 控件、<b>prefers-reduced-motion</b> 降级（直接显示 hero）。<br>
+      · 真接入时会做成<b>每次会话只播一次</b>（sessionStorage），老访客不被打扰。
+    </div>
+  </div>
+</body>
+</html>

--- a/demos/intro/index.html
+++ b/demos/intro/index.html
@@ -66,7 +66,7 @@
         <div class="meta">
           <div class="tagk">最出片 · 路人也 wow</div>
           <h3>Constellation · 粒子聚合</h3>
-          <p>Agent 关键词像上下文一样浮现，钢蓝/青色粒子分批汇聚拼出 JOYE；成形后点击进入，粒子向上自然消散。更像你的博客入口。</p>
+          <p>把入场改成一次 Agent run：接收任务、调用 MCP / Tool、生成内容碎片、合并成 JOYE；成形后点击进入，粒子向上自然消散。</p>
           <div class="play">▶ 全屏播放</div>
         </div>
       </a>

--- a/demos/intro/index.html
+++ b/demos/intro/index.html
@@ -47,8 +47,8 @@
 </head>
 <body>
   <div class="wrap">
-    <h1>入场动画 · 三个方向</h1>
-    <div class="sub">深色模式预览 · 点任意卡片 <b>全屏播放</b> · 每个都以「化解进入真实 hero」收尾</div>
+    <h1>入场动画 · 四个方向</h1>
+    <div class="sub">深色模式预览 · 点任意卡片 <b>全屏播放</b> · 真实站点里通过 Tweak 面板切换评审</div>
 
     <div class="grid">
       <a class="card" href="./terminal-boot.html">
@@ -66,7 +66,7 @@
         <div class="meta">
           <div class="tagk">最出片 · 路人也 wow</div>
           <h3>Constellation · 粒子聚合</h3>
-          <p>钢蓝/青色粒子从四周汇聚拼出 JOYE，带星座连线，鼠标可推开互动；停留后炸散、hero 浮现。Canvas 功底直接拉满。</p>
+          <p>Agent 关键词像上下文一样浮现，钢蓝/青色粒子分批汇聚拼出 JOYE；成形后点击进入，粒子向上自然消散。更像你的博客入口。</p>
           <div class="play">▶ 全屏播放</div>
         </div>
       </a>
@@ -84,7 +84,7 @@
       <a class="card" href="./multi-agent.html">
         <div class="thumb t2"><div class="dots"></div><span class="mono">orchestrator ◦ planner ◦ judge</span></div>
         <div class="meta">
-          <div class="tagk">动画三（新）· 最对口</div>
+          <div class="tagk">动画四 · 最对口</div>
           <h3>Multi-Agent · 编排</h3>
           <p>带标签的 agent 节点冒出、连边、消息沿边流动「协作」，收敛后炸成粒子拼出 JOYE。把你做 Multi-Agent 这件事本身变成片头。</p>
           <div class="play">▶ 全屏播放</div>
@@ -93,10 +93,10 @@
     </div>
 
     <div class="note">
-      <b>说明</b> · 这些是独立 demo，<b>还没接进站点</b>，只为给你看方向。<br>
+      <b>说明</b> · 这些是独立 demo，同时也都已接进真实站点的 IntroOverlay 变体，方便你全屏细看和站内评审。<br>
       · 字体用了 Inter 顶替 Satoshi（本地 demo 加载不到站内字体），真接入时换回 Satoshi。<br>
       · 头像引用了仓库里的真实 avatar.png（相对路径）。<br>
-      · 三个都做了：<b>跳过 / 重播</b> 控件、<b>prefers-reduced-motion</b> 降级（直接显示 hero）。<br>
+      · 四个都做了：<b>跳过 / 重播</b> 控件、<b>prefers-reduced-motion</b> 降级（直接显示 hero）。<br>
       · 真接入时会做成<b>每次会话只播一次</b>（sessionStorage），老访客不被打扰。
     </div>
   </div>

--- a/demos/intro/kinetic-type.html
+++ b/demos/intro/kinetic-type.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Intro · Kinetic Type</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --bg:#0f1419;--fg:#faf9f8;--muted:#9aa6b2;--cyan:#7dd3fc;--steel:#659eb9;--ok:#41d18a;
+    --mono:'JetBrains Mono',ui-monospace,Menlo,monospace;
+    --sans:'Inter','Satoshi',system-ui,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%;margin:0}
+  body{background:var(--bg);color:var(--fg);font-family:var(--sans);overflow:hidden}
+
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.5;mix-blend-mode:soft-light;
+    background:repeating-linear-gradient(0deg,rgba(255,255,255,.03) 0 1px,transparent 1px 3px)}
+  .glow{position:fixed;inset:-20%;pointer-events:none;
+    background:radial-gradient(45% 45% at 50% 45%,rgba(125,211,252,.08),transparent 70%)}
+
+  /* word stage */
+  .seq{position:fixed;inset:0;display:grid;place-items:center;overflow:hidden}
+  .word{position:absolute;font-weight:900;letter-spacing:-.03em;line-height:.9;
+    font-size:clamp(56px,13vw,180px);will-change:transform,opacity;
+    display:flex;gap:.02em}
+  .word .ch{display:inline-block;opacity:0;transform:translateY(.9em);
+    font-variation-settings:'wght' 200;}
+  .word.in .ch{animation:rise .62s cubic-bezier(.16,1,.3,1) forwards}
+  @keyframes rise{
+    0%{opacity:0;transform:translateY(.9em);font-variation-settings:'wght' 150}
+    60%{opacity:1}
+    100%{opacity:1;transform:translateY(0);font-variation-settings:'wght' 850}
+  }
+  .word.out{animation:leave .5s cubic-bezier(.7,0,.84,0) forwards}
+  @keyframes leave{to{opacity:0;transform:translateY(-.35em);filter:blur(6px)}}
+  .accent{color:var(--cyan)}
+  .thin{font-weight:200;font-variation-settings:'wght' 280}
+
+  /* the wipe bar that sweeps across to "deposit" type */
+  .bar{position:fixed;top:0;bottom:0;width:42vw;left:-46vw;z-index:5;pointer-events:none;
+    background:linear-gradient(90deg,transparent,rgba(125,211,252,.0) 30%,rgba(125,211,252,.16),rgba(101,158,185,.5) 92%,var(--cyan));
+    box-shadow:0 0 80px 20px rgba(125,211,252,.18)}
+  .bar.go{animation:wipe 1.05s cubic-bezier(.7,0,.2,1) forwards}
+  @keyframes wipe{to{left:104vw}}
+
+  .kick{position:fixed;left:0;right:0;top:calc(50% + 9vw);text-align:center;
+    font-family:var(--mono);font-size:13px;letter-spacing:.34em;text-transform:uppercase;
+    color:var(--muted);opacity:0}
+  .kick.show{animation:kfade .8s ease forwards}
+  @keyframes kfade{to{opacity:.85}}
+
+  /* hero reveal */
+  .hero{position:fixed;inset:0;display:grid;place-items:center;opacity:0;pointer-events:none}
+  .hero.show{opacity:1;pointer-events:auto;transition:opacity 1s ease}
+  .card{display:flex;flex-direction:column;align-items:center;gap:18px;text-align:center}
+  .avatar{width:112px;height:112px;border-radius:50%;padding:4px;
+    border:1px solid rgba(255,255,255,.14);object-fit:cover;
+    background:conic-gradient(from 210deg,var(--steel),var(--cyan),var(--steel));
+    box-shadow:0 0 46px rgba(125,211,252,.28)}
+  .name{font-weight:800;font-size:34px;letter-spacing:-.02em;margin:0}
+  .meta{color:var(--muted);font-family:var(--mono);font-size:13px;display:flex;gap:14px}
+  .ital{color:var(--cyan);font-style:italic;font-size:15px}
+  .pill{display:inline-flex;align-items:center;gap:9px;padding:9px 16px;border-radius:999px;
+    border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.03);font-size:14px;
+    color:var(--fg);text-decoration:none;transition:.2s}
+  .pill:hover{border-color:rgba(125,211,252,.4);box-shadow:0 0 0 4px rgba(125,211,252,.08)}
+  .ping{position:relative;width:9px;height:9px}
+  .ping i{position:absolute;inset:0;border-radius:50%;background:var(--ok)}
+  .ping i:first-child{animation:ping 1.4s cubic-bezier(0,0,.2,1) infinite}
+  @keyframes ping{75%,100%{transform:scale(2.4);opacity:0}}
+  .card>*{opacity:0;transform:translateY(14px)}
+  .hero.show .card>*{animation:up .7s cubic-bezier(.2,.7,.2,1) forwards}
+  .hero.show .card>*:nth-child(1){animation-delay:.05s}
+  .hero.show .card>*:nth-child(2){animation-delay:.16s}
+  .hero.show .card>*:nth-child(3){animation-delay:.26s}
+  .hero.show .card>*:nth-child(4){animation-delay:.36s}
+  .hero.show .card>*:nth-child(5){animation-delay:.46s}
+  @keyframes up{to{opacity:1;transform:none}}
+
+  .ctl{position:fixed;bottom:18px;right:18px;display:flex;gap:10px;z-index:20;font-family:var(--mono);font-size:12px}
+  .ctl button{background:rgba(255,255,255,.04);color:var(--muted);border:1px solid rgba(255,255,255,.1);
+    padding:7px 12px;border-radius:8px;cursor:pointer;transition:.2s}
+  .ctl button:hover{color:var(--fg);border-color:rgba(125,211,252,.4)}
+  .hint{position:fixed;bottom:20px;left:20px;font-family:var(--mono);font-size:12px;color:rgba(154,166,178,.5);z-index:20}
+</style>
+</head>
+<body>
+  <div class="glow"></div>
+  <div class="grain"></div>
+  <div class="bar" id="bar"></div>
+
+  <div class="seq" id="seq"></div>
+  <div class="kick" id="kick">Joye · personal site</div>
+
+  <div class="hero" id="hero">
+    <div class="card">
+      <img class="avatar" src="../../src/assets/avatar.png" alt="Joye" onerror="this.removeAttribute('src')" />
+      <h1 class="name">Joye</h1>
+      <div class="meta"><span>📍 Melbourne, Australia</span><span>· GitHub</span></div>
+      <div class="ital">“Stay hungry, stay foolish.”</div>
+      <a class="pill" href="javascript:void 0"><span class="ping"><i></i><i></i></span> Connect Me!</a>
+    </div>
+  </div>
+
+  <div class="hint">这是入场动画演示 · 变量字体重量随入场变化</div>
+  <div class="ctl"><button id="skip">跳过 →</button><button id="replay">重播 ↻</button></div>
+
+<script>
+const seq = document.getElementById('seq');
+const bar = document.getElementById('bar');
+const kick = document.getElementById('kick');
+const hero = document.getElementById('hero');
+const reduce = matchMedia('(prefers-reduced-motion:reduce)').matches;
+let timers=[];
+const sleep = ms => new Promise(r=>timers.push(setTimeout(r, reduce?ms*0.2:ms)));
+
+// each item: array of {t:text, c:class}
+const WORDS = [
+  [{t:'FRONT'},{t:'END',c:'accent'}],
+  [{t:'DESIGN'}],
+  [{t:'×',c:'thin'},{t:' AI',c:'accent'}],
+  [{t:'JOYE'}],
+];
+
+function makeWord(parts){
+  const w=document.createElement('div'); w.className='word';
+  parts.forEach(p=>{
+    const span=document.createElement('span');
+    if(p.c) span.className=p.c;
+    [...p.t].forEach((ch,i)=>{
+      const c=document.createElement('span'); c.className='ch';
+      c.textContent = ch===' ' ? ' ' : ch;
+      c.style.animationDelay = (i*0.045)+'s';
+      span.append(c);
+    });
+    w.append(span);
+  });
+  return w;
+}
+
+async function showWord(parts, hold=820, last=false){
+  const w = makeWord(parts); seq.append(w);
+  // fire wipe bar in sync
+  bar.classList.remove('go'); void bar.offsetWidth; bar.classList.add('go');
+  await sleep(140);
+  w.classList.add('in');
+  await sleep(hold);
+  if(!last){ w.classList.add('out'); await sleep(420); w.remove(); }
+  return w;
+}
+
+async function run(){
+  seq.innerHTML=''; hero.classList.remove('show'); kick.classList.remove('show');
+  await sleep(250);
+  await showWord(WORDS[0], 760);
+  await showWord(WORDS[1], 640);
+  await showWord(WORDS[2], 720);
+  const j = await showWord(WORDS[3], 900, true);
+  kick.classList.add('show');
+  await sleep(900);
+  // resolve into hero
+  j.classList.add('out'); kick.classList.remove('show');
+  await sleep(360);
+  hero.classList.add('show');
+}
+
+function skip(){ timers.forEach(clearTimeout); timers=[]; seq.innerHTML=''; kick.classList.remove('show'); hero.classList.add('show'); }
+document.getElementById('skip').onclick = skip;
+document.getElementById('replay').onclick = ()=>{ timers.forEach(clearTimeout); timers=[]; run(); };
+if(reduce){ hero.classList.add('show'); } else { run(); }
+</script>
+</body>
+</html>

--- a/demos/intro/multi-agent.html
+++ b/demos/intro/multi-agent.html
@@ -1,0 +1,267 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Intro · Multi-Agent</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --bg:#0f1419;--fg:#faf9f8;--muted:#9aa6b2;--cyan:#7dd3fc;--steel:#659eb9;--ok:#41d18a;
+    --mono:'JetBrains Mono',ui-monospace,Menlo,monospace;
+    --sans:'Inter','Satoshi',system-ui,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%;margin:0}
+  body{background:radial-gradient(120% 120% at 50% 38%,#121a22,#0a0e13 70%);color:var(--fg);
+    font-family:var(--sans);overflow:hidden}
+  canvas{position:fixed;inset:0;display:block}
+
+  .cap{position:fixed;left:0;right:0;top:7%;text-align:center;font-family:var(--mono);
+    font-size:12.5px;letter-spacing:.22em;color:var(--cyan);opacity:0;text-transform:uppercase}
+  .cap.show{animation:fade .8s ease forwards}
+  @keyframes fade{to{opacity:.8}}
+
+  .hero{position:fixed;inset:0;display:grid;place-items:center;opacity:0;pointer-events:none}
+  .hero.show{opacity:1;pointer-events:auto;transition:opacity 1s ease}
+  .card{display:flex;flex-direction:column;align-items:center;gap:18px;text-align:center}
+  .avatar{width:112px;height:112px;border-radius:50%;padding:4px;
+    border:1px solid rgba(255,255,255,.14);object-fit:cover;
+    background:conic-gradient(from 210deg,var(--steel),var(--cyan),var(--steel));
+    box-shadow:0 0 50px rgba(125,211,252,.3)}
+  .name{font-weight:800;font-size:34px;letter-spacing:-.02em;margin:0}
+  .meta{color:var(--muted);font-family:var(--mono);font-size:13px;display:flex;gap:14px}
+  .ital{color:var(--cyan);font-style:italic;font-size:15px}
+  .pill{display:inline-flex;align-items:center;gap:9px;padding:9px 16px;border-radius:999px;
+    border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.03);font-size:14px;
+    color:var(--fg);text-decoration:none;transition:.2s}
+  .pill:hover{border-color:rgba(125,211,252,.4);box-shadow:0 0 0 4px rgba(125,211,252,.08)}
+  .ping{position:relative;width:9px;height:9px}
+  .ping i{position:absolute;inset:0;border-radius:50%;background:var(--ok)}
+  .ping i:first-child{animation:ping 1.4s cubic-bezier(0,0,.2,1) infinite}
+  @keyframes ping{75%,100%{transform:scale(2.4);opacity:0}}
+  .card>*{opacity:0;transform:translateY(14px)}
+  .hero.show .card>*{animation:up .7s cubic-bezier(.2,.7,.2,1) forwards}
+  .hero.show .card>*:nth-child(1){animation-delay:.05s}
+  .hero.show .card>*:nth-child(2){animation-delay:.16s}
+  .hero.show .card>*:nth-child(3){animation-delay:.26s}
+  .hero.show .card>*:nth-child(4){animation-delay:.36s}
+  .hero.show .card>*:nth-child(5){animation-delay:.46s}
+  @keyframes up{to{opacity:1;transform:none}}
+
+  .ctl{position:fixed;bottom:18px;right:18px;display:flex;gap:10px;z-index:20;font-family:var(--mono);font-size:12px}
+  .ctl button{background:rgba(255,255,255,.04);color:var(--muted);border:1px solid rgba(255,255,255,.1);
+    padding:7px 12px;border-radius:8px;cursor:pointer;transition:.2s}
+  .ctl button:hover{color:var(--fg);border-color:rgba(125,211,252,.4)}
+  .hint{position:fixed;bottom:20px;left:20px;font-family:var(--mono);font-size:12px;color:rgba(154,166,178,.5);z-index:20}
+</style>
+</head>
+<body>
+  <canvas id="c"></canvas>
+  <div class="cap" id="cap">multi-agent runtime</div>
+
+  <div class="hero" id="hero">
+    <div class="card">
+      <img class="avatar" src="../../src/assets/avatar.png" alt="Joye" onerror="this.removeAttribute('src')" />
+      <h1 class="name">Joye</h1>
+      <div class="meta"><span>📍 Melbourne, Australia</span><span>· GitHub</span></div>
+      <div class="ital">“Stay hungry, stay foolish.”</div>
+      <a class="pill" href="javascript:void 0"><span class="ping"><i></i><i></i></span> Connect Me!</a>
+    </div>
+  </div>
+
+  <div class="hint">这是入场动画演示 · 动画三候选 · Multi-Agent 编排</div>
+  <div class="ctl"><button id="skip">跳过 →</button><button id="replay">重播 ↻</button></div>
+
+<script>
+const cv = document.getElementById('c');
+const ctx = cv.getContext('2d');
+const cap = document.getElementById('cap');
+const hero = document.getElementById('hero');
+const reduce = matchMedia('(prefers-reduced-motion:reduce)').matches;
+let W,H,DPR, raf, t0=0;
+let nodes=[], edges=[], messages=[], schedule=[], schedPtr=0, parts=[], joyePts=[], converged=false, heroShown=false;
+
+const ROLES = ['planner','router','search','code','memory','judge','tool','writer'];
+
+function vw(){ return innerWidth||document.documentElement.clientWidth||1280; }
+function vh(){ return innerHeight||document.documentElement.clientHeight||800; }
+function resize(){
+  DPR=Math.min(devicePixelRatio||1,2);
+  W=cv.width=Math.round(vw()*DPR); H=cv.height=Math.round(vh()*DPR);
+  cv.style.width=vw()+'px'; cv.style.height=vh()+'px';
+}
+addEventListener('resize', ()=>{ if(!converged){ resize(); buildGraph(); } });
+
+function buildGraph(){
+  nodes=[]; edges=[];
+  const cx=W/2, cy=H*0.45, R=Math.min(W,H)*0.30;
+  // orchestrator (index 0)
+  nodes.push({ x:cx, y:cy, hx:cx, hy:cy, label:'orchestrator', hub:true, act:0, appear:0.0, r:7*DPR });
+  // workers on a ring
+  for(let i=0;i<ROLES.length;i++){
+    const a = (-Math.PI/2) + i/ROLES.length*Math.PI*2;
+    const jitter = (Math.sin(i*12.9)*0.5)*R*0.10;
+    const x=cx+Math.cos(a)*(R+jitter), y=cy+Math.sin(a)*(R+jitter);
+    nodes.push({ x, y, hx:x, hy:y, label:ROLES[i], hub:false, act:0, appear:0.18+i*0.06, r:5.5*DPR });
+  }
+  // edges: hub<->worker
+  for(let i=1;i<nodes.length;i++) edges.push({ a:0, b:i, appear:0.4+i*0.05, lit:0 });
+  // edges: ring between adjacent workers
+  for(let i=1;i<nodes.length;i++){
+    const j = i%ROLES.length + 1;
+    edges.push({ a:i, b:j, appear:0.8+i*0.03, lit:0 });
+  }
+  buildSchedule();
+}
+
+function buildSchedule(){
+  schedule=[]; schedPtr=0;
+  // wave 1 — orchestrator dispatches to every worker
+  for(let i=1;i<nodes.length;i++) schedule.push({ t:0.95+i*0.055, a:0, b:i });
+  // wave 2 — workers cross-talk along the ring
+  for(let i=1;i<nodes.length;i++) schedule.push({ t:1.5+i*0.05, a:i, b:(i%ROLES.length)+1 });
+  // wave 3 — workers report back to orchestrator
+  for(let i=1;i<nodes.length;i++) schedule.push({ t:2.05+i*0.05, a:i, b:0 });
+  schedule.sort((p,q)=>p.t-q.t);
+}
+
+function sampleJOYE(){
+  if(!W||!H) return [];
+  const off=document.createElement('canvas'); off.width=W; off.height=H;
+  const o=off.getContext('2d');
+  o.fillStyle='#fff'; o.textBaseline='middle'; o.textAlign='left';
+  const tracking=0.18; let size=Math.min(H*0.4, W*0.34);
+  const setFont=()=>o.font=`700 ${size}px Inter, system-ui, sans-serif`;
+  setFont();
+  const adv=()=>{ let w=0; for(const ch of 'JOYE') w+=o.measureText(ch).width+size*tracking; return w-size*tracking; };
+  if(adv()>W*0.74){ size*=W*0.74/adv(); setFont(); }
+  let x=(W-adv())/2; const y=H*0.45;
+  for(const ch of 'JOYE'){ o.fillText(ch,x,y); x+=o.measureText(ch).width+size*tracking; }
+  const d=o.getImageData(0,0,W,H).data; const gap=Math.max(5,Math.round(7*DPR)); const pts=[];
+  for(let yy=0;yy<H;yy+=gap) for(let xx=0;xx<W;xx+=gap) if(d[(yy*W+xx)*4+3]>128) pts.push({x:xx,y:yy});
+  return pts;
+}
+
+function spawnMsg(a,b){
+  edges.forEach(e=>{ if((e.a===a&&e.b===b)||(e.a===b&&e.b===a)) e.lit=1; });
+  messages.push({ a, b, t:0, dur:0.5 });
+}
+
+function nodeColor(n, a){
+  return n.hub ? `rgba(125,211,252,${a})` : `rgba(150,200,225,${a})`;
+}
+
+function converge(){
+  converged=true;
+  joyePts=sampleJOYE();
+  parts=[];
+  for(let i=0;i<joyePts.length;i++){
+    const src=nodes[(Math.random()*nodes.length)|0];
+    parts.push({ x:src.x, y:src.y, tx:joyePts[i].x, ty:joyePts[i].y,
+      r:(Math.random()*0.9+0.7)*DPR, k:0, hue:Math.random() });
+  }
+  cap.classList.remove('show');
+}
+
+function frame(ts){
+  if(!t0) t0=ts;
+  const el=(ts-t0)/1000;
+  ctx.clearRect(0,0,W,H);
+
+  if(el>1.4 && !cap.classList.contains('show') && !converged) cap.classList.add('show');
+  if(el>2.6 && !converged) converge();
+  if(converged && el>3.7 && !heroShown){ heroShown=true; hero.classList.add('show'); }
+
+  if(!converged){
+    // fire scheduled messages
+    while(schedPtr<schedule.length && el>=schedule[schedPtr].t){
+      const s=schedule[schedPtr++]; spawnMsg(s.a,s.b);
+    }
+    // edges
+    for(const e of edges){
+      const ap=Math.max(0,Math.min(1,(el-e.appear)/0.5));
+      if(ap<=0) continue;
+      const A=nodes[e.a], B=nodes[e.b];
+      ctx.strokeStyle=`rgba(125,211,252,${(0.10+e.lit*0.35)*ap})`;
+      ctx.lineWidth=(0.7+e.lit*1.2)*DPR;
+      ctx.beginPath(); ctx.moveTo(A.x,A.y); ctx.lineTo(B.x,B.y); ctx.stroke();
+      e.lit*=0.92;
+    }
+    // messages
+    for(const m of messages){
+      m.t+=0.016/m.dur;
+      const A=nodes[m.a], B=nodes[m.b];
+      const e=m.t<1?m.t*m.t*(3-2*m.t):1;
+      const x=A.x+(B.x-A.x)*e, y=A.y+(B.y-A.y)*e;
+      ctx.beginPath(); ctx.fillStyle='rgba(174,232,255,0.95)';
+      ctx.shadowColor='rgba(125,211,252,0.9)'; ctx.shadowBlur=10*DPR;
+      ctx.arc(x,y,2.4*DPR,0,7); ctx.fill(); ctx.shadowBlur=0;
+      if(m.t>=1) nodes[m.b].act=1;
+    }
+    messages=messages.filter(m=>m.t<1);
+    // nodes
+    for(const n of nodes){
+      const ap=Math.max(0,Math.min(1,(el-n.appear)/0.3));
+      if(ap<=0) continue;
+      n.act*=0.94;
+      const rr=n.r*ap*(1+n.act*0.5);
+      // glow
+      if(n.act>0.02){
+        ctx.beginPath(); ctx.fillStyle=`rgba(125,211,252,${0.12*n.act})`;
+        ctx.arc(n.x,n.y,rr*3.4,0,7); ctx.fill();
+      }
+      ctx.beginPath(); ctx.fillStyle='rgba(13,20,28,0.9)';
+      ctx.arc(n.x,n.y,rr,0,7); ctx.fill();
+      ctx.lineWidth=(n.hub?2:1.4)*DPR;
+      ctx.strokeStyle=nodeColor(n,(0.55+n.act*0.45)*ap);
+      ctx.beginPath(); ctx.arc(n.x,n.y,rr,0,7); ctx.stroke();
+      // label
+      ctx.font=`${(n.hub?12:11)*DPR}px ${'JetBrains Mono, monospace'}`;
+      ctx.textAlign='center'; ctx.textBaseline='middle';
+      ctx.fillStyle=`rgba(${n.act>0.3?'200,235,255':'150,166,178'},${(0.5+n.act*0.5)*ap})`;
+      ctx.fillText(n.label, n.x, n.y+rr+11*DPR);
+    }
+  } else {
+    // convergence: nodes fade, particles assemble JOYE
+    const since=(ts-t0)/1000-2.6;
+    const nodeA=Math.max(0,1-since*1.6);
+    if(nodeA>0.02){
+      for(const e of edges){ const A=nodes[e.a],B=nodes[e.b];
+        ctx.strokeStyle=`rgba(125,211,252,${0.08*nodeA})`; ctx.lineWidth=0.7*DPR;
+        ctx.beginPath(); ctx.moveTo(A.x,A.y); ctx.lineTo(B.x,B.y); ctx.stroke(); }
+      for(const n of nodes){ ctx.beginPath(); ctx.fillStyle=nodeColor(n,0.5*nodeA);
+        ctx.arc(n.x,n.y,n.r,0,7); ctx.fill(); }
+    }
+    for(const p of parts){
+      p.k=Math.min(1,p.k+0.045);
+      const e=1-Math.pow(1-p.k,3);
+      p.x+=(p.tx-p.x)*0.12; p.y+=(p.ty-p.y)*0.12;
+      const k=p.x/W; const r=Math.round(101+(125-101)*k), g=Math.round(158+(211-158)*k), b=Math.round(185+(252-185)*k);
+      ctx.beginPath(); ctx.fillStyle=`rgba(${r},${g},${b},${0.6+0.4*e})`;
+      ctx.arc(p.x,p.y,p.r,0,7); ctx.fill();
+    }
+  }
+
+  raf=requestAnimationFrame(frame);
+}
+
+function start(){
+  cancelAnimationFrame(raf);
+  resize();
+  messages=[]; parts=[]; converged=false; heroShown=false; t0=0;
+  hero.classList.remove('show'); cap.classList.remove('show');
+  buildGraph();
+  if(reduce){ hero.classList.add('show'); return; }
+  raf=requestAnimationFrame(frame);
+}
+function skip(){ cancelAnimationFrame(raf); ctx.clearRect(0,0,W,H); cap.classList.remove('show'); hero.classList.add('show'); }
+
+document.getElementById('skip').onclick=skip;
+document.getElementById('replay').onclick=start;
+start();
+</script>
+</body>
+</html>

--- a/demos/intro/terminal-boot.html
+++ b/demos/intro/terminal-boot.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Intro · joye.init()</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --bg:#0f1419;        /* site dark background */
+    --fg:#faf9f8;        /* near-white foreground */
+    --muted:#9aa6b2;
+    --cyan:#7dd3fc;      /* dark-mode primary */
+    --steel:#659eb9;     /* light-mode primary */
+    --ok:#41d18a;
+    --line:rgba(125,211,252,.14);
+    --mono:'JetBrains Mono',ui-monospace,'SF Mono',Menlo,Consolas,monospace;
+    --sans:'Inter','Satoshi',system-ui,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%}
+  body{
+    margin:0;background:var(--bg);color:var(--fg);font-family:var(--sans);
+    overflow:hidden;display:grid;place-items:center;
+  }
+
+  /* ── ambient background ── */
+  .stage{position:fixed;inset:0;display:grid;place-items:center}
+  .glow{position:fixed;inset:-20%;pointer-events:none;
+    background:
+      radial-gradient(40% 50% at 50% 38%, rgba(125,211,252,.10), transparent 70%),
+      radial-gradient(60% 60% at 70% 80%, rgba(101,158,185,.08), transparent 70%);
+    filter:blur(2px)}
+  .scan{position:fixed;inset:0;pointer-events:none;opacity:.5;mix-blend-mode:overlay;
+    background:repeating-linear-gradient(0deg,rgba(255,255,255,.05) 0 1px,transparent 1px 3px)}
+  .sweep{position:fixed;left:0;right:0;height:40vh;pointer-events:none;
+    background:linear-gradient(180deg,transparent,rgba(125,211,252,.06),transparent);
+    transform:translateY(-50vh);animation:sweep 5.5s linear infinite}
+  @keyframes sweep{to{transform:translateY(150vh)}}
+  .vignette{position:fixed;inset:0;pointer-events:none;
+    box-shadow:inset 0 0 220px 40px rgba(0,0,0,.65)}
+
+  /* ── terminal window ── */
+  .term{
+    width:min(680px,90vw);background:rgba(13,18,24,.78);
+    border:1px solid rgba(125,211,252,.18);border-radius:12px;
+    box-shadow:0 30px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(255,255,255,.02) inset;
+    backdrop-filter:blur(8px);overflow:hidden;
+    transition:transform .9s cubic-bezier(.7,0,.2,1),opacity .9s ease,filter .9s ease;
+  }
+  .term.gone{transform:scale(1.12) translateY(-8px);opacity:0;filter:blur(10px)}
+  .chrome{display:flex;align-items:center;gap:8px;padding:11px 14px;
+    background:rgba(255,255,255,.03);border-bottom:1px solid rgba(255,255,255,.05)}
+  .dot{width:11px;height:11px;border-radius:50%}
+  .dot.r{background:#ff5f57}.dot.y{background:#febc2e}.dot.g{background:#28c840}
+  .chrome .ttl{margin-left:8px;font-family:var(--mono);font-size:12px;color:var(--muted)}
+  .body{padding:20px 22px 26px;font-family:var(--mono);font-size:14px;line-height:1.85;
+    min-height:300px}
+  .row{white-space:pre-wrap;word-break:break-word}
+  .prompt{color:var(--cyan)}
+  .ok{color:var(--ok)}
+  .dim{color:var(--muted)}
+  .bar{color:var(--steel)}
+  .art{color:var(--cyan);line-height:1.15;font-size:clamp(9px,2.1vw,15px);text-shadow:0 0 18px rgba(125,211,252,.35)}
+  .caret{display:inline-block;width:9px;height:1.05em;background:var(--cyan);
+    margin-left:2px;transform:translateY(2px);animation:blink 1s steps(1) infinite}
+  @keyframes blink{50%{opacity:0}}
+
+  /* ── hero reveal ── */
+  .hero{position:fixed;inset:0;display:grid;place-items:center;opacity:0;pointer-events:none}
+  .hero.show{opacity:1;pointer-events:auto;transition:opacity 1s ease .15s}
+  .card{display:flex;flex-direction:column;align-items:center;gap:18px;text-align:center}
+  .avatar{width:112px;height:112px;border-radius:50%;padding:4px;
+    border:1px solid rgba(255,255,255,.14);object-fit:cover;
+    background:conic-gradient(from 210deg,var(--steel),var(--cyan),var(--steel));
+    box-shadow:0 0 40px rgba(125,211,252,.25)}
+  .name{font-family:var(--sans);font-weight:800;font-size:34px;letter-spacing:-.02em;margin:0}
+  .meta{color:var(--muted);font-family:var(--mono);font-size:13px;display:flex;gap:14px}
+  .tag{color:var(--cyan);font-style:italic;font-size:15px}
+  .pill{display:inline-flex;align-items:center;gap:9px;padding:9px 16px;border-radius:999px;
+    border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.03);
+    font-size:14px;color:var(--fg);text-decoration:none;transition:.2s}
+  .pill:hover{border-color:rgba(125,211,252,.4);box-shadow:0 0 0 4px rgba(125,211,252,.08)}
+  .ping{position:relative;width:9px;height:9px}
+  .ping i{position:absolute;inset:0;border-radius:50%;background:var(--ok)}
+  .ping i:first-child{animation:ping 1.4s cubic-bezier(0,0,.2,1) infinite}
+  @keyframes ping{75%,100%{transform:scale(2.4);opacity:0}}
+
+  /* per-element stagger for hero */
+  .card>*{opacity:0;transform:translateY(14px)}
+  .hero.show .card>*{animation:up .7s cubic-bezier(.2,.7,.2,1) forwards}
+  .hero.show .card>*:nth-child(1){animation-delay:.05s}
+  .hero.show .card>*:nth-child(2){animation-delay:.16s}
+  .hero.show .card>*:nth-child(3){animation-delay:.26s}
+  .hero.show .card>*:nth-child(4){animation-delay:.36s}
+  .hero.show .card>*:nth-child(5){animation-delay:.46s}
+  @keyframes up{to{opacity:1;transform:none}}
+
+  /* controls */
+  .ctl{position:fixed;bottom:18px;right:18px;display:flex;gap:10px;z-index:20;font-family:var(--mono);font-size:12px}
+  .ctl button{background:rgba(255,255,255,.04);color:var(--muted);border:1px solid rgba(255,255,255,.1);
+    padding:7px 12px;border-radius:8px;cursor:pointer;transition:.2s}
+  .ctl button:hover{color:var(--fg);border-color:rgba(125,211,252,.4)}
+  .hint{position:fixed;bottom:20px;left:20px;font-family:var(--mono);font-size:12px;color:rgba(154,166,178,.5);z-index:20}
+
+  @media (prefers-reduced-motion:reduce){
+    .sweep,.caret,.ping i:first-child{animation:none}
+  }
+</style>
+</head>
+<body>
+  <div class="glow"></div>
+  <div class="sweep"></div>
+  <div class="scan"></div>
+  <div class="vignette"></div>
+
+  <div class="stage">
+    <div class="term" id="term">
+      <div class="chrome">
+        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+        <span class="ttl">joye@dev — ~/site — zsh</span>
+      </div>
+      <div class="body" id="out"></div>
+    </div>
+  </div>
+
+  <div class="hero" id="hero">
+    <div class="card">
+      <img class="avatar" src="../../src/assets/avatar.png" alt="Joye"
+           onerror="this.style.background='conic-gradient(from 210deg,var(--steel),var(--cyan),var(--steel))';this.removeAttribute('src')" />
+      <h1 class="name">Joye</h1>
+      <div class="meta"><span>📍 Melbourne, Australia</span><span>· GitHub</span></div>
+      <div class="tag">“Stay hungry, stay foolish.”</div>
+      <a class="pill" href="javascript:void 0"><span class="ping"><i></i><i></i></span> Connect Me!</a>
+    </div>
+  </div>
+
+  <div class="hint">这是入场动画演示 · 真实站点里只在首次访问播放</div>
+  <div class="ctl">
+    <button id="skip">跳过 →</button>
+    <button id="replay">重播 ↻</button>
+  </div>
+
+<script>
+const out = document.getElementById('out');
+const term = document.getElementById('term');
+const hero = document.getElementById('hero');
+const reduce = matchMedia('(prefers-reduced-motion:reduce)').matches;
+let timers = [];
+const sleep = ms => new Promise(r => timers.push(setTimeout(r, reduce ? ms*0.2 : ms)));
+
+const ART = String.raw`
+   ___ ___  _   _ ___
+  |_  / _ \| | | | __|
+   / / (_) | |_| | _|
+  /___\___/ \___/|___|`;
+
+function line(html='', cls=''){
+  const d=document.createElement('div');
+  d.className='row '+cls; d.innerHTML=html; out.appendChild(d); return d;
+}
+
+async function type(el, text, speed=26){
+  for(const ch of text){ el.append(ch); await sleep(speed); }
+}
+
+async function caretLine(prefix, cmd, speed=34){
+  const el = line(`<span class="prompt">${prefix}</span> `);
+  const c = document.createElement('span'); c.className='caret'; el.append(c);
+  for(const ch of cmd){ c.before(ch); await sleep(speed); }
+  await sleep(260); c.remove();
+}
+
+async function progress(label){
+  const el = line(`<span class="ok">[ ok ]</span> ${label}  <span class="bar"></span>`);
+  const bar = el.querySelector('.bar');
+  const blocks=['░░░░░░░░░░','▓▓░░░░░░░░','▓▓▓▓▓░░░░░','▓▓▓▓▓▓▓▓░░','▓▓▓▓▓▓▓▓▓▓'];
+  for(const b of blocks){ bar.textContent = b + (b.includes('░')?'':' 100%'); await sleep(90); }
+}
+
+async function run(){
+  out.innerHTML=''; term.classList.remove('gone'); hero.classList.remove('show');
+  await sleep(300);
+  await caretLine('$', './joye --init');
+  await sleep(120);
+  await progress('booting joye.dev');
+  await progress('loading design-system');
+  line(`<span class="ok">[ ok ]</span> mounting personality module: <span style="color:var(--cyan)">JoJo</span> 🤖`);
+  await sleep(160);
+  line(`<span class="ok">[ ok ]</span> compiling <span class="dim">8 years of</span> frontend <span class="prompt">→</span> ai-agent`);
+  await sleep(420);
+  await caretLine('$', 'whoami');
+  const art = line('', 'art'); art.textContent = ART;
+  await sleep(120);
+  line(`<span class="dim">Joye · Full-Stack & AI Agent Developer · Melbourne 🇦🇺</span>`);
+  await sleep(520);
+  await caretLine('$', 'open ~/');
+  await sleep(360);
+
+  // hand off to hero
+  term.classList.add('gone');
+  await sleep(420);
+  hero.classList.add('show');
+}
+
+function finish(){ // skip straight to hero
+  timers.forEach(clearTimeout); timers=[];
+  term.classList.add('gone'); hero.classList.add('show');
+}
+
+document.getElementById('skip').onclick = finish;
+document.getElementById('replay').onclick = ()=>{ timers.forEach(clearTimeout); timers=[]; run(); };
+run();
+</script>
+</body>
+</html>

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -1,49 +1,65 @@
 ---
 /**
- * IntroOverlay — full-screen particle entrance that forms the word "JOYE"
- * from drifting particles, then disperses + fades to reveal the page beneath.
+ * IntroOverlay — full-screen home-page entrance animation, with a small
+ * "Tweak" panel (bottom-left) for switching between variants + replaying.
  *
- * Behaviour:
- *  - Plays once per browser session (sessionStorage `intro-seen`).
- *  - Skippable (button or click anywhere).
- *  - Respects `prefers-reduced-motion` (removed before first paint).
- *  - Theme-aware: colours are read from the site's CSS design tokens
- *    (`--background` / `--primary` / `--foreground`), so it matches both
- *    light (steel-blue particles) and dark (cyan particles) modes.
+ * Three variants (selected via localStorage `intro-variant`, default '2'):
+ *   1 · 粒子   — particles fly in and spell "JOYE" (constellation)
+ *   2 · 终端   — `joye.init()` terminal boot sequence
+ *   3 · 排版   — kinetic variable-weight typography
  *
- * The overlay does NOT render its own hero — it sits above the real homepage
- * and fades out to reveal it, so there is nothing to keep in sync.
+ * Shared behaviour:
+ *   - Auto-plays once per session (sessionStorage `intro-seen`), skippable,
+ *     disabled under prefers-reduced-motion.
+ *   - Never renders its own hero — it sits above the page and fades out to
+ *     reveal the real homepage beneath. Overlay bg == site bg (no colour jump).
+ *   - The overlay is hidden (not removed) after playing, so the Tweak panel's
+ *     replay / variant buttons can re-run it without a reload.
+ *
+ * NOTE: the Tweak panel is a review/testing aid. Before a production merge we
+ * should gate it (e.g. `?tweak` query or remove it).
+ *
+ * Scripts use `is:inline` so the dynamically-created DOM (canvas / terminal /
+ * words) is styled by the `is:global` block below (Astro's scoped styles don't
+ * reach nodes created at runtime).
  */
 ---
 
 <div id='intro-overlay' class='intro-overlay' aria-hidden='true'>
-  <canvas id='intro-canvas'></canvas>
+  <div id='intro-stage' class='intro-stage'></div>
   <button id='intro-skip' class='intro-skip' type='button' aria-label='跳过入场动画'>跳过 →</button>
 </div>
 
-{/* Synchronous gate: drop the overlay before first paint for repeat visits / reduced motion. */}
+<div id='intro-tweak' class='intro-tweak' aria-hidden='true'>
+  <span class='intro-tweak__label'>入场动画</span>
+  <button type='button' data-variant='1'>动画一 · 粒子</button>
+  <button type='button' data-variant='2'>动画二 · 终端</button>
+  <button type='button' data-variant='3'>动画三 · 排版</button>
+  <span class='intro-tweak__sep'></span>
+  <button type='button' id='intro-replay'>↻ replay</button>
+</div>
+
+{/* Synchronous gate: hide the overlay before first paint for repeat visits / reduced motion. */}
 <script is:inline>
   ;(function () {
     try {
-      var skip =
-        sessionStorage.getItem('intro-seen') === '1' ||
-        (window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches)
-      if (skip) {
+      var seen = sessionStorage.getItem('intro-seen') === '1'
+      var reduce = window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches
+      if (seen || reduce) {
         var el = document.getElementById('intro-overlay')
-        if (el) el.remove()
+        if (el) el.classList.add('intro-idle')
       }
     } catch (e) {}
   })()
 </script>
 
-<style>
+<style is:global>
   .intro-overlay {
     position: fixed;
     inset: 0;
     z-index: 9999;
     background: hsl(var(--background));
     overflow: hidden;
-    /* keep it opaque from first paint; JS fades it out */
     opacity: 1;
   }
   .intro-overlay::before {
@@ -53,18 +69,29 @@
     pointer-events: none;
     background: radial-gradient(42% 46% at 50% 45%, hsl(var(--primary) / 0.1), transparent 70%);
   }
+  .intro-overlay.intro-idle {
+    display: none;
+  }
   .intro-overlay.intro-done {
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.9s ease;
   }
-  #intro-canvas {
+  .intro-stage {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+  }
+  .intro-canvas {
     position: absolute;
     inset: 0;
     width: 100%;
     height: 100%;
     display: block;
   }
+
+  /* skip button */
   .intro-skip {
     position: absolute;
     bottom: 22px;
@@ -84,7 +111,229 @@
     color: hsl(var(--foreground));
     border-color: hsl(var(--primary) / 0.5);
   }
-  /* Belt-and-braces: never show for reduced-motion users even before JS runs. */
+
+  /* Tweak panel (review aid) */
+  .intro-tweak {
+    position: fixed;
+    bottom: 18px;
+    left: 18px;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px;
+    border-radius: 12px;
+    background: hsl(var(--card) / 0.82);
+    border: 1px solid hsl(var(--border));
+    box-shadow: 0 10px 30px -12px rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(8px);
+    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+    font-size: 12px;
+  }
+  .intro-tweak__label {
+    padding: 0 6px 0 4px;
+    color: hsl(var(--muted-foreground));
+    opacity: 0.8;
+  }
+  .intro-tweak button {
+    font: inherit;
+    color: hsl(var(--muted-foreground));
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    padding: 6px 10px;
+    cursor: pointer;
+    transition: 0.15s;
+    white-space: nowrap;
+  }
+  .intro-tweak button:hover {
+    color: hsl(var(--foreground));
+    background: hsl(var(--muted) / 0.6);
+  }
+  .intro-tweak button.on {
+    color: hsl(var(--primary));
+    border-color: hsl(var(--primary) / 0.45);
+    background: hsl(var(--primary) / 0.08);
+  }
+  .intro-tweak #intro-replay {
+    color: hsl(var(--foreground));
+    border-color: hsl(var(--border));
+  }
+  .intro-tweak__sep {
+    width: 1px;
+    align-self: stretch;
+    margin: 2px 2px;
+    background: hsl(var(--border));
+  }
+
+  /* ── variant 2 · terminal boot (always-dark window for the boot aesthetic) ── */
+  .intro-term {
+    width: min(680px, 90vw);
+    background: rgba(13, 18, 24, 0.85);
+    border: 1px solid rgba(125, 211, 252, 0.18);
+    border-radius: 12px;
+    box-shadow: 0 30px 80px -20px rgba(0, 0, 0, 0.7);
+    overflow: hidden;
+    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  }
+  .intro-term__chrome {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 11px 14px;
+    background: rgba(255, 255, 255, 0.03);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  }
+  .intro-term__chrome .d {
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+  }
+  .intro-term__chrome .r {
+    background: #ff5f57;
+  }
+  .intro-term__chrome .y {
+    background: #febc2e;
+  }
+  .intro-term__chrome .g {
+    background: #28c840;
+  }
+  .intro-term__chrome .t {
+    margin-left: 8px;
+    font-size: 12px;
+    color: #9aa6b2;
+  }
+  .intro-term__body {
+    padding: 20px 22px 26px;
+    font-size: 14px;
+    line-height: 1.85;
+    min-height: 280px;
+    color: #dfe7ef;
+  }
+  .intro-term .ln {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .intro-term .p {
+    color: #7dd3fc;
+  }
+  .intro-term .ok {
+    color: #41d18a;
+  }
+  .intro-term .dim {
+    color: #9aa6b2;
+  }
+  .intro-term .b {
+    color: #659eb9;
+  }
+  .intro-term .c {
+    color: #7dd3fc;
+  }
+  .intro-term .art {
+    color: #7dd3fc;
+    line-height: 1.15;
+    font-size: clamp(9px, 2.1vw, 15px);
+    white-space: pre;
+    text-shadow: 0 0 18px rgba(125, 211, 252, 0.35);
+  }
+  .intro-term .cr {
+    display: inline-block;
+    width: 9px;
+    height: 1.05em;
+    background: #7dd3fc;
+    margin-left: 2px;
+    transform: translateY(2px);
+    animation: intro-blink 1s steps(1) infinite;
+  }
+  @keyframes intro-blink {
+    50% {
+      opacity: 0;
+    }
+  }
+
+  /* ── variant 3 · kinetic type ── */
+  .intro-kin {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+  }
+  .intro-kin .wd {
+    position: absolute;
+    display: flex;
+    gap: 0.02em;
+    font-weight: 900;
+    letter-spacing: -0.03em;
+    line-height: 0.9;
+    font-size: clamp(56px, 13vw, 170px);
+    color: hsl(var(--foreground));
+  }
+  .intro-kin .ch {
+    display: inline-block;
+    opacity: 0;
+    transform: translateY(0.9em);
+    font-variation-settings: 'wght' 200;
+  }
+  .intro-kin .wd.in .ch {
+    animation: intro-rise 0.62s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  }
+  .intro-kin .wd.out {
+    animation: intro-leave 0.45s cubic-bezier(0.7, 0, 0.84, 0) forwards;
+  }
+  .intro-kin .ac {
+    color: hsl(var(--primary));
+  }
+  .intro-kin .th {
+    font-weight: 200;
+  }
+  .intro-kin__bar {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 42vw;
+    left: -46vw;
+    pointer-events: none;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      hsl(var(--primary) / 0.16),
+      hsl(var(--primary) / 0.5) 92%,
+      hsl(var(--primary))
+    );
+    box-shadow: 0 0 80px 20px hsl(var(--primary) / 0.18);
+  }
+  .intro-kin__bar.go {
+    animation: intro-wipe 1.05s cubic-bezier(0.7, 0, 0.2, 1) forwards;
+  }
+  @keyframes intro-rise {
+    0% {
+      opacity: 0;
+      transform: translateY(0.9em);
+      font-variation-settings: 'wght' 200;
+    }
+    60% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 1;
+      transform: none;
+      font-variation-settings: 'wght' 800;
+    }
+  }
+  @keyframes intro-leave {
+    to {
+      opacity: 0;
+      transform: translateY(-0.35em);
+      filter: blur(6px);
+    }
+  }
+  @keyframes intro-wipe {
+    to {
+      left: 104vw;
+    }
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .intro-overlay {
       display: none;
@@ -92,246 +341,342 @@
   }
 </style>
 
-<script>
-  const overlay = document.getElementById('intro-overlay') as HTMLElement | null
-  const canvas = document.getElementById('intro-canvas') as HTMLCanvasElement | null
+<script is:inline>
+  ;(function () {
+    var overlay = document.getElementById('intro-overlay')
+    var stage = document.getElementById('intro-stage')
+    var panel = document.getElementById('intro-tweak')
+    if (!overlay || !stage) return
 
-  if (overlay && canvas) {
-    // Mark immediately so a refresh mid-play doesn't replay.
-    try {
-      sessionStorage.setItem('intro-seen', '1')
-    } catch (e) {}
+    var reduce = window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches
+    var active = null
+    var revealing = false
 
-    const ctx = canvas.getContext('2d')!
-    const reduce = matchMedia('(prefers-reduced-motion: reduce)').matches
-
-    type P = { x: number; y: number; vx: number; vy: number; tx: number; ty: number; r: number; tw: number }
-    let W = 0
-    let H = 0
-    let DPR = 1
-    let particles: P[] = []
-    let phase: 'gather' | 'hold' | 'scatter' = 'gather'
-    let finishing = false
-    let finished = false
-    let raf = 0
-    let t0 = 0
-    const mouse = { x: -1e9, y: -1e9 }
-
-    // ── theme tokens → canvas colours ──────────────────────────────────────
-    const cs = getComputedStyle(document.documentElement)
-    const parseHSL = (v: string) => {
-      const m = v.trim().match(/([\d.]+)\s+([\d.]+)%\s+([\d.]+)%/)
-      return m ? { h: +m[1], s: +m[2], l: +m[3] } : { h: 200, s: 30, l: 50 }
-    }
-    const PRI = parseHSL(cs.getPropertyValue('--primary'))
-    const isDark = document.documentElement.classList.contains('dark')
-    // Light mode sits on a near-white bg, so push particles darker + more
-    // saturated + more opaque to keep "JOYE" crisp. Dark mode keeps the bright
-    // cyan that already pops against the dark background.
-    const baseL = isDark ? PRI.l : Math.min(PRI.l, 40)
-    const sat = isDark ? PRI.s : Math.min(PRI.s + 18, 62)
-    const SPAN = isDark ? 18 : 14 // lightness spread across x → subtle gradient
-    const linkA = isDark ? 0.1 : 0.18
-    const dot = (k: number, a: number) => {
-      const l = Math.max(4, Math.min(96, baseL + (k - 0.5) * SPAN))
-      return `hsl(${PRI.h} ${sat}% ${l}% / ${a})`
-    }
-    const linkColor = `hsl(${PRI.h} ${sat}% ${baseL}%`
-
-    const vw = () => innerWidth || document.documentElement.clientWidth || 1280
-    const vh = () => innerHeight || document.documentElement.clientHeight || 800
-    function resize() {
-      DPR = Math.min(devicePixelRatio || 1, 2)
-      const w = vw()
-      const h = vh()
-      W = canvas!.width = Math.round(w * DPR)
-      H = canvas!.height = Math.round(h * DPR)
-      canvas!.style.width = w + 'px'
-      canvas!.style.height = h + 'px'
-    }
-
-    // Sample "JOYE" into target points, with manual letter-spacing for legibility.
-    function sampleText(text: string) {
-      if (!W || !H) return [] as { x: number; y: number }[]
-      const off = document.createElement('canvas')
-      off.width = W
-      off.height = H
-      const o = off.getContext('2d')!
-      o.fillStyle = '#fff'
-      o.textBaseline = 'middle'
-      o.textAlign = 'left'
-      const tracking = 0.18
-      let size = Math.min(H * 0.4, W * 0.32)
-      const setFont = () => (o.font = `700 ${size}px Satoshi, system-ui, sans-serif`)
-      setFont()
-      const advance = () => {
-        let w = 0
-        for (const ch of text) w += o.measureText(ch).width + size * tracking
-        return w - size * tracking
+    function getVariant() {
+      try {
+        return localStorage.getItem('intro-variant') || '2'
+      } catch (e) {
+        return '2'
       }
-      const maxW = W * 0.72
-      if (advance() > maxW) {
-        size *= maxW / advance()
+    }
+    function setVariant(v) {
+      try {
+        localStorage.setItem('intro-variant', v)
+      } catch (e) {}
+      highlight(v)
+    }
+    function highlight(v) {
+      if (!panel) return
+      var btns = panel.querySelectorAll('[data-variant]')
+      for (var i = 0; i < btns.length; i++) {
+        btns[i].classList.toggle('on', btns[i].getAttribute('data-variant') === v)
+      }
+    }
+    function stopActive() {
+      if (active && active.stop) {
+        try {
+          active.stop()
+        } catch (e) {}
+      }
+      active = null
+    }
+    function reveal() {
+      if (revealing) return
+      revealing = true
+      overlay.classList.add('intro-done')
+      setTimeout(function () {
+        stopActive()
+        overlay.classList.add('intro-idle')
+        overlay.classList.remove('intro-done')
+        stage.innerHTML = ''
+      }, 950)
+    }
+    function play() {
+      stopActive()
+      revealing = false
+      stage.innerHTML = ''
+      overlay.classList.remove('intro-idle')
+      overlay.classList.remove('intro-done')
+      try {
+        sessionStorage.setItem('intro-seen', '1')
+      } catch (e) {}
+      var v = getVariant()
+      highlight(v)
+      if (v === '2') active = playTerminal(stage, reveal)
+      else if (v === '3') active = playKinetic(stage, reveal)
+      else active = playConstellation(stage, reveal)
+    }
+
+    // ── variant 1 · constellation ───────────────────────────────────────────
+    function playConstellation(stage, done) {
+      var canvas = document.createElement('canvas')
+      canvas.className = 'intro-canvas'
+      stage.appendChild(canvas)
+      var ctx = canvas.getContext('2d')
+      var root = document.documentElement
+      var dark = root.classList.contains('dark')
+      var styles = getComputedStyle(root)
+      function parseHSL(v) {
+        var m = String(v).trim().match(/([\d.]+)\s+([\d.]+)%\s+([\d.]+)%/)
+        return m ? { h: +m[1], s: +m[2], l: +m[3] } : { h: 200, s: 30, l: 50 }
+      }
+      var PRI = parseHSL(styles.getPropertyValue('--primary'))
+      var baseL = dark ? PRI.l : Math.min(PRI.l, 40)
+      var sat = dark ? PRI.s : Math.min(PRI.s + 18, 62)
+      var SPAN = dark ? 18 : 14
+      var linkA = dark ? 0.1 : 0.18
+      function dot(k, a) {
+        var l = Math.max(4, Math.min(96, baseL + (k - 0.5) * SPAN))
+        return 'hsl(' + PRI.h + ' ' + sat + '% ' + l + '% / ' + a + ')'
+      }
+      var linkColor = 'hsl(' + PRI.h + ' ' + sat + '% ' + baseL + '%'
+      var W = 0, H = 0, DPR = 1, particles = [], phase = 'gather', t0 = 0, raf = 0, stopped = false
+      var mouse = { x: -1e9, y: -1e9 }
+      function vw() { return innerWidth || document.documentElement.clientWidth || 1280 }
+      function vh() { return innerHeight || document.documentElement.clientHeight || 800 }
+      function resize() {
+        DPR = Math.min(devicePixelRatio || 1, 2)
+        var w = vw(), h = vh()
+        W = canvas.width = Math.round(w * DPR)
+        H = canvas.height = Math.round(h * DPR)
+        canvas.style.width = w + 'px'
+        canvas.style.height = h + 'px'
+      }
+      function sampleText(text) {
+        if (!W || !H) return []
+        var off = document.createElement('canvas')
+        off.width = W
+        off.height = H
+        var o = off.getContext('2d')
+        o.fillStyle = '#fff'
+        o.textBaseline = 'middle'
+        o.textAlign = 'left'
+        var tracking = 0.18
+        var size = Math.min(H * 0.4, W * 0.32)
+        function setFont() { o.font = '700 ' + size + 'px Satoshi, system-ui, sans-serif' }
         setFont()
+        function advance() {
+          var w = 0
+          for (var i = 0; i < text.length; i++) w += o.measureText(text[i]).width + size * tracking
+          return w - size * tracking
+        }
+        var maxW = W * 0.72
+        if (advance() > maxW) { size *= maxW / advance(); setFont() }
+        var x = (W - advance()) / 2
+        var y = H * 0.47
+        for (var i = 0; i < text.length; i++) {
+          o.fillText(text[i], x, y)
+          x += o.measureText(text[i]).width + size * tracking
+        }
+        var data = o.getImageData(0, 0, W, H).data
+        var gap = Math.max(5, Math.round(7 * DPR))
+        var pts = []
+        for (var yy = 0; yy < H; yy += gap)
+          for (var xx = 0; xx < W; xx += gap)
+            if (data[(yy * W + xx) * 4 + 3] > 128) pts.push({ x: xx, y: yy })
+        return pts
       }
-      let x = (W - advance()) / 2
-      const y = H * 0.47
-      for (const ch of text) {
-        o.fillText(ch, x, y)
-        x += o.measureText(ch).width + size * tracking
+      function build() {
+        var pts = sampleText('JOYE')
+        while (particles.length < pts.length)
+          particles.push({ x: 0, y: 0, vx: 0, vy: 0, tx: 0, ty: 0, r: (Math.random() * 0.9 + 0.7) * DPR, tw: Math.random() * 6.28 })
+        particles.length = pts.length
+        pts.sort(function () { return Math.random() - 0.5 })
+        for (var i = 0; i < particles.length; i++) { particles[i].tx = pts[i].x; particles[i].ty = pts[i].y }
       }
-      const data = o.getImageData(0, 0, W, H).data
-      const gap = Math.max(5, Math.round(7 * DPR))
-      const pts: { x: number; y: number }[] = []
-      for (let yy = 0; yy < H; yy += gap)
-        for (let xx = 0; xx < W; xx += gap)
-          if (data[(yy * W + xx) * 4 + 3] > 128) pts.push({ x: xx, y: yy })
-      return pts
-    }
-
-    function build() {
-      const pts = sampleText('JOYE')
-      while (particles.length < pts.length)
-        particles.push({ x: 0, y: 0, vx: 0, vy: 0, tx: 0, ty: 0, r: (Math.random() * 0.9 + 0.7) * DPR, tw: Math.random() * 6.28 })
-      particles.length = pts.length
-      pts.sort(() => Math.random() - 0.5)
-      particles.forEach((p, i) => {
-        p.tx = pts[i].x
-        p.ty = pts[i].y
-      })
-    }
-
-    function frame(ts: number) {
-      if (!t0) t0 = ts
-      const el = (ts - t0) / 1000
-      ctx.clearRect(0, 0, W, H)
-
-      if (el > 1.7 && phase === 'gather') phase = 'hold'
-      if (el > 2.5 && !finishing) beginReveal()
-
-      const ease = phase === 'gather' ? 0.07 : phase === 'hold' ? 0.13 : 0.02
-
-      // constellation links while formed-ish
-      if (phase !== 'scatter') {
-        ctx.lineWidth = DPR * 0.6
-        for (let i = 0; i < particles.length; i += 2) {
-          const p = particles[i]
-          for (let j = i + 2; j < i + 10 && j < particles.length; j++) {
-            const q = particles[j]
-            const dx = p.x - q.x
-            const dy = p.y - q.y
-            const d2 = dx * dx + dy * dy
-            const R = 26 * DPR
-            if (d2 < R * R) {
-              ctx.strokeStyle = `${linkColor} / ${linkA * (1 - d2 / (R * R))})`
-              ctx.beginPath()
-              ctx.moveTo(p.x, p.y)
-              ctx.lineTo(q.x, q.y)
-              ctx.stroke()
+      function frame(ts) {
+        if (stopped) return
+        if (!t0) t0 = ts
+        var el = (ts - t0) / 1000
+        ctx.clearRect(0, 0, W, H)
+        if (el > 1.7 && phase === 'gather') phase = 'hold'
+        if (el > 2.5 && phase !== 'scatter') { phase = 'scatter'; done() }
+        var ease = phase === 'gather' ? 0.07 : phase === 'hold' ? 0.13 : 0.02
+        if (phase !== 'scatter') {
+          ctx.lineWidth = DPR * 0.6
+          for (var i = 0; i < particles.length; i += 2) {
+            var p = particles[i]
+            for (var j = i + 2; j < i + 10 && j < particles.length; j++) {
+              var q = particles[j]
+              var dx = p.x - q.x, dy = p.y - q.y, d2 = dx * dx + dy * dy, R = 26 * DPR
+              if (d2 < R * R) {
+                ctx.strokeStyle = linkColor + ' / ' + (linkA * (1 - d2 / (R * R))) + ')'
+                ctx.beginPath(); ctx.moveTo(p.x, p.y); ctx.lineTo(q.x, q.y); ctx.stroke()
+              }
             }
           }
         }
-      }
-
-      for (const p of particles) {
-        if (phase === 'scatter') {
-          p.vx += (Math.random() - 0.5) * 0.7 * DPR
-          p.vy += ((Math.random() - 0.5) * 0.7 - 0.16) * DPR
-        } else {
-          p.vx += (p.tx - p.x) * ease
-          p.vy += (p.ty - p.y) * ease
-          const mdx = p.x - mouse.x
-          const mdy = p.y - mouse.y
-          const md2 = mdx * mdx + mdy * mdy
-          const R = 110 * DPR
-          if (md2 < R * R) {
-            const f = (1 - md2 / (R * R)) * 4
-            const d = Math.sqrt(md2) || 1
-            p.vx += (mdx / d) * f
-            p.vy += (mdy / d) * f
+        for (var k = 0; k < particles.length; k++) {
+          var pt = particles[k]
+          if (phase === 'scatter') {
+            pt.vx += (Math.random() - 0.5) * 0.7 * DPR
+            pt.vy += ((Math.random() - 0.5) * 0.7 - 0.16) * DPR
+          } else {
+            pt.vx += (pt.tx - pt.x) * ease
+            pt.vy += (pt.ty - pt.y) * ease
+            var mdx = pt.x - mouse.x, mdy = pt.y - mouse.y, md2 = mdx * mdx + mdy * mdy, MR = 110 * DPR
+            if (md2 < MR * MR) { var f = (1 - md2 / (MR * MR)) * 4, d = Math.sqrt(md2) || 1; pt.vx += (mdx / d) * f; pt.vy += (mdy / d) * f }
           }
+          pt.vx *= 0.86; pt.vy *= 0.86; pt.x += pt.vx; pt.y += pt.vy; pt.tw += 0.05
+          var near = (pt.x - pt.tx) * (pt.x - pt.tx) + (pt.y - pt.ty) * (pt.y - pt.ty) < (8 * DPR) * (8 * DPR)
+          var tw = (dark ? 0.6 : 0.8) + Math.sin(pt.tw) * (dark ? 0.22 : 0.15)
+          var a = phase === 'scatter' ? (dark ? 0.5 : 0.62) : (near ? (dark ? 0.95 : 1) : dark ? 0.7 : 0.86) * tw
+          ctx.beginPath()
+          ctx.fillStyle = dot(pt.x / W, Math.min(1, a))
+          ctx.arc(pt.x, pt.y, pt.r * (near ? 1.25 : 1), 0, 7)
+          ctx.fill()
         }
-        p.vx *= 0.86
-        p.vy *= 0.86
-        p.x += p.vx
-        p.y += p.vy
-        p.tw += 0.05
-
-        const near = (p.x - p.tx) ** 2 + (p.y - p.ty) ** 2 < (8 * DPR) ** 2
-        const tw = (isDark ? 0.6 : 0.8) + Math.sin(p.tw) * (isDark ? 0.22 : 0.15)
-        const a =
-          phase === 'scatter'
-            ? isDark
-              ? 0.5
-              : 0.62
-            : (near ? (isDark ? 0.95 : 1) : isDark ? 0.7 : 0.86) * tw
-        ctx.beginPath()
-        ctx.fillStyle = dot(p.x / W, Math.min(1, a))
-        ctx.arc(p.x, p.y, p.r * (near ? 1.25 : 1), 0, 7)
-        ctx.fill()
+        raf = requestAnimationFrame(frame)
       }
-
-      if (!finished) raf = requestAnimationFrame(frame)
+      function onMove(e) { mouse.x = e.clientX * DPR; mouse.y = e.clientY * DPR }
+      function onResize() { if (!stopped) { resize(); build() } }
+      addEventListener('mousemove', onMove)
+      addEventListener('resize', onResize)
+      resize(); build()
+      if (particles.length === 0) { done() }
+      else {
+        var rad = Math.max(W, H)
+        for (var i = 0; i < particles.length; i++) {
+          var ang = Math.random() * 6.283
+          particles[i].x = W / 2 + Math.cos(ang) * rad
+          particles[i].y = H / 2 + Math.sin(ang) * rad
+        }
+        raf = requestAnimationFrame(frame)
+      }
+      return {
+        stop: function () { stopped = true; cancelAnimationFrame(raf); removeEventListener('mousemove', onMove); removeEventListener('resize', onResize) }
+      }
     }
 
-    function beginReveal() {
-      if (finishing) return
-      finishing = true
-      phase = 'scatter'
-      overlay!.classList.add('intro-done')
-      setTimeout(() => {
-        finished = true
-        cancelAnimationFrame(raf)
-        overlay!.remove()
-      }, 950)
+    // ── variant 2 · terminal boot ────────────────────────────────────────────
+    function playTerminal(stage, done) {
+      var wrap = document.createElement('div')
+      wrap.innerHTML =
+        '<div class="intro-term">' +
+        '<div class="intro-term__chrome"><span class="d r"></span><span class="d y"></span><span class="d g"></span><span class="t">joye@dev — ~/site — zsh</span></div>' +
+        '<div class="intro-term__body"></div></div>'
+      stage.appendChild(wrap)
+      var out = wrap.querySelector('.intro-term__body')
+      var timers = [], stopped = false
+      function sleep(ms) { return new Promise(function (r) { timers.push(setTimeout(r, ms)) }) }
+      function line(html, cls) { var d = document.createElement('div'); d.className = 'ln ' + (cls || ''); d.innerHTML = html; out.appendChild(d); return d }
+      function caret(prefix, cmd, sp) {
+        sp = sp || 34
+        var el = line('<span class="p">' + prefix + '</span> ')
+        var c = document.createElement('span'); c.className = 'cr'; el.appendChild(c)
+        var i = 0
+        return new Promise(function (resolve) {
+          function step() {
+            if (stopped) return resolve()
+            if (i >= cmd.length) { timers.push(setTimeout(function () { c.remove(); resolve() }, 240)); return }
+            c.parentNode.insertBefore(document.createTextNode(cmd[i]), c); i++
+            timers.push(setTimeout(step, sp))
+          }
+          step()
+        })
+      }
+      function prog(label) {
+        var el = line('<span class="ok">[ ok ]</span> ' + label + '  <span class="b"></span>')
+        var b = el.querySelector('.b')
+        var steps = ['▓▓░░░░░░░░', '▓▓▓▓▓░░░░░', '▓▓▓▓▓▓▓▓░░', '▓▓▓▓▓▓▓▓▓▓ 100%']
+        var i = 0
+        return new Promise(function (resolve) {
+          function step() {
+            if (stopped || i >= steps.length) return resolve()
+            b.textContent = steps[i]; i++
+            timers.push(setTimeout(step, 90))
+          }
+          step()
+        })
+      }
+      var ART = '   ___ ___  _   _ ___\n  |_  / _ \\| | | | __|\n   / / (_) | |_| | _|\n  /___\\___/ \\___/|___|'
+      ;(async function () {
+        await sleep(250); if (stopped) return
+        await caret('$', './joye --init'); if (stopped) return
+        await prog('booting joye.dev'); await prog('loading design-system'); if (stopped) return
+        line('<span class="ok">[ ok ]</span> mounting personality module: <span class="c">JoJo</span> 🤖'); await sleep(150)
+        line('<span class="ok">[ ok ]</span> compiling <span class="dim">8 years of</span> frontend <span class="p">→</span> ai-agent'); await sleep(420); if (stopped) return
+        await caret('$', 'whoami'); var a = line('', 'art'); a.textContent = ART; await sleep(120)
+        line('<span class="dim">Joye · Full-Stack &amp; AI Agent Developer · Melbourne 🇦🇺</span>'); await sleep(520); if (stopped) return
+        await caret('$', 'open ~/'); await sleep(320)
+        if (!stopped) done()
+      })()
+      return { stop: function () { stopped = true; for (var i = 0; i < timers.length; i++) clearTimeout(timers[i]); timers = [] } }
     }
 
-    function start() {
-      resize()
-      particles = []
-      build()
-      if (particles.length === 0) {
-        // font/layout not ready or sampling failed → don't block the page
-        beginReveal()
-        return
+    // ── variant 3 · kinetic type ─────────────────────────────────────────────
+    function playKinetic(stage, done) {
+      var kin = document.createElement('div'); kin.className = 'intro-kin'
+      var bar = document.createElement('div'); bar.className = 'intro-kin__bar'
+      var seq = document.createElement('div'); seq.style.position = 'absolute'; seq.style.inset = '0'
+      seq.style.display = 'grid'; seq.style.placeItems = 'center'
+      kin.appendChild(bar); kin.appendChild(seq); stage.appendChild(kin)
+      var timers = [], stopped = false
+      function sleep(ms) { return new Promise(function (r) { timers.push(setTimeout(r, ms)) }) }
+      var WORDS = [
+        [{ t: 'FRONT' }, { t: 'END', c: 'ac' }],
+        [{ t: 'DESIGN' }],
+        [{ t: '×', c: 'th' }, { t: ' AI', c: 'ac' }],
+        [{ t: 'JOYE' }]
+      ]
+      function makeWord(parts) {
+        var w = document.createElement('div'); w.className = 'wd'
+        parts.forEach(function (p) {
+          var s = document.createElement('span'); if (p.c) s.className = p.c
+          for (var i = 0; i < p.t.length; i++) {
+            var c = document.createElement('span'); c.className = 'ch'
+            c.textContent = p.t[i] === ' ' ? ' ' : p.t[i]
+            c.style.animationDelay = i * 0.045 + 's'
+            s.appendChild(c)
+          }
+          w.appendChild(s)
+        })
+        return w
       }
-      // scatter-in start positions
-      const rad = Math.max(W, H)
-      particles.forEach((p) => {
-        const ang = Math.random() * 6.283
-        p.x = W / 2 + Math.cos(ang) * rad
-        p.y = H / 2 + Math.sin(ang) * rad
-      })
-      raf = requestAnimationFrame(frame)
+      async function show(parts, hold, last) {
+        if (stopped) return null
+        var w = makeWord(parts); seq.appendChild(w)
+        bar.classList.remove('go'); void bar.offsetWidth; bar.classList.add('go')
+        await sleep(140); if (stopped) return w
+        w.classList.add('in')
+        await sleep(hold)
+        if (!last && !stopped) { w.classList.add('out'); await sleep(420); w.remove() }
+        return w
+      }
+      ;(async function () {
+        await sleep(220)
+        await show(WORDS[0], 720); await show(WORDS[1], 600); await show(WORDS[2], 680)
+        var j = await show(WORDS[3], 820, true); if (stopped) return
+        await sleep(160); if (j) j.classList.add('out'); await sleep(320)
+        if (!stopped) done()
+      })()
+      return { stop: function () { stopped = true; for (var i = 0; i < timers.length; i++) clearTimeout(timers[i]); timers = []; kin.remove() } }
     }
 
-    // interactions
-    addEventListener('resize', () => {
-      if (!finished) {
-        resize()
-        build()
+    // ── wiring ───────────────────────────────────────────────────────────────
+    var skipBtn = document.getElementById('intro-skip')
+    if (skipBtn) skipBtn.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
+    overlay.addEventListener('click', function (e) { if (e.target === overlay || e.target === stage) reveal() })
+    var replayBtn = document.getElementById('intro-replay')
+    if (replayBtn) replayBtn.addEventListener('click', function () { play() })
+    if (panel) {
+      var btns = panel.querySelectorAll('[data-variant]')
+      for (var i = 0; i < btns.length; i++) {
+        ;(function (b) {
+          b.addEventListener('click', function () { setVariant(b.getAttribute('data-variant')); play() })
+        })(btns[i])
       }
-    })
-    addEventListener('mousemove', (e) => {
-      mouse.x = e.clientX * DPR
-      mouse.y = e.clientY * DPR
-    })
-    document.getElementById('intro-skip')?.addEventListener('click', (e) => {
-      e.stopPropagation()
-      beginReveal()
-    })
-    overlay.addEventListener('click', beginReveal)
+    }
+    highlight(getVariant())
 
-    if (reduce) {
-      overlay.remove()
+    // auto-play once per session
+    var seen = false
+    try { seen = sessionStorage.getItem('intro-seen') === '1' } catch (e) {}
+    if (!seen && !reduce) {
+      var fontReady = document.fonts && document.fonts.load ? document.fonts.load('700 120px "Satoshi"') : null
+      Promise.race([Promise.resolve(fontReady).catch(function () {}), new Promise(function (r) { setTimeout(r, 700) })]).then(play)
     } else {
-      // Sample once the brand font is ready so "JOYE" has the right shape.
-      const go = () => start()
-      const fontReady = (document as any).fonts?.load?.('700 120px "Satoshi"')
-      Promise.race([
-        Promise.resolve(fontReady).catch(() => {}),
-        new Promise((r) => setTimeout(r, 700))
-      ]).then(go)
+      overlay.classList.add('intro-idle')
     }
-  }
+  })()
 </script>

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -3,10 +3,11 @@
  * IntroOverlay — full-screen home-page entrance animation, with a small
  * "Tweak" panel (bottom-left) for switching between variants + replaying.
  *
- * Three variants (selected via localStorage `intro-variant`, default '2'):
- *   1 · 粒子   — particles fly in and spell "JOYE" (constellation)
+ * Four variants (selected via localStorage `intro-variant`, default '2'):
+ *   1 · 粒子   — agent/context tokens feed particles that spell "JOYE"
  *   2 · 终端   — `joye.init()` terminal boot sequence
  *   3 · 排版   — kinetic variable-weight typography
+ *   4 · 编排   — labelled multi-agent graph converges into "JOYE"
  *
  * Shared behaviour:
  *   - Auto-plays once per session (sessionStorage `intro-seen`), skippable,
@@ -35,6 +36,7 @@
   <button type='button' data-variant='1'>动画一 · 粒子</button>
   <button type='button' data-variant='2'>动画二 · 终端</button>
   <button type='button' data-variant='3'>动画三 · 排版</button>
+  <button type='button' data-variant='4'>动画四 · 编排</button>
   <span class='intro-tweak__sep'></span>
   <button type='button' id='intro-replay'>↻ replay</button>
 </div>
@@ -90,6 +92,108 @@
     height: 100%;
     display: block;
   }
+  .intro-context {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    overflow: hidden;
+    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  }
+  .intro-token {
+    position: absolute;
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+    color: hsl(var(--primary) / 0.56);
+    font-size: clamp(10px, 1.2vw, 13px);
+    letter-spacing: 0.08em;
+    text-transform: lowercase;
+    text-shadow: 0 0 18px hsl(var(--primary) / 0.16);
+    transition:
+      opacity 0.9s ease,
+      transform 1.2s cubic-bezier(0.16, 1, 0.3, 1),
+      filter 0.9s ease;
+    white-space: nowrap;
+  }
+  .intro-context.show .intro-token {
+    opacity: 0.46;
+    transform: translateY(0) scale(1);
+  }
+  .intro-context.folding .intro-token {
+    opacity: 0.16;
+    transform: translateY(-12px) scale(0.96);
+    filter: blur(0.5px);
+  }
+  .intro-context.leaving .intro-token {
+    opacity: 0;
+    transform: translateY(-34px) scale(0.94);
+    filter: blur(2px);
+  }
+  .intro-enter {
+    position: absolute;
+    left: 50%;
+    top: calc(50% + clamp(96px, 18vh, 170px));
+    z-index: 3;
+    transform: translate(-50%, 10px);
+    opacity: 0;
+    pointer-events: none;
+    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+    font-size: 13px;
+    color: hsl(var(--foreground));
+    background: hsl(var(--card) / 0.68);
+    border: 1px solid hsl(var(--primary) / 0.34);
+    border-radius: 8px;
+    padding: 10px 15px;
+    cursor: pointer;
+    backdrop-filter: blur(10px);
+    box-shadow:
+      0 14px 36px -18px hsl(var(--foreground) / 0.45),
+      inset 0 1px 0 hsl(var(--foreground) / 0.08);
+    transition:
+      opacity 0.45s ease,
+      transform 0.45s ease,
+      background 0.2s ease,
+      border-color 0.2s ease,
+      box-shadow 0.2s ease;
+  }
+  .intro-enter.show {
+    transform: translate(-50%, 0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .intro-enter:hover {
+    border-color: hsl(var(--primary) / 0.65);
+    background: hsl(var(--primary) / 0.11);
+    box-shadow:
+      0 18px 48px -20px hsl(var(--primary) / 0.72),
+      inset 0 1px 0 hsl(var(--foreground) / 0.12);
+  }
+  .intro-enter:focus-visible {
+    outline: 2px solid hsl(var(--primary));
+    outline-offset: 3px;
+  }
+  .intro-trace {
+    position: absolute;
+    left: 50%;
+    top: calc(50% + clamp(164px, 26vh, 250px));
+    z-index: 3;
+    transform: translate(-50%, 8px);
+    opacity: 0;
+    pointer-events: none;
+    color: hsl(var(--muted-foreground));
+    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-align: center;
+    white-space: nowrap;
+    transition:
+      opacity 0.55s ease,
+      transform 0.55s ease;
+  }
+  .intro-trace.show {
+    transform: translate(-50%, 0);
+    opacity: 0.46;
+  }
 
   /* skip button */
   .intro-skip {
@@ -120,7 +224,9 @@
     z-index: 10000;
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 6px;
+    max-width: calc(100vw - 36px);
     padding: 6px;
     border-radius: 12px;
     background: hsl(var(--card) / 0.82);
@@ -360,6 +466,31 @@
     }
   }
 
+  /* ── variant 4 · multi-agent orchestration ── */
+  .intro-agent {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  }
+  .intro-agent__cap {
+    position: absolute;
+    top: 7%;
+    left: 0;
+    right: 0;
+    z-index: 1;
+    text-align: center;
+    color: hsl(var(--primary));
+    font-size: 12px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    opacity: 0;
+    transition: opacity 0.7s ease;
+  }
+  .intro-agent__cap.show {
+    opacity: 0.78;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .intro-overlay {
       display: none;
@@ -380,7 +511,8 @@
 
     function getVariant() {
       try {
-        return localStorage.getItem('intro-variant') || '2'
+        var v = localStorage.getItem('intro-variant') || '2'
+        return /^(1|2|3|4)$/.test(v) ? v : '2'
       } catch (e) {
         return '2'
       }
@@ -438,6 +570,7 @@
       highlight(v)
       if (v === '2') active = playTerminal(stage)
       else if (v === '3') active = playKinetic(stage, reveal)
+      else if (v === '4') active = playMultiAgent(stage, reveal)
       else active = playConstellation(stage, reveal)
     }
 
@@ -446,6 +579,30 @@
       var canvas = document.createElement('canvas')
       canvas.className = 'intro-canvas'
       stage.appendChild(canvas)
+      var context = document.createElement('div')
+      context.className = 'intro-context'
+      var TOKENS = ['context', 'planner', 'tools', 'memory', 'eval', 'rag', 'multi-agent', 'openharness', 'frontend', 'design', 'ship', 'notes', 'search', 'trace', 'typescript', 'cursor']
+      var POS = [[10, 18], [24, 12], [43, 16], [62, 11], [80, 19], [14, 38], [30, 31], [68, 34], [84, 42], [18, 66], [36, 76], [55, 71], [75, 66], [8, 82], [48, 88], [87, 82]]
+      for (var ti = 0; ti < TOKENS.length; ti++) {
+        var token = document.createElement('span')
+        token.className = 'intro-token'
+        token.textContent = TOKENS[ti]
+        token.style.left = POS[ti][0] + '%'
+        token.style.top = POS[ti][1] + '%'
+        token.style.transitionDelay = (ti * 0.045) + 's'
+        context.appendChild(token)
+      }
+      stage.appendChild(context)
+      var enter = document.createElement('button')
+      enter.className = 'intro-enter'
+      enter.type = 'button'
+      enter.textContent = location.pathname.indexOf('/en') === 0 ? 'enter ~/joye →' : '进入 ~/joye →'
+      enter.setAttribute('aria-label', enter.textContent)
+      stage.appendChild(enter)
+      var trace = document.createElement('div')
+      trace.className = 'intro-trace'
+      trace.textContent = 'context loaded · tools ready · welcome back'
+      stage.appendChild(trace)
       var ctx = canvas.getContext('2d')
       var root = document.documentElement
       var dark = root.classList.contains('dark')
@@ -466,6 +623,33 @@
       var linkColor = 'hsl(' + PRI.h + ' ' + sat + '% ' + baseL + '%'
       var W = 0, H = 0, DPR = 1, particles = [], phase = 'gather', t0 = 0, raf = 0, stopped = false
       var mouse = { x: -1e9, y: -1e9 }
+      var enterShown = false, exitingLocal = false, autoExit = 0, revealDelay = 0, contextTimer = 0, scatterStart = 0
+      contextTimer = setTimeout(function () { if (!stopped) context.classList.add('show') }, 120)
+      function showEnter() {
+        if (enterShown || exitingLocal || stopped) return
+        enterShown = true
+        context.classList.add('folding')
+        enter.classList.add('show')
+        trace.classList.add('show')
+        autoExit = setTimeout(beginExit, 12000)
+      }
+      function beginExit() {
+        if (exitingLocal || stopped) return
+        exitingLocal = true
+        phase = 'scatter'
+        scatterStart = 0
+        context.classList.remove('show')
+        context.classList.add('leaving')
+        enter.classList.remove('show')
+        trace.classList.remove('show')
+        enter.disabled = true
+        clearTimeout(autoExit)
+        revealDelay = setTimeout(done, 1350)
+      }
+      function onEnter(e) {
+        e.stopPropagation()
+        beginExit()
+      }
       function vw() { return innerWidth || document.documentElement.clientWidth || 1280 }
       function vh() { return innerHeight || document.documentElement.clientHeight || 800 }
       function resize() {
@@ -513,19 +697,27 @@
       function build() {
         var pts = sampleText('JOYE')
         while (particles.length < pts.length)
-          particles.push({ x: 0, y: 0, vx: 0, vy: 0, tx: 0, ty: 0, r: (Math.random() * 0.9 + 0.7) * DPR, tw: Math.random() * 6.28 })
+          particles.push({ x: 0, y: 0, vx: 0, vy: 0, tx: 0, ty: 0, r: (Math.random() * 0.9 + 0.7) * DPR, tw: Math.random() * 6.28, delay: 0, drift: Math.random() * 6.28 })
         particles.length = pts.length
         pts.sort(function () { return Math.random() - 0.5 })
-        for (var i = 0; i < particles.length; i++) { particles[i].tx = pts[i].x; particles[i].ty = pts[i].y }
+        for (var i = 0; i < particles.length; i++) {
+          particles[i].tx = pts[i].x
+          particles[i].ty = pts[i].y
+          particles[i].delay = 0.2 + (i % 6) * 0.18 + Math.random() * 1.25
+          if (!particles[i].drift) particles[i].drift = Math.random() * 6.28
+        }
       }
       function frame(ts) {
         if (stopped) return
         if (!t0) t0 = ts
         var el = (ts - t0) / 1000
+        if (phase === 'scatter' && !scatterStart) scatterStart = ts
+        var scatterAge = scatterStart ? (ts - scatterStart) / 1000 : 0
         ctx.clearRect(0, 0, W, H)
-        if (el > 1.7 && phase === 'gather') phase = 'hold'
-        if (el > 2.5 && phase !== 'scatter') { phase = 'scatter'; done() }
-        var ease = phase === 'gather' ? 0.07 : phase === 'hold' ? 0.13 : 0.02
+        if (el > 3.15 && phase === 'gather') phase = 'hold'
+        if (el > 2.35 && phase !== 'scatter') context.classList.add('folding')
+        if (el > 4.05 && phase === 'hold') showEnter()
+        var ease = phase === 'gather' ? 0.045 : phase === 'hold' ? 0.11 : 0.018
         if (phase !== 'scatter') {
           ctx.lineWidth = DPR * 0.6
           for (var i = 0; i < particles.length; i += 2) {
@@ -543,28 +735,40 @@
         for (var k = 0; k < particles.length; k++) {
           var pt = particles[k]
           if (phase === 'scatter') {
-            pt.vx += (Math.random() - 0.5) * 0.7 * DPR
-            pt.vy += ((Math.random() - 0.5) * 0.7 - 0.16) * DPR
+            var odx = (pt.x - W / 2) / Math.max(W, 1)
+            pt.vx += (Math.random() - 0.5) * 0.16 * DPR + odx * 0.09 * DPR
+            pt.vy += ((Math.random() - 0.5) * 0.08 - 0.11) * DPR
           } else {
-            pt.vx += (pt.tx - pt.x) * ease
-            pt.vy += (pt.ty - pt.y) * ease
+            var pull = phase === 'hold' ? 1 : Math.max(0, Math.min(1, (el - pt.delay) / 1.55))
+            if (pull < 1) {
+              pt.vx += Math.sin(el * 0.9 + pt.drift) * 0.012 * DPR
+              pt.vy += Math.cos(el * 0.7 + pt.drift) * 0.012 * DPR
+            }
+            var localEase = ease * (0.2 + pull * 0.8)
+            pt.vx += (pt.tx - pt.x) * localEase * pull
+            pt.vy += (pt.ty - pt.y) * localEase * pull
             var mdx = pt.x - mouse.x, mdy = pt.y - mouse.y, md2 = mdx * mdx + mdy * mdy, MR = 110 * DPR
             if (md2 < MR * MR) { var f = (1 - md2 / (MR * MR)) * 4, d = Math.sqrt(md2) || 1; pt.vx += (mdx / d) * f; pt.vy += (mdy / d) * f }
           }
-          pt.vx *= 0.86; pt.vy *= 0.86; pt.x += pt.vx; pt.y += pt.vy; pt.tw += 0.05
+          var damp = phase === 'scatter' ? 0.91 : 0.87
+          pt.vx *= damp; pt.vy *= damp; pt.x += pt.vx; pt.y += pt.vy; pt.tw += 0.05
           var near = (pt.x - pt.tx) * (pt.x - pt.tx) + (pt.y - pt.ty) * (pt.y - pt.ty) < (8 * DPR) * (8 * DPR)
           var tw = (dark ? 0.6 : 0.8) + Math.sin(pt.tw) * (dark ? 0.22 : 0.15)
-          var a = phase === 'scatter' ? (dark ? 0.5 : 0.62) : (near ? (dark ? 0.95 : 1) : dark ? 0.7 : 0.86) * tw
+          var fade = phase === 'scatter' ? Math.max(0, 1 - scatterAge / 2.4) : 1
+          var a = phase === 'scatter' ? (dark ? 0.5 : 0.62) * fade : (near ? (dark ? 0.95 : 1) : dark ? 0.7 : 0.86) * tw
           ctx.beginPath()
           ctx.fillStyle = dot(pt.x / W, Math.min(1, a))
-          ctx.arc(pt.x, pt.y, pt.r * (near ? 1.25 : 1), 0, 7)
+          ctx.arc(pt.x, pt.y, pt.r * (near ? 1.25 : 1) * (phase === 'scatter' ? 0.95 + scatterAge * 0.08 : 1), 0, 7)
           ctx.fill()
         }
         raf = requestAnimationFrame(frame)
       }
       function onMove(e) { mouse.x = e.clientX * DPR; mouse.y = e.clientY * DPR }
+      function onLeave() { mouse.x = -1e9; mouse.y = -1e9 }
       function onResize() { if (!stopped) { resize(); build() } }
+      enter.addEventListener('click', onEnter)
       addEventListener('mousemove', onMove)
+      addEventListener('mouseleave', onLeave)
       addEventListener('resize', onResize)
       resize(); build()
       if (particles.length === 0) { done() }
@@ -578,7 +782,18 @@
         raf = requestAnimationFrame(frame)
       }
       return {
-        stop: function () { stopped = true; cancelAnimationFrame(raf); removeEventListener('mousemove', onMove); removeEventListener('resize', onResize) }
+        blockOverlayClick: true,
+        stop: function () {
+          stopped = true
+          clearTimeout(autoExit)
+          clearTimeout(revealDelay)
+          clearTimeout(contextTimer)
+          cancelAnimationFrame(raf)
+          enter.removeEventListener('click', onEnter)
+          removeEventListener('mousemove', onMove)
+          removeEventListener('mouseleave', onLeave)
+          removeEventListener('resize', onResize)
+        }
       }
     }
 
@@ -679,10 +894,182 @@
       return { stop: function () { stopped = true; for (var i = 0; i < timers.length; i++) clearTimeout(timers[i]); timers = []; kin.remove() } }
     }
 
+    // ── variant 4 · multi-agent orchestration ────────────────────────────────
+    function playMultiAgent(stage, done) {
+      var wrap = document.createElement('div'); wrap.className = 'intro-agent'
+      var canvas = document.createElement('canvas'); canvas.className = 'intro-canvas'
+      var cap = document.createElement('div'); cap.className = 'intro-agent__cap'; cap.textContent = 'multi-agent runtime'
+      wrap.appendChild(canvas); wrap.appendChild(cap); stage.appendChild(wrap)
+      var ctx = canvas.getContext('2d')
+      if (!ctx) { done(); return { stop: function () { wrap.remove() } } }
+
+      var root = document.documentElement
+      var styles = getComputedStyle(root)
+      var dark = root.classList.contains('dark')
+      function parseHSL(v) {
+        var m = String(v).trim().match(/([\d.]+)\s+([\d.]+)%\s+([\d.]+)%/)
+        return m ? { h: +m[1], s: +m[2], l: +m[3] } : { h: 200, s: 36, l: 56 }
+      }
+      var PRI = parseHSL(styles.getPropertyValue('--primary'))
+      var SAT = Math.min(90, PRI.s + 16)
+      function tone(l, a) { return 'hsl(' + PRI.h + ' ' + SAT + '% ' + l + '% / ' + a + ')' }
+      function textTone(a) { return dark ? 'rgba(250,249,248,' + a + ')' : 'rgba(24,30,36,' + a + ')' }
+
+      var W = 0, H = 0, DPR = 1, raf = 0, t0 = 0, stopped = false, converged = false, finished = false
+      var nodes = [], edges = [], messages = [], schedule = [], schedPtr = 0, parts = []
+      var ROLES = ['planner', 'router', 'search', 'code', 'memory', 'judge', 'tool', 'writer']
+
+      function vw() { return innerWidth || document.documentElement.clientWidth || 1280 }
+      function vh() { return innerHeight || document.documentElement.clientHeight || 800 }
+      function resize() {
+        DPR = Math.min(devicePixelRatio || 1, 2)
+        var w = vw(), h = vh()
+        W = canvas.width = Math.round(w * DPR)
+        H = canvas.height = Math.round(h * DPR)
+        canvas.style.width = w + 'px'
+        canvas.style.height = h + 'px'
+      }
+      function buildGraph() {
+        nodes = []; edges = []
+        var cx = W / 2, cy = H * 0.45
+        var roles = W / DPR < 560 ? ['plan', 'route', 'code', 'memory', 'judge', 'write'] : ROLES
+        var R = Math.min(W, H) * (roles.length > 6 ? 0.3 : 0.33)
+        nodes.push({ x: cx, y: cy, label: 'orchestrator', hub: true, act: 0, appear: 0, r: 7 * DPR })
+        for (var i = 0; i < roles.length; i++) {
+          var a = -Math.PI / 2 + (i / roles.length) * Math.PI * 2
+          var jitter = Math.sin(i * 12.9) * R * 0.05
+          nodes.push({ x: cx + Math.cos(a) * (R + jitter), y: cy + Math.sin(a) * (R + jitter), label: roles[i], hub: false, act: 0, appear: 0.18 + i * 0.06, r: 5.5 * DPR })
+        }
+        for (var j = 1; j < nodes.length; j++) edges.push({ a: 0, b: j, appear: 0.4 + j * 0.05, lit: 0 })
+        for (var k = 1; k < nodes.length; k++) edges.push({ a: k, b: (k % roles.length) + 1, appear: 0.8 + k * 0.03, lit: 0 })
+        buildSchedule()
+      }
+      function buildSchedule() {
+        schedule = []; schedPtr = 0
+        for (var i = 1; i < nodes.length; i++) schedule.push({ t: 0.95 + i * 0.055, a: 0, b: i })
+        for (var j = 1; j < nodes.length; j++) schedule.push({ t: 1.5 + j * 0.05, a: j, b: (j % (nodes.length - 1)) + 1 })
+        for (var k = 1; k < nodes.length; k++) schedule.push({ t: 2.05 + k * 0.05, a: k, b: 0 })
+        schedule.sort(function (a, b) { return a.t - b.t })
+      }
+      function sampleJOYE() {
+        var off = document.createElement('canvas')
+        off.width = W; off.height = H
+        var o = off.getContext('2d')
+        o.fillStyle = '#fff'; o.textBaseline = 'middle'; o.textAlign = 'left'
+        var tracking = 0.18, size = Math.min(H * 0.4, W * 0.34)
+        function setFont() { o.font = '700 ' + size + 'px Satoshi, system-ui, sans-serif' }
+        setFont()
+        function advance() {
+          var w = 0
+          for (var i = 0; i < 4; i++) w += o.measureText('JOYE'[i]).width + size * tracking
+          return w - size * tracking
+        }
+        if (advance() > W * 0.74) { size *= (W * 0.74) / advance(); setFont() }
+        var x = (W - advance()) / 2, y = H * 0.45
+        for (var i = 0; i < 4; i++) { var ch = 'JOYE'[i]; o.fillText(ch, x, y); x += o.measureText(ch).width + size * tracking }
+        var data = o.getImageData(0, 0, W, H).data
+        var gap = Math.max(5, Math.round(7 * DPR))
+        var pts = []
+        for (var yy = 0; yy < H; yy += gap)
+          for (var xx = 0; xx < W; xx += gap)
+            if (data[(yy * W + xx) * 4 + 3] > 128) pts.push({ x: xx, y: yy })
+        return pts
+      }
+      function spawnMessage(a, b) {
+        for (var i = 0; i < edges.length; i++) {
+          var e = edges[i]
+          if ((e.a === a && e.b === b) || (e.a === b && e.b === a)) e.lit = 1
+        }
+        messages.push({ a: a, b: b, t: 0, dur: 0.5 })
+      }
+      function converge() {
+        converged = true; cap.classList.remove('show')
+        var pts = sampleJOYE()
+        if (pts.length === 0) { finished = true; done(); return }
+        parts = []
+        for (var i = 0; i < pts.length; i++) {
+          var src = nodes[(Math.random() * nodes.length) | 0]
+          parts.push({ x: src.x, y: src.y, vx: 0, vy: 0, tx: pts[i].x, ty: pts[i].y, r: (Math.random() * 0.9 + 0.7) * DPR })
+        }
+      }
+      function frame(ts) {
+        if (stopped) return
+        if (!t0) t0 = ts
+        var el = (ts - t0) / 1000
+        ctx.clearRect(0, 0, W, H)
+        if (el > 1.4 && !converged) cap.classList.add('show')
+        if (el > 2.65 && !converged) converge()
+        if (converged && el > 3.8 && !finished) { finished = true; done() }
+
+        if (!converged) {
+          while (schedPtr < schedule.length && el >= schedule[schedPtr].t) { var s = schedule[schedPtr++]; spawnMessage(s.a, s.b) }
+          for (var i = 0; i < edges.length; i++) {
+            var edge = edges[i], ap = Math.max(0, Math.min(1, (el - edge.appear) / 0.5))
+            if (ap <= 0) continue
+            var A = nodes[edge.a], B = nodes[edge.b]
+            ctx.strokeStyle = tone(dark ? 68 : 46, (0.1 + edge.lit * 0.35) * ap)
+            ctx.lineWidth = (0.7 + edge.lit * 1.2) * DPR
+            ctx.beginPath(); ctx.moveTo(A.x, A.y); ctx.lineTo(B.x, B.y); ctx.stroke()
+            edge.lit *= 0.92
+          }
+          for (var j = 0; j < messages.length; j++) {
+            var m = messages[j]
+            m.t += 0.016 / m.dur
+            var MA = nodes[m.a], MB = nodes[m.b], ease = m.t < 1 ? m.t * m.t * (3 - 2 * m.t) : 1
+            var mx = MA.x + (MB.x - MA.x) * ease, my = MA.y + (MB.y - MA.y) * ease
+            ctx.beginPath(); ctx.fillStyle = tone(dark ? 82 : 38, 0.95); ctx.shadowColor = tone(dark ? 76 : 45, 0.9); ctx.shadowBlur = 10 * DPR
+            ctx.arc(mx, my, 2.4 * DPR, 0, 7); ctx.fill(); ctx.shadowBlur = 0
+            if (m.t >= 1) MB.act = 1
+          }
+          messages = messages.filter(function (m) { return m.t < 1 })
+          for (var k = 0; k < nodes.length; k++) {
+            var n = nodes[k], nap = Math.max(0, Math.min(1, (el - n.appear) / 0.3))
+            if (nap <= 0) continue
+            n.act *= 0.94
+            var rr = n.r * nap * (1 + n.act * 0.5)
+            if (n.act > 0.02) { ctx.beginPath(); ctx.fillStyle = tone(dark ? 72 : 44, 0.12 * n.act); ctx.arc(n.x, n.y, rr * 3.4, 0, 7); ctx.fill() }
+            ctx.beginPath(); ctx.fillStyle = dark ? 'rgba(13, 20, 28, 0.9)' : 'rgba(255, 255, 255, 0.82)'; ctx.arc(n.x, n.y, rr, 0, 7); ctx.fill()
+            ctx.lineWidth = (n.hub ? 2 : 1.4) * DPR
+            ctx.strokeStyle = tone(n.hub ? (dark ? 72 : 43) : (dark ? 78 : 48), (0.55 + n.act * 0.45) * nap)
+            ctx.beginPath(); ctx.arc(n.x, n.y, rr, 0, 7); ctx.stroke()
+            ctx.font = (n.hub ? 12 : 11) * DPR + 'px JetBrains Mono, monospace'
+            ctx.textAlign = 'center'; ctx.textBaseline = 'middle'
+            ctx.fillStyle = n.act > 0.3 ? tone(dark ? 84 : 35, nap) : textTone((0.48 + n.act * 0.28) * nap)
+            ctx.fillText(n.label, n.x, n.y + rr + 11 * DPR)
+          }
+        } else {
+          var since = el - 2.65
+          var nodeA = Math.max(0, 1 - since * 1.6)
+          if (nodeA > 0.02) {
+            for (var eix = 0; eix < edges.length; eix++) { var ge = edges[eix], GA = nodes[ge.a], GB = nodes[ge.b]; ctx.strokeStyle = tone(dark ? 68 : 46, 0.08 * nodeA); ctx.lineWidth = 0.7 * DPR; ctx.beginPath(); ctx.moveTo(GA.x, GA.y); ctx.lineTo(GB.x, GB.y); ctx.stroke() }
+            for (var nix = 0; nix < nodes.length; nix++) { var gn = nodes[nix]; ctx.beginPath(); ctx.fillStyle = tone(dark ? 72 : 43, 0.5 * nodeA); ctx.arc(gn.x, gn.y, gn.r, 0, 7); ctx.fill() }
+          }
+          for (var pix = 0; pix < parts.length; pix++) {
+            var p = parts[pix]
+            if (finished) { p.vx += (Math.random() - 0.5) * 0.6 * DPR; p.vy += ((Math.random() - 0.5) * 0.6 - 0.12) * DPR }
+            else { p.vx += (p.tx - p.x) * 0.12; p.vy += (p.ty - p.y) * 0.12 }
+            p.vx *= 0.84; p.vy *= 0.84; p.x += p.vx; p.y += p.vy
+            var shade = dark ? 74 + (p.x / W) * 10 : 42 + (p.x / W) * 12
+            ctx.beginPath(); ctx.fillStyle = tone(shade, dark ? 0.92 : 0.98); ctx.arc(p.x, p.y, p.r, 0, 7); ctx.fill()
+          }
+        }
+        raf = requestAnimationFrame(frame)
+      }
+      function onResize() { if (!stopped) { resize(); if (!converged) buildGraph() } }
+      addEventListener('resize', onResize)
+      resize(); buildGraph(); raf = requestAnimationFrame(frame)
+      return {
+        stop: function () { stopped = true; cancelAnimationFrame(raf); removeEventListener('resize', onResize); wrap.remove() }
+      }
+    }
+
     // ── wiring ───────────────────────────────────────────────────────────────
     var skipBtn = document.getElementById('intro-skip')
     if (skipBtn) skipBtn.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
-    overlay.addEventListener('click', function (e) { if (e.target === overlay || e.target === stage) reveal() })
+    overlay.addEventListener('click', function () {
+      if (active && active.blockOverlayClick) return
+      reveal()
+    })
     var replayBtn = document.getElementById('intro-replay')
     if (replayBtn) replayBtn.addEventListener('click', function () { play() })
     if (panel) {

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -40,7 +40,10 @@ import avatar from 'src/assets/avatar.png'
   <button id='intro-skip' class='intro-skip' type='button' aria-label='跳过入场动画'>跳过 →</button>
 </div>
 
-{/* Synchronous gate: drop the overlay before first paint for repeat visits / reduced motion. */}
+<button id='intro-replay' class='intro-replay' type='button' aria-label='重播入场动画'>↻ 重播入场</button>
+<noscript><style>.intro-overlay{display:none}</style></noscript>
+
+{/* Synchronous gate: hide the overlay before first paint for repeat visits / reduced motion (kept in DOM so 重播 can re-run it). */}
 <script is:inline>
   ;(function () {
     try {
@@ -49,7 +52,7 @@ import avatar from 'src/assets/avatar.png'
         (window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches)
       if (skip) {
         var el = document.getElementById('intro-overlay')
-        if (el) el.remove()
+        if (el) el.classList.add('intro-idle')
       }
     } catch (e) {}
   })()
@@ -68,6 +71,33 @@ import avatar from 'src/assets/avatar.png'
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.95s ease;
+  }
+  .intro-overlay.intro-idle {
+    display: none;
+  }
+  /* persistent replay control — lives on the page, themed to match it */
+  .intro-replay {
+    position: fixed;
+    left: 18px;
+    bottom: 18px;
+    z-index: 50;
+    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    color: hsl(var(--muted-foreground) / 0.7);
+    background: hsl(var(--card) / 0.5);
+    border: 1px solid hsl(var(--border));
+    border-radius: 999px;
+    padding: 6px 12px;
+    cursor: pointer;
+    opacity: 0.55;
+    backdrop-filter: blur(6px);
+    transition: 0.25s;
+  }
+  .intro-replay:hover {
+    opacity: 1;
+    color: hsl(var(--foreground));
+    border-color: hsl(var(--primary) / 0.5);
   }
   #intro-canvas {
     position: absolute;
@@ -221,11 +251,6 @@ import avatar from 'src/assets/avatar.png'
     0%, 100% { box-shadow: 0 0 0 0 rgba(125, 211, 252, 0); }
     50% { box-shadow: 0 0 22px -4px rgba(125, 211, 252, 0.55); }
   }
-  @media (prefers-reduced-motion: reduce) {
-    .intro-overlay {
-      display: none;
-    }
-  }
 </style>
 
 <script is:inline>
@@ -234,7 +259,6 @@ import avatar from 'src/assets/avatar.png'
     var canvas = document.getElementById('intro-canvas')
     var hud = document.getElementById('intro-hud')
     if (!overlay || !canvas) return
-    try { sessionStorage.setItem('intro-seen', '1') } catch (e) {}
 
     var ctx = canvas.getContext('2d')
     var reduce = window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches
@@ -379,12 +403,16 @@ import avatar from 'src/assets/avatar.png'
       landed = true
       if (card) card.classList.add('show')
     }
-    function reveal() {                       // visitor chose to enter → fade to real homepage
+    function reveal() {                       // visitor chose to enter → fade to real homepage (kept in DOM for 重播)
       if (revealing) return
       revealing = true
       if (card) card.classList.remove('show')
       overlay.classList.add('intro-done')
-      setTimeout(function () { cancelAnimationFrame(raf); overlay.remove() }, 1000)
+      setTimeout(function () {
+        cancelAnimationFrame(raf)
+        overlay.classList.add('intro-idle')
+        overlay.classList.remove('intro-done')
+      }, 1000)
     }
 
     function start() {
@@ -392,20 +420,34 @@ import avatar from 'src/assets/avatar.png'
       if (parts.length === 0) { setTimeout(start, 120); return }
       raf = requestAnimationFrame(frame)
     }
+    function play() {                         // (re)run the intro from noise — first visit + 重播
+      cancelAnimationFrame(raf)
+      d = 0; dTarget = 0; pulse = 0; stepShown = -1; doneAt = 0; t0 = 0
+      revealing = false; landed = false
+      if (card) card.classList.remove('show')
+      hud.style.opacity = ''; hud.classList.remove('show')
+      overlay.classList.remove('intro-idle'); overlay.classList.remove('intro-done')
+      try { sessionStorage.setItem('intro-seen', '1') } catch (e) {}
+      start()
+    }
 
-    addEventListener('resize', function () { if (!revealing) { resize(); build() } })
+    addEventListener('resize', function () { if (!revealing && !overlay.classList.contains('intro-idle')) { resize(); build() } })
     var skipBtn = document.getElementById('intro-skip')
     if (skipBtn) skipBtn.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
     var enterBtn = document.getElementById('intro-enter')
     if (enterBtn) enterBtn.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
     var avEl = document.getElementById('intro-av')
     if (avEl) avEl.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
+    var replayBtn = document.getElementById('intro-replay')
+    if (replayBtn) replayBtn.addEventListener('click', play)
 
-    if (reduce) {
-      overlay.remove()
-    } else {
+    var seen = false
+    try { seen = sessionStorage.getItem('intro-seen') === '1' } catch (e) {}
+    if (!seen && !reduce) {
       var fontReady = document.fonts && document.fonts.load ? document.fonts.load('700 120px "Satoshi"') : null
-      Promise.race([Promise.resolve(fontReady).catch(function () {}), new Promise(function (r) { setTimeout(r, 700) })]).then(start)
+      Promise.race([Promise.resolve(fontReady).catch(function () {}), new Promise(function (r) { setTimeout(r, 700) })]).then(play)
+    } else {
+      overlay.classList.add('intro-idle')   // hidden on repeat visits; 重播 re-runs it
     }
   })()
 </script>

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -166,88 +166,114 @@
     background: hsl(var(--border));
   }
 
-  /* ── variant 2 · terminal boot (always-dark window for the boot aesthetic) ── */
-  .intro-term {
-    width: min(680px, 90vw);
-    background: rgba(13, 18, 24, 0.85);
-    border: 1px solid rgba(125, 211, 252, 0.18);
-    border-radius: 12px;
-    box-shadow: 0 30px 80px -20px rgba(0, 0, 0, 0.7);
+  /* ── variant 2 · fullscreen CRT boot ── */
+  .intro-crt {
+    position: absolute;
+    inset: 0;
     overflow: hidden;
+    background: radial-gradient(120% 120% at 50% 42%, #0a1117 0%, #04070a 100%);
+    color: #d7f5e6;
     font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+    font-size: clamp(11px, 1.5vw, 16px);
+    line-height: 1.72;
+    text-shadow: 0 0 6px rgba(125, 211, 252, 0.22);
+    transform-origin: 50% 50%;
+    animation: intro-crt-flicker 4s infinite steps(40);
   }
-  .intro-term__chrome {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 11px 14px;
-    background: rgba(255, 255, 255, 0.03);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  .intro-crt__inner {
+    position: absolute;
+    inset: 0;
+    padding: clamp(22px, 5.5vh, 70px) clamp(20px, 6vw, 96px);
+    overflow: hidden;
   }
-  .intro-term__chrome .d {
-    width: 11px;
-    height: 11px;
-    border-radius: 50%;
+  .intro-crt::after {
+    /* scanlines */
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.3) 0 1px, transparent 1px 3px);
+    mix-blend-mode: multiply;
   }
-  .intro-term__chrome .r {
-    background: #ff5f57;
+  .intro-crt__vignette {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    box-shadow: inset 0 0 220px 70px rgba(0, 0, 0, 0.72);
   }
-  .intro-term__chrome .y {
-    background: #febc2e;
-  }
-  .intro-term__chrome .g {
-    background: #28c840;
-  }
-  .intro-term__chrome .t {
-    margin-left: 8px;
-    font-size: 12px;
-    color: #9aa6b2;
-  }
-  .intro-term__body {
-    padding: 20px 22px 26px;
-    font-size: 14px;
-    line-height: 1.85;
-    min-height: 280px;
-    color: #dfe7ef;
-  }
-  .intro-term .ln {
+  .intro-crt .ln {
     white-space: pre-wrap;
     word-break: break-word;
   }
-  .intro-term .p {
+  .intro-crt .p {
     color: #7dd3fc;
   }
-  .intro-term .ok {
+  .intro-crt .ok {
     color: #41d18a;
   }
-  .intro-term .dim {
-    color: #9aa6b2;
+  .intro-crt .dim {
+    color: #5e7385;
   }
-  .intro-term .b {
-    color: #659eb9;
-  }
-  .intro-term .c {
+  .intro-crt .c {
     color: #7dd3fc;
   }
-  .intro-term .art {
+  .intro-crt .hd {
+    color: #9effd0;
+  }
+  .intro-crt .art {
     color: #7dd3fc;
-    line-height: 1.15;
-    font-size: clamp(9px, 2.1vw, 15px);
     white-space: pre;
-    text-shadow: 0 0 18px rgba(125, 211, 252, 0.35);
+    line-height: 1.12;
+    text-shadow: 0 0 16px rgba(125, 211, 252, 0.4);
   }
-  .intro-term .cr {
+  .intro-crt .cr {
     display: inline-block;
-    width: 9px;
+    width: 0.6em;
     height: 1.05em;
     background: #7dd3fc;
     margin-left: 2px;
     transform: translateY(2px);
+    box-shadow: 0 0 8px rgba(125, 211, 252, 0.7);
     animation: intro-blink 1s steps(1) infinite;
+  }
+  .intro-crt.intro-crt--off {
+    animation: intro-crt-off 0.55s ease-in forwards;
   }
   @keyframes intro-blink {
     50% {
       opacity: 0;
+    }
+  }
+  @keyframes intro-crt-flicker {
+    0%, 46%, 54%, 100% {
+      filter: brightness(1);
+    }
+    50% {
+      filter: brightness(1.06);
+    }
+    52% {
+      filter: brightness(0.96);
+    }
+  }
+  @keyframes intro-crt-off {
+    0% {
+      transform: scale(1, 1);
+      opacity: 1;
+      filter: brightness(1.3);
+    }
+    48% {
+      transform: scale(1, 0.004);
+      opacity: 1;
+      filter: brightness(3.2);
+    }
+    70% {
+      transform: scale(1, 0.004);
+      filter: brightness(3.2);
+    }
+    100% {
+      transform: scale(0, 0.004);
+      opacity: 0;
+      filter: brightness(3.4);
     }
   }
 
@@ -350,7 +376,7 @@
 
     var reduce = window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches
     var active = null
-    var revealing = false
+    var exiting = false
 
     function getVariant() {
       try {
@@ -380,20 +406,28 @@
       }
       active = null
     }
+    function hideOverlay() {
+      stopActive()
+      overlay.classList.add('intro-idle')
+      overlay.classList.remove('intro-done')
+      stage.innerHTML = ''
+    }
     function reveal() {
-      if (revealing) return
-      revealing = true
+      if (exiting) return
+      exiting = true
       overlay.classList.add('intro-done')
-      setTimeout(function () {
-        stopActive()
-        overlay.classList.add('intro-idle')
-        overlay.classList.remove('intro-done')
-        stage.innerHTML = ''
-      }, 950)
+      setTimeout(hideOverlay, 950)
+    }
+    function crtExit(screen) {
+      // variant 2's own outro: CRT power-off collapse, then hide
+      if (exiting) return
+      exiting = true
+      if (screen) screen.classList.add('intro-crt--off')
+      setTimeout(hideOverlay, 560)
     }
     function play() {
       stopActive()
-      revealing = false
+      exiting = false
       stage.innerHTML = ''
       overlay.classList.remove('intro-idle')
       overlay.classList.remove('intro-done')
@@ -402,7 +436,7 @@
       } catch (e) {}
       var v = getVariant()
       highlight(v)
-      if (v === '2') active = playTerminal(stage, reveal)
+      if (v === '2') active = playTerminal(stage)
       else if (v === '3') active = playKinetic(stage, reveal)
       else active = playConstellation(stage, reveal)
     }
@@ -548,58 +582,50 @@
       }
     }
 
-    // ── variant 2 · terminal boot ────────────────────────────────────────────
-    function playTerminal(stage, done) {
-      var wrap = document.createElement('div')
-      wrap.innerHTML =
-        '<div class="intro-term">' +
-        '<div class="intro-term__chrome"><span class="d r"></span><span class="d y"></span><span class="d g"></span><span class="t">joye@dev — ~/site — zsh</span></div>' +
-        '<div class="intro-term__body"></div></div>'
-      stage.appendChild(wrap)
-      var out = wrap.querySelector('.intro-term__body')
+    // ── variant 2 · fullscreen CRT boot ──────────────────────────────────────
+    function playTerminal(stage) {
+      var screen = document.createElement('div')
+      screen.className = 'intro-crt'
+      screen.innerHTML = '<div class="intro-crt__inner"></div><div class="intro-crt__vignette"></div>'
+      stage.appendChild(screen)
+      var out = screen.querySelector('.intro-crt__inner')
       var timers = [], stopped = false
       function sleep(ms) { return new Promise(function (r) { timers.push(setTimeout(r, ms)) }) }
       function line(html, cls) { var d = document.createElement('div'); d.className = 'ln ' + (cls || ''); d.innerHTML = html; out.appendChild(d); return d }
+      function boot(ts, label) { return line('<span class="dim">[ ' + ts + ' ]</span> ' + label + ' <span class="ok">[  OK  ]</span>') }
       function caret(prefix, cmd, sp) {
-        sp = sp || 34
+        sp = sp || 32
         var el = line('<span class="p">' + prefix + '</span> ')
         var c = document.createElement('span'); c.className = 'cr'; el.appendChild(c)
         var i = 0
         return new Promise(function (resolve) {
           function step() {
             if (stopped) return resolve()
-            if (i >= cmd.length) { timers.push(setTimeout(function () { c.remove(); resolve() }, 240)); return }
+            if (i >= cmd.length) { timers.push(setTimeout(function () { c.remove(); resolve() }, 220)); return }
             c.parentNode.insertBefore(document.createTextNode(cmd[i]), c); i++
             timers.push(setTimeout(step, sp))
           }
           step()
         })
       }
-      function prog(label) {
-        var el = line('<span class="ok">[ ok ]</span> ' + label + '  <span class="b"></span>')
-        var b = el.querySelector('.b')
-        var steps = ['▓▓░░░░░░░░', '▓▓▓▓▓░░░░░', '▓▓▓▓▓▓▓▓░░', '▓▓▓▓▓▓▓▓▓▓ 100%']
-        var i = 0
-        return new Promise(function (resolve) {
-          function step() {
-            if (stopped || i >= steps.length) return resolve()
-            b.textContent = steps[i]; i++
-            timers.push(setTimeout(step, 90))
-          }
-          step()
-        })
-      }
       var ART = '   ___ ___  _   _ ___\n  |_  / _ \\| | | | __|\n   / / (_) | |_| | _|\n  /___\\___/ \\___/|___|'
       ;(async function () {
-        await sleep(250); if (stopped) return
-        await caret('$', './joye --init'); if (stopped) return
-        await prog('booting joye.dev'); await prog('loading design-system'); if (stopped) return
-        line('<span class="ok">[ ok ]</span> mounting personality module: <span class="c">JoJo</span> 🤖'); await sleep(150)
-        line('<span class="ok">[ ok ]</span> compiling <span class="dim">8 years of</span> frontend <span class="p">→</span> ai-agent'); await sleep(420); if (stopped) return
-        await caret('$', 'whoami'); var a = line('', 'art'); a.textContent = ART; await sleep(120)
-        line('<span class="dim">Joye · Full-Stack &amp; AI Agent Developer · Melbourne 🇦🇺</span>'); await sleep(520); if (stopped) return
-        await caret('$', 'open ~/'); await sleep(320)
-        if (!stopped) done()
+        await sleep(200); if (stopped) return
+        line('<span class="hd">JoyeOS 4.8.0</span> <span class="dim">(tty1)</span>')
+        line('&nbsp;'); await sleep(180)
+        boot('0.000000', 'Booting <span class="hd">joye.dev</span> kernel'); await sleep(85)
+        boot('0.013002', 'Loading design-system'); await sleep(80)
+        boot('0.041190', 'Mounting /home/joye'); await sleep(80)
+        boot('0.072551', 'Starting personality daemon (<span class="c">JoJo</span>)'); await sleep(80)
+        line('<span class="dim">[ 0.105324 ]</span> compiling <span class="dim">8 years of</span> frontend <span class="p">→</span> ai-agent'); await sleep(120)
+        boot('0.151002', 'Initializing multi-agent runtime'); await sleep(280); if (stopped) return
+        var a = line('', 'art'); a.textContent = ART; await sleep(200)
+        line('&nbsp;'); await sleep(140)
+        await caret('joye@dev:~$', 'whoami'); if (stopped) return
+        line('<span class="hd">Joye</span> <span class="dim">· Full-Stack &amp; AI Agent Developer · Melbourne 🇦🇺</span>'); await sleep(440)
+        await caret('joye@dev:~$', 'open ~/'); await sleep(180)
+        line('<span class="dim">[ launching interface ... ]</span>'); await sleep(360)
+        if (!stopped) crtExit(screen)
       })()
       return { stop: function () { stopped = true; for (var i = 0; i < timers.length; i++) clearTimeout(timers[i]); timers = [] } }
     }

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -4,7 +4,7 @@
  * "Tweak" panel (bottom-left) for switching between variants + replaying.
  *
  * Four variants (selected via localStorage `intro-variant`, default '2'):
- *   1 · 粒子   — agent/context tokens feed particles that spell "JOYE"
+ *   1 · 粒子   — an agent run calls tools, emits shards, then composes "JOYE"
  *   2 · 终端   — `joye.init()` terminal boot sequence
  *   3 · 排版   — kinetic variable-weight typography
  *   4 · 编排   — labelled multi-agent graph converges into "JOYE"
@@ -92,7 +92,7 @@
     height: 100%;
     display: block;
   }
-  .intro-context {
+  .intro-run {
     position: absolute;
     inset: 0;
     z-index: 1;
@@ -100,33 +100,130 @@
     overflow: hidden;
     font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
   }
-  .intro-token {
+  .intro-task {
     position: absolute;
     opacity: 0;
-    transform: translateY(12px) scale(0.98);
+    top: 8%;
+    left: 50%;
+    transform: translate(-50%, 12px);
     color: hsl(var(--primary) / 0.56);
     font-size: clamp(10px, 1.2vw, 13px);
     letter-spacing: 0.08em;
-    text-transform: lowercase;
     text-shadow: 0 0 18px hsl(var(--primary) / 0.16);
     transition:
       opacity 0.9s ease,
-      transform 1.2s cubic-bezier(0.16, 1, 0.3, 1),
-      filter 0.9s ease;
+      transform 1.2s cubic-bezier(0.16, 1, 0.3, 1);
     white-space: nowrap;
   }
-  .intro-context.show .intro-token {
-    opacity: 0.46;
-    transform: translateY(0) scale(1);
+  .intro-run.start .intro-task {
+    opacity: 0.56;
+    transform: translate(-50%, 0);
   }
-  .intro-context.folding .intro-token {
-    opacity: 0.16;
-    transform: translateY(-12px) scale(0.96);
+  .intro-tools {
+    position: absolute;
+    inset: 0;
+  }
+  .intro-tool {
+    position: absolute;
+    width: clamp(132px, 16vw, 212px);
+    max-width: 42vw;
+    opacity: 0;
+    transform: translate(-50%, 10px) scale(0.98);
+    padding: 8px 10px;
+    color: hsl(var(--muted-foreground));
+    background: hsl(var(--card) / 0.42);
+    border: 1px solid hsl(var(--border) / 0.7);
+    border-radius: 8px;
+    box-shadow: 0 14px 36px -24px hsl(var(--foreground) / 0.5);
+    backdrop-filter: blur(8px);
+    transition:
+      opacity 0.65s ease,
+      transform 0.8s cubic-bezier(0.16, 1, 0.3, 1),
+      border-color 0.5s ease,
+      filter 0.5s ease;
+  }
+  .intro-run.invoke .intro-tool {
+    opacity: 0.58;
+    transform: translate(-50%, 0) scale(1);
+  }
+  .intro-tool__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    color: hsl(var(--foreground) / 0.75);
+    font-size: 11px;
+    white-space: nowrap;
+  }
+  .intro-tool__call {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .intro-tool__status {
+    color: hsl(var(--primary) / 0.8);
+    font-size: 10px;
+  }
+  .intro-shards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-top: 7px;
+  }
+  .intro-shard {
+    opacity: 0;
+    transform: translateY(6px);
+    color: hsl(var(--primary) / 0.7);
+    font-size: 10px;
+    line-height: 1;
+    padding: 4px 6px;
+    border-radius: 6px;
+    background: hsl(var(--primary) / 0.07);
+    border: 1px solid hsl(var(--primary) / 0.12);
+    transition:
+      opacity 0.55s ease,
+      transform 0.55s ease;
+  }
+  .intro-run.compose .intro-shard {
+    opacity: 0.72;
+    transform: translateY(0);
+  }
+  .intro-run.merge .intro-tool {
+    opacity: 0.2;
+    transform: translate(-50%, -10px) scale(0.97);
     filter: blur(0.5px);
   }
-  .intro-context.leaving .intro-token {
+  .intro-merge {
+    position: absolute;
+    left: 50%;
+    top: 65%;
     opacity: 0;
-    transform: translateY(-34px) scale(0.94);
+    transform: translate(-50%, 10px);
+    color: hsl(var(--primary) / 0.62);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    white-space: nowrap;
+    transition:
+      opacity 0.7s ease,
+      transform 0.7s ease;
+  }
+  .intro-run.merge .intro-merge {
+    opacity: 0.58;
+    transform: translate(-50%, 0);
+  }
+  .intro-run.leaving .intro-task {
+    opacity: 0;
+    transform: translate(-50%, -34px) scale(0.94);
+    filter: blur(2px);
+  }
+  .intro-run.leaving .intro-tool {
+    opacity: 0;
+    transform: translate(-50%, -34px) scale(0.94);
+    filter: blur(2px);
+  }
+  .intro-run.leaving .intro-merge {
+    opacity: 0;
+    transform: translate(-50%, -34px) scale(0.94);
     filter: blur(2px);
   }
   .intro-enter {
@@ -193,6 +290,33 @@
   .intro-trace.show {
     transform: translate(-50%, 0);
     opacity: 0.46;
+  }
+  @media (max-width: 700px) {
+    .intro-task {
+      top: 6%;
+      max-width: calc(100vw - 32px);
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .intro-tool {
+      width: 138px;
+      max-width: 44vw;
+      padding: 7px 8px;
+    }
+    .intro-tool__head {
+      gap: 8px;
+      font-size: 10px;
+    }
+    .intro-shard {
+      font-size: 9px;
+      padding: 3px 5px;
+    }
+    .intro-merge {
+      top: 56%;
+      max-width: calc(100vw - 32px);
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 
   /* skip button */
@@ -580,18 +704,56 @@
       canvas.className = 'intro-canvas'
       stage.appendChild(canvas)
       var context = document.createElement('div')
-      context.className = 'intro-context'
-      var TOKENS = ['context', 'planner', 'tools', 'memory', 'eval', 'rag', 'multi-agent', 'openharness', 'frontend', 'design', 'ship', 'notes', 'search', 'trace', 'typescript', 'cursor']
-      var POS = [[10, 18], [24, 12], [43, 16], [62, 11], [80, 19], [14, 38], [30, 31], [68, 34], [84, 42], [18, 66], [36, 76], [55, 71], [75, 66], [8, 82], [48, 88], [87, 82]]
-      for (var ti = 0; ti < TOKENS.length; ti++) {
-        var token = document.createElement('span')
-        token.className = 'intro-token'
-        token.textContent = TOKENS[ti]
-        token.style.left = POS[ti][0] + '%'
-        token.style.top = POS[ti][1] + '%'
-        token.style.transitionDelay = (ti * 0.045) + 's'
-        context.appendChild(token)
+      context.className = 'intro-run'
+      var task = document.createElement('div')
+      task.className = 'intro-task'
+      task.textContent = 'task: compose joye.dev/home'
+      context.appendChild(task)
+      var toolsWrap = document.createElement('div')
+      toolsWrap.className = 'intro-tools'
+      var TOOLS = [
+        { call: 'agent.runtime()', shards: ['plan', 'loop'], pos: [50, 15] },
+        { call: 'mcp.filesystem()', shards: ['posts', 'projects'], pos: [22, 27] },
+        { call: 'mcp.github()', shards: ['OpenHarness', 'ship log'], pos: [78, 29] },
+        { call: 'memory.search()', shards: ['design taste', 'frontend'], pos: [22, 56] },
+        { call: 'examples.unitize()', shards: ['tool call', 'UI case'], pos: [78, 56] },
+        { call: 'merge_context()', shards: ['identity', 'JOYE'], pos: [50, 82] }
+      ]
+      for (var ti = 0; ti < TOOLS.length; ti++) {
+        var item = TOOLS[ti]
+        var tool = document.createElement('div')
+        tool.className = 'intro-tool'
+        tool.style.left = item.pos[0] + '%'
+        tool.style.top = item.pos[1] + '%'
+        tool.style.transitionDelay = (0.12 + ti * 0.08) + 's'
+        var head = document.createElement('div')
+        head.className = 'intro-tool__head'
+        var call = document.createElement('span')
+        call.className = 'intro-tool__call'
+        call.textContent = item.call
+        var status = document.createElement('span')
+        status.className = 'intro-tool__status'
+        status.textContent = 'ok'
+        head.appendChild(call)
+        head.appendChild(status)
+        tool.appendChild(head)
+        var shards = document.createElement('div')
+        shards.className = 'intro-shards'
+        for (var si = 0; si < item.shards.length; si++) {
+          var shard = document.createElement('span')
+          shard.className = 'intro-shard'
+          shard.textContent = item.shards[si]
+          shard.style.transitionDelay = (0.24 + ti * 0.07 + si * 0.08) + 's'
+          shards.appendChild(shard)
+        }
+        tool.appendChild(shards)
+        toolsWrap.appendChild(tool)
       }
+      context.appendChild(toolsWrap)
+      var merge = document.createElement('div')
+      merge.className = 'intro-merge'
+      merge.textContent = 'merge: context shards → JOYE'
+      context.appendChild(merge)
       stage.appendChild(context)
       var enter = document.createElement('button')
       enter.className = 'intro-enter'
@@ -601,7 +763,7 @@
       stage.appendChild(enter)
       var trace = document.createElement('div')
       trace.className = 'intro-trace'
-      trace.textContent = 'context loaded · tools ready · welcome back'
+      trace.textContent = 'agent loop complete · context merged'
       stage.appendChild(trace)
       var ctx = canvas.getContext('2d')
       var root = document.documentElement
@@ -623,12 +785,11 @@
       var linkColor = 'hsl(' + PRI.h + ' ' + sat + '% ' + baseL + '%'
       var W = 0, H = 0, DPR = 1, particles = [], phase = 'gather', t0 = 0, raf = 0, stopped = false
       var mouse = { x: -1e9, y: -1e9 }
-      var enterShown = false, exitingLocal = false, autoExit = 0, revealDelay = 0, contextTimer = 0, scatterStart = 0
-      contextTimer = setTimeout(function () { if (!stopped) context.classList.add('show') }, 120)
+      var enterShown = false, exitingLocal = false, autoExit = 0, revealDelay = 0, scatterStart = 0
       function showEnter() {
         if (enterShown || exitingLocal || stopped) return
         enterShown = true
-        context.classList.add('folding')
+        context.classList.add('merge')
         enter.classList.add('show')
         trace.classList.add('show')
         autoExit = setTimeout(beginExit, 12000)
@@ -638,13 +799,12 @@
         exitingLocal = true
         phase = 'scatter'
         scatterStart = 0
-        context.classList.remove('show')
         context.classList.add('leaving')
         enter.classList.remove('show')
         trace.classList.remove('show')
         enter.disabled = true
         clearTimeout(autoExit)
-        revealDelay = setTimeout(done, 1350)
+        revealDelay = setTimeout(done, 850)
       }
       function onEnter(e) {
         e.stopPropagation()
@@ -697,13 +857,16 @@
       function build() {
         var pts = sampleText('JOYE')
         while (particles.length < pts.length)
-          particles.push({ x: 0, y: 0, vx: 0, vy: 0, tx: 0, ty: 0, r: (Math.random() * 0.9 + 0.7) * DPR, tw: Math.random() * 6.28, delay: 0, drift: Math.random() * 6.28 })
+          particles.push({ x: 0, y: 0, vx: 0, vy: 0, tx: 0, ty: 0, sx: 0, sy: 0, r: (Math.random() * 0.9 + 0.7) * DPR, tw: Math.random() * 6.28, delay: 0, drift: Math.random() * 6.28 })
         particles.length = pts.length
         pts.sort(function () { return Math.random() - 0.5 })
         for (var i = 0; i < particles.length; i++) {
+          var source = TOOLS[i % TOOLS.length].pos
           particles[i].tx = pts[i].x
           particles[i].ty = pts[i].y
-          particles[i].delay = 0.2 + (i % 6) * 0.18 + Math.random() * 1.25
+          particles[i].sx = W * source[0] / 100 + (Math.random() - 0.5) * 150 * DPR
+          particles[i].sy = H * source[1] / 100 + (Math.random() - 0.5) * 76 * DPR
+          particles[i].delay = 0.9 + (i % TOOLS.length) * 0.16 + Math.random() * 0.85
           if (!particles[i].drift) particles[i].drift = Math.random() * 6.28
         }
       }
@@ -714,10 +877,26 @@
         if (phase === 'scatter' && !scatterStart) scatterStart = ts
         var scatterAge = scatterStart ? (ts - scatterStart) / 1000 : 0
         ctx.clearRect(0, 0, W, H)
-        if (el > 3.15 && phase === 'gather') phase = 'hold'
-        if (el > 2.35 && phase !== 'scatter') context.classList.add('folding')
-        if (el > 4.05 && phase === 'hold') showEnter()
+        if (el > 0.12) context.classList.add('start')
+        if (el > 0.72) context.classList.add('invoke')
+        if (el > 1.55) context.classList.add('compose')
+        if (el > 2.95 && phase !== 'scatter') context.classList.add('merge')
+        if (el > 3.7 && phase === 'gather') phase = 'hold'
+        if (el > 4.35 && phase === 'hold') showEnter()
         var ease = phase === 'gather' ? 0.045 : phase === 'hold' ? 0.11 : 0.018
+        if (phase !== 'scatter' && el > 0.72) {
+          var linkFade = Math.min(1, (el - 0.72) / 0.75)
+          if (el > 2.85) linkFade *= Math.max(0.18, 1 - (el - 2.85) / 1.2)
+          ctx.lineWidth = DPR * 0.7
+          for (var li = 0; li < TOOLS.length; li++) {
+            var src = TOOLS[li].pos
+            ctx.strokeStyle = linkColor + ' / ' + (0.085 * linkFade) + ')'
+            ctx.beginPath()
+            ctx.moveTo(W * src[0] / 100, H * src[1] / 100)
+            ctx.quadraticCurveTo(W / 2, H * 0.35, W / 2, H * 0.47)
+            ctx.stroke()
+          }
+        }
         if (phase !== 'scatter') {
           ctx.lineWidth = DPR * 0.6
           for (var i = 0; i < particles.length; i += 2) {
@@ -739,7 +918,7 @@
             pt.vx += (Math.random() - 0.5) * 0.16 * DPR + odx * 0.09 * DPR
             pt.vy += ((Math.random() - 0.5) * 0.08 - 0.11) * DPR
           } else {
-            var pull = phase === 'hold' ? 1 : Math.max(0, Math.min(1, (el - pt.delay) / 1.55))
+            var pull = phase === 'hold' ? 1 : Math.max(0, Math.min(1, (el - pt.delay) / 2.05))
             if (pull < 1) {
               pt.vx += Math.sin(el * 0.9 + pt.drift) * 0.012 * DPR
               pt.vy += Math.cos(el * 0.7 + pt.drift) * 0.012 * DPR
@@ -754,8 +933,10 @@
           pt.vx *= damp; pt.vy *= damp; pt.x += pt.vx; pt.y += pt.vy; pt.tw += 0.05
           var near = (pt.x - pt.tx) * (pt.x - pt.tx) + (pt.y - pt.ty) * (pt.y - pt.ty) < (8 * DPR) * (8 * DPR)
           var tw = (dark ? 0.6 : 0.8) + Math.sin(pt.tw) * (dark ? 0.22 : 0.15)
-          var fade = phase === 'scatter' ? Math.max(0, 1 - scatterAge / 2.4) : 1
+          var fade = phase === 'scatter' ? Math.max(0, 1 - scatterAge / 1.45) : 1
+          var born = (phase === 'scatter' || phase === 'hold') ? 1 : Math.max(0, Math.min(1, (el - pt.delay + 0.28) / 0.55))
           var a = phase === 'scatter' ? (dark ? 0.5 : 0.62) * fade : (near ? (dark ? 0.95 : 1) : dark ? 0.7 : 0.86) * tw
+          a *= born
           ctx.beginPath()
           ctx.fillStyle = dot(pt.x / W, Math.min(1, a))
           ctx.arc(pt.x, pt.y, pt.r * (near ? 1.25 : 1) * (phase === 'scatter' ? 0.95 + scatterAge * 0.08 : 1), 0, 7)
@@ -773,11 +954,11 @@
       resize(); build()
       if (particles.length === 0) { done() }
       else {
-        var rad = Math.max(W, H)
         for (var i = 0; i < particles.length; i++) {
-          var ang = Math.random() * 6.283
-          particles[i].x = W / 2 + Math.cos(ang) * rad
-          particles[i].y = H / 2 + Math.sin(ang) * rad
+          particles[i].x = particles[i].sx
+          particles[i].y = particles[i].sy
+          particles[i].vx = (Math.random() - 0.5) * DPR
+          particles[i].vy = (Math.random() - 0.5) * DPR
         }
         raf = requestAnimationFrame(frame)
       }
@@ -787,7 +968,6 @@
           stopped = true
           clearTimeout(autoExit)
           clearTimeout(revealDelay)
-          clearTimeout(contextTimer)
           cancelAnimationFrame(raf)
           enter.removeEventListener('click', onEnter)
           removeEventListener('mousemove', onMove)

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -353,7 +353,14 @@ import avatar from 'src/assets/avatar.png'
       if (d > 0.985 && !doneAt && el > STEPS[STEPS.length - 1].t + 0.5) doneAt = ts
       if (doneAt && ts - doneAt > 700 && !landed) land()
       var dim = doneAt ? Math.min(1, (ts - doneAt) / 900) : 0
-      var breathe = 1 + Math.sin(el * 0.85) * 0.3 * dim   // slow breathing glow once landed (~7s)
+      // slow breath when landed: scattered+dim → gathered+bright (held ~2s) → scattered+dim (~8s)
+      var bt = (el * 0.125) % 1, bc
+      if (bt < 0.34) bc = bt / 0.34
+      else if (bt < 0.6) bc = 1
+      else bc = Math.max(0, 1 - (bt - 0.6) / 0.34)
+      bc = bc * bc * (3 - 2 * bc)
+      var breathScatter = (1 - bc) * 0.05 * dim
+      var bf = 1 - dim + dim * (0.4 + bc)
       updateStages()
       if (doneAt) hud.style.opacity = String(1 - dim)
 
@@ -363,19 +370,20 @@ import avatar from 'src/assets/avatar.png'
 
       for (var k = 0; k < parts.length; k++) {
         var p = parts[k]
-        var ax = p.tx + p.ox * noiseK, ay = p.ty + p.oy * noiseK
+        var sK = noiseK + breathScatter
+        var ax = p.tx + p.ox * sK, ay = p.ty + p.oy * sK
         p.x += (ax - p.x) * (0.18 + pulse * 0.5); p.y += (ay - p.y) * (0.18 + pulse * 0.5)
         // hover — disperse away from the cursor + enlarge + light up; spring back when it leaves
         var hb = 0
         if (d > 0.5) {
-          var mdx = p.x - mouse.x, mdy = p.y - mouse.y, m2 = mdx * mdx + mdy * mdy, RR = (42 * DPR) * (42 * DPR)
-          if (m2 < RR) { hb = 1 - m2 / RR; var dd = Math.sqrt(m2) || 1, f = hb * 12 * DPR; p.x += mdx / dd * f; p.y += mdy / dd * f }
+          var mdx = p.x - mouse.x, mdy = p.y - mouse.y, m2 = mdx * mdx + mdy * mdy, RR = (21 * DPR) * (21 * DPR)
+          if (m2 < RR) { hb = 1 - m2 / RR; var dd = Math.sqrt(m2) || 1, f = hb * 8 * DPR; p.x += mdx / dd * f; p.y += mdy / dd * f }
         }
         var turb = noiseK * 34 * DPR
         var rx = p.x + Math.sin(p.y * 0.012 + el * 1.7 + p.seed * 6.28) * turb
         var ry = p.y + Math.cos(p.x * 0.012 - el * 1.4 + p.seed * 4) * turb
         var tw = 0.55 + Math.sin(p.tw = (p.tw || 0) + 0.04) * 0.2 * (1 - dim * 0.92)
-        var a = (0.30 + d * 0.6) * tw * (1 + pulse * 1.1) * (1 - dim * 0.4) * breathe * (1 + hb * 2.4)   // recede + slow breathe when landed; hover lights it up
+        var a = (0.30 + d * 0.6) * tw * (1 + pulse * 1.1) * bf * (1 + hb * 2.4)   // breathe (dim↔bright) when landed; hover lights it up
         var s = p.r * (7.5 - d * 4.6) * (1 + pulse * 0.5 + hb * 1.8)         // + bigger glow under hover
         ctx.globalAlpha = Math.min(1, a)
         ctx.drawImage(sprite, rx - s / 2, ry - s / 2, s, s)

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -1,0 +1,337 @@
+---
+/**
+ * IntroOverlay — full-screen particle entrance that forms the word "JOYE"
+ * from drifting particles, then disperses + fades to reveal the page beneath.
+ *
+ * Behaviour:
+ *  - Plays once per browser session (sessionStorage `intro-seen`).
+ *  - Skippable (button or click anywhere).
+ *  - Respects `prefers-reduced-motion` (removed before first paint).
+ *  - Theme-aware: colours are read from the site's CSS design tokens
+ *    (`--background` / `--primary` / `--foreground`), so it matches both
+ *    light (steel-blue particles) and dark (cyan particles) modes.
+ *
+ * The overlay does NOT render its own hero — it sits above the real homepage
+ * and fades out to reveal it, so there is nothing to keep in sync.
+ */
+---
+
+<div id='intro-overlay' class='intro-overlay' aria-hidden='true'>
+  <canvas id='intro-canvas'></canvas>
+  <button id='intro-skip' class='intro-skip' type='button' aria-label='跳过入场动画'>跳过 →</button>
+</div>
+
+{/* Synchronous gate: drop the overlay before first paint for repeat visits / reduced motion. */}
+<script is:inline>
+  ;(function () {
+    try {
+      var skip =
+        sessionStorage.getItem('intro-seen') === '1' ||
+        (window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches)
+      if (skip) {
+        var el = document.getElementById('intro-overlay')
+        if (el) el.remove()
+      }
+    } catch (e) {}
+  })()
+</script>
+
+<style>
+  .intro-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: hsl(var(--background));
+    overflow: hidden;
+    /* keep it opaque from first paint; JS fades it out */
+    opacity: 1;
+  }
+  .intro-overlay::before {
+    content: '';
+    position: absolute;
+    inset: -20%;
+    pointer-events: none;
+    background: radial-gradient(42% 46% at 50% 45%, hsl(var(--primary) / 0.1), transparent 70%);
+  }
+  .intro-overlay.intro-done {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.9s ease;
+  }
+  #intro-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+  .intro-skip {
+    position: absolute;
+    bottom: 22px;
+    right: 22px;
+    z-index: 2;
+    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+    font-size: 12px;
+    color: hsl(var(--muted-foreground));
+    background: hsl(var(--card) / 0.55);
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    padding: 7px 12px;
+    cursor: pointer;
+    transition: 0.2s;
+  }
+  .intro-skip:hover {
+    color: hsl(var(--foreground));
+    border-color: hsl(var(--primary) / 0.5);
+  }
+  /* Belt-and-braces: never show for reduced-motion users even before JS runs. */
+  @media (prefers-reduced-motion: reduce) {
+    .intro-overlay {
+      display: none;
+    }
+  }
+</style>
+
+<script>
+  const overlay = document.getElementById('intro-overlay') as HTMLElement | null
+  const canvas = document.getElementById('intro-canvas') as HTMLCanvasElement | null
+
+  if (overlay && canvas) {
+    // Mark immediately so a refresh mid-play doesn't replay.
+    try {
+      sessionStorage.setItem('intro-seen', '1')
+    } catch (e) {}
+
+    const ctx = canvas.getContext('2d')!
+    const reduce = matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    type P = { x: number; y: number; vx: number; vy: number; tx: number; ty: number; r: number; tw: number }
+    let W = 0
+    let H = 0
+    let DPR = 1
+    let particles: P[] = []
+    let phase: 'gather' | 'hold' | 'scatter' = 'gather'
+    let finishing = false
+    let finished = false
+    let raf = 0
+    let t0 = 0
+    const mouse = { x: -1e9, y: -1e9 }
+
+    // ── theme tokens → canvas colours ──────────────────────────────────────
+    const cs = getComputedStyle(document.documentElement)
+    const parseHSL = (v: string) => {
+      const m = v.trim().match(/([\d.]+)\s+([\d.]+)%\s+([\d.]+)%/)
+      return m ? { h: +m[1], s: +m[2], l: +m[3] } : { h: 200, s: 30, l: 50 }
+    }
+    const PRI = parseHSL(cs.getPropertyValue('--primary'))
+    const isDark = document.documentElement.classList.contains('dark')
+    // Light mode sits on a near-white bg, so push particles darker + more
+    // saturated + more opaque to keep "JOYE" crisp. Dark mode keeps the bright
+    // cyan that already pops against the dark background.
+    const baseL = isDark ? PRI.l : Math.min(PRI.l, 40)
+    const sat = isDark ? PRI.s : Math.min(PRI.s + 18, 62)
+    const SPAN = isDark ? 18 : 14 // lightness spread across x → subtle gradient
+    const linkA = isDark ? 0.1 : 0.18
+    const dot = (k: number, a: number) => {
+      const l = Math.max(4, Math.min(96, baseL + (k - 0.5) * SPAN))
+      return `hsl(${PRI.h} ${sat}% ${l}% / ${a})`
+    }
+    const linkColor = `hsl(${PRI.h} ${sat}% ${baseL}%`
+
+    const vw = () => innerWidth || document.documentElement.clientWidth || 1280
+    const vh = () => innerHeight || document.documentElement.clientHeight || 800
+    function resize() {
+      DPR = Math.min(devicePixelRatio || 1, 2)
+      const w = vw()
+      const h = vh()
+      W = canvas!.width = Math.round(w * DPR)
+      H = canvas!.height = Math.round(h * DPR)
+      canvas!.style.width = w + 'px'
+      canvas!.style.height = h + 'px'
+    }
+
+    // Sample "JOYE" into target points, with manual letter-spacing for legibility.
+    function sampleText(text: string) {
+      if (!W || !H) return [] as { x: number; y: number }[]
+      const off = document.createElement('canvas')
+      off.width = W
+      off.height = H
+      const o = off.getContext('2d')!
+      o.fillStyle = '#fff'
+      o.textBaseline = 'middle'
+      o.textAlign = 'left'
+      const tracking = 0.18
+      let size = Math.min(H * 0.4, W * 0.32)
+      const setFont = () => (o.font = `700 ${size}px Satoshi, system-ui, sans-serif`)
+      setFont()
+      const advance = () => {
+        let w = 0
+        for (const ch of text) w += o.measureText(ch).width + size * tracking
+        return w - size * tracking
+      }
+      const maxW = W * 0.72
+      if (advance() > maxW) {
+        size *= maxW / advance()
+        setFont()
+      }
+      let x = (W - advance()) / 2
+      const y = H * 0.47
+      for (const ch of text) {
+        o.fillText(ch, x, y)
+        x += o.measureText(ch).width + size * tracking
+      }
+      const data = o.getImageData(0, 0, W, H).data
+      const gap = Math.max(5, Math.round(7 * DPR))
+      const pts: { x: number; y: number }[] = []
+      for (let yy = 0; yy < H; yy += gap)
+        for (let xx = 0; xx < W; xx += gap)
+          if (data[(yy * W + xx) * 4 + 3] > 128) pts.push({ x: xx, y: yy })
+      return pts
+    }
+
+    function build() {
+      const pts = sampleText('JOYE')
+      while (particles.length < pts.length)
+        particles.push({ x: 0, y: 0, vx: 0, vy: 0, tx: 0, ty: 0, r: (Math.random() * 0.9 + 0.7) * DPR, tw: Math.random() * 6.28 })
+      particles.length = pts.length
+      pts.sort(() => Math.random() - 0.5)
+      particles.forEach((p, i) => {
+        p.tx = pts[i].x
+        p.ty = pts[i].y
+      })
+    }
+
+    function frame(ts: number) {
+      if (!t0) t0 = ts
+      const el = (ts - t0) / 1000
+      ctx.clearRect(0, 0, W, H)
+
+      if (el > 1.7 && phase === 'gather') phase = 'hold'
+      if (el > 2.5 && !finishing) beginReveal()
+
+      const ease = phase === 'gather' ? 0.07 : phase === 'hold' ? 0.13 : 0.02
+
+      // constellation links while formed-ish
+      if (phase !== 'scatter') {
+        ctx.lineWidth = DPR * 0.6
+        for (let i = 0; i < particles.length; i += 2) {
+          const p = particles[i]
+          for (let j = i + 2; j < i + 10 && j < particles.length; j++) {
+            const q = particles[j]
+            const dx = p.x - q.x
+            const dy = p.y - q.y
+            const d2 = dx * dx + dy * dy
+            const R = 26 * DPR
+            if (d2 < R * R) {
+              ctx.strokeStyle = `${linkColor} / ${linkA * (1 - d2 / (R * R))})`
+              ctx.beginPath()
+              ctx.moveTo(p.x, p.y)
+              ctx.lineTo(q.x, q.y)
+              ctx.stroke()
+            }
+          }
+        }
+      }
+
+      for (const p of particles) {
+        if (phase === 'scatter') {
+          p.vx += (Math.random() - 0.5) * 0.7 * DPR
+          p.vy += ((Math.random() - 0.5) * 0.7 - 0.16) * DPR
+        } else {
+          p.vx += (p.tx - p.x) * ease
+          p.vy += (p.ty - p.y) * ease
+          const mdx = p.x - mouse.x
+          const mdy = p.y - mouse.y
+          const md2 = mdx * mdx + mdy * mdy
+          const R = 110 * DPR
+          if (md2 < R * R) {
+            const f = (1 - md2 / (R * R)) * 4
+            const d = Math.sqrt(md2) || 1
+            p.vx += (mdx / d) * f
+            p.vy += (mdy / d) * f
+          }
+        }
+        p.vx *= 0.86
+        p.vy *= 0.86
+        p.x += p.vx
+        p.y += p.vy
+        p.tw += 0.05
+
+        const near = (p.x - p.tx) ** 2 + (p.y - p.ty) ** 2 < (8 * DPR) ** 2
+        const tw = (isDark ? 0.6 : 0.8) + Math.sin(p.tw) * (isDark ? 0.22 : 0.15)
+        const a =
+          phase === 'scatter'
+            ? isDark
+              ? 0.5
+              : 0.62
+            : (near ? (isDark ? 0.95 : 1) : isDark ? 0.7 : 0.86) * tw
+        ctx.beginPath()
+        ctx.fillStyle = dot(p.x / W, Math.min(1, a))
+        ctx.arc(p.x, p.y, p.r * (near ? 1.25 : 1), 0, 7)
+        ctx.fill()
+      }
+
+      if (!finished) raf = requestAnimationFrame(frame)
+    }
+
+    function beginReveal() {
+      if (finishing) return
+      finishing = true
+      phase = 'scatter'
+      overlay!.classList.add('intro-done')
+      setTimeout(() => {
+        finished = true
+        cancelAnimationFrame(raf)
+        overlay!.remove()
+      }, 950)
+    }
+
+    function start() {
+      resize()
+      particles = []
+      build()
+      if (particles.length === 0) {
+        // font/layout not ready or sampling failed → don't block the page
+        beginReveal()
+        return
+      }
+      // scatter-in start positions
+      const rad = Math.max(W, H)
+      particles.forEach((p) => {
+        const ang = Math.random() * 6.283
+        p.x = W / 2 + Math.cos(ang) * rad
+        p.y = H / 2 + Math.sin(ang) * rad
+      })
+      raf = requestAnimationFrame(frame)
+    }
+
+    // interactions
+    addEventListener('resize', () => {
+      if (!finished) {
+        resize()
+        build()
+      }
+    })
+    addEventListener('mousemove', (e) => {
+      mouse.x = e.clientX * DPR
+      mouse.y = e.clientY * DPR
+    })
+    document.getElementById('intro-skip')?.addEventListener('click', (e) => {
+      e.stopPropagation()
+      beginReveal()
+    })
+    overlay.addEventListener('click', beginReveal)
+
+    if (reduce) {
+      overlay.remove()
+    } else {
+      // Sample once the brand font is ready so "JOYE" has the right shape.
+      const go = () => start()
+      const fontReady = (document as any).fonts?.load?.('700 120px "Satoshi"')
+      Promise.race([
+        Promise.resolve(fontReady).catch(() => {}),
+        new Promise((r) => setTimeout(r, 700))
+      ]).then(go)
+    }
+  }
+</script>

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -1,55 +1,46 @@
 ---
 /**
- * IntroOverlay — full-screen home-page entrance animation, with a small
- * "Tweak" panel (bottom-left) for switching between variants + replaying.
+ * IntroOverlay — home-page entrance animation.
  *
- * Four variants (selected via localStorage `intro-variant`, default '2'):
- *   1 · 粒子   — an agent run calls tools, emits shards, then composes "JOYE"
- *   2 · 终端   — `joye.init()` terminal boot sequence
- *   3 · 排版   — kinetic variable-weight typography
- *   4 · 编排   — labelled multi-agent graph converges into "JOYE"
+ * An agent generates "JOYE" by diffusion: a field of noise denoises in
+ * discrete steps (a 3-stage pipeline: sample → refine → decode) until the
+ * name resolves, then the overlay fades to reveal the real homepage beneath.
  *
- * Shared behaviour:
- *   - Auto-plays once per session (sessionStorage `intro-seen`), skippable,
- *     disabled under prefers-reduced-motion.
- *   - Never renders its own hero — it sits above the page and fades out to
- *     reveal the real homepage beneath. Overlay bg == site bg (no colour jump).
- *   - The overlay is hidden (not removed) after playing, so the Tweak panel's
- *     replay / variant buttons can re-run it without a reload.
+ * Behaviour:
+ *   - Plays once per browser session (sessionStorage `intro-seen`).
+ *   - Skippable (button, or click anywhere). Disabled under prefers-reduced-motion.
+ *   - Hover while it's up disperses + lights up that patch of particles.
+ *   - Dark overlay (the diffusion aesthetic); fades out to the real page.
  *
- * NOTE: the Tweak panel is a review/testing aid. Before a production merge we
- * should gate it (e.g. `?tweak` query or remove it).
- *
- * Scripts use `is:inline` so the dynamically-created DOM (canvas / terminal /
- * words) is styled by the `is:global` block below (Astro's scoped styles don't
- * reach nodes created at runtime).
+ * Scripts use `is:inline` so the runtime-created <canvas> is styled by the
+ * `is:global` block (Astro scoped styles don't reach nodes made at runtime).
  */
 ---
 
 <div id='intro-overlay' class='intro-overlay' aria-hidden='true'>
-  <div id='intro-stage' class='intro-stage'></div>
+  <canvas id='intro-canvas'></canvas>
+  <div class='intro-hud' id='intro-hud'>
+    <div class='intro-pipe'>
+      <div class='intro-stage'><i></i><span>sample</span></div>
+      <div class='intro-seg'><b></b></div>
+      <div class='intro-stage'><i></i><span>refine</span></div>
+      <div class='intro-seg'><b></b></div>
+      <div class='intro-stage'><i></i><span>decode</span></div>
+    </div>
+  </div>
   <button id='intro-skip' class='intro-skip' type='button' aria-label='跳过入场动画'>跳过 →</button>
 </div>
 
-<div id='intro-tweak' class='intro-tweak' aria-hidden='true'>
-  <span class='intro-tweak__label'>入场动画</span>
-  <button type='button' data-variant='1'>动画一 · 粒子</button>
-  <button type='button' data-variant='2'>动画二 · 终端</button>
-  <button type='button' data-variant='3'>动画三 · 排版</button>
-  <button type='button' data-variant='4'>动画四 · 编排</button>
-  <span class='intro-tweak__sep'></span>
-  <button type='button' id='intro-replay'>↻ replay</button>
-</div>
-
-{/* Synchronous gate: hide the overlay before first paint for repeat visits / reduced motion. */}
+{/* Synchronous gate: drop the overlay before first paint for repeat visits / reduced motion. */}
 <script is:inline>
   ;(function () {
     try {
-      var seen = sessionStorage.getItem('intro-seen') === '1'
-      var reduce = window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches
-      if (seen || reduce) {
+      var skip =
+        sessionStorage.getItem('intro-seen') === '1' ||
+        (window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches)
+      if (skip) {
         var el = document.getElementById('intro-overlay')
-        if (el) el.classList.add('intro-idle')
+        if (el) el.remove()
       }
     } catch (e) {}
   })()
@@ -60,266 +51,88 @@
     position: fixed;
     inset: 0;
     z-index: 9999;
-    background: hsl(var(--background));
+    background: #06090d;
     overflow: hidden;
     opacity: 1;
-  }
-  .intro-overlay::before {
-    content: '';
-    position: absolute;
-    inset: -20%;
-    pointer-events: none;
-    background: radial-gradient(42% 46% at 50% 45%, hsl(var(--primary) / 0.1), transparent 70%);
-  }
-  .intro-overlay.intro-idle {
-    display: none;
   }
   .intro-overlay.intro-done {
     opacity: 0;
     pointer-events: none;
-    transition: opacity 0.9s ease;
+    transition: opacity 0.95s ease;
   }
-  .intro-stage {
-    position: absolute;
-    inset: 0;
-    display: grid;
-    place-items: center;
-  }
-  .intro-canvas {
+  #intro-canvas {
     position: absolute;
     inset: 0;
     width: 100%;
     height: 100%;
     display: block;
   }
-  .intro-run {
-    position: absolute;
-    inset: 0;
-    z-index: 1;
-    pointer-events: none;
-    overflow: hidden;
-    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-  }
-  .intro-task {
-    position: absolute;
-    opacity: 0;
-    top: 8%;
+  /* 3-stage agent pipeline */
+  .intro-hud {
+    position: fixed;
     left: 50%;
-    transform: translate(-50%, 12px);
-    color: hsl(var(--primary) / 0.56);
-    font-size: clamp(10px, 1.2vw, 13px);
-    letter-spacing: 0.08em;
-    text-shadow: 0 0 18px hsl(var(--primary) / 0.16);
-    transition:
-      opacity 0.9s ease,
-      transform 1.2s cubic-bezier(0.16, 1, 0.3, 1);
+    top: 8.5%;
+    transform: translateX(-50%);
+    z-index: 2;
+    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+    opacity: 0;
+    transition: opacity 0.9s ease;
     white-space: nowrap;
   }
-  .intro-run.start .intro-task {
-    opacity: 0.56;
-    transform: translate(-50%, 0);
+  .intro-hud.show {
+    opacity: 1;
   }
-  .intro-tools {
-    position: absolute;
-    inset: 0;
-  }
-  .intro-tool {
-    position: absolute;
-    width: clamp(132px, 16vw, 212px);
-    max-width: 42vw;
-    opacity: 0;
-    transform: translate(-50%, 10px) scale(0.98);
-    padding: 8px 10px;
-    color: hsl(var(--muted-foreground));
-    background: hsl(var(--card) / 0.42);
-    border: 1px solid hsl(var(--border) / 0.7);
-    border-radius: 8px;
-    box-shadow: 0 14px 36px -24px hsl(var(--foreground) / 0.5);
-    backdrop-filter: blur(8px);
-    transition:
-      opacity 0.65s ease,
-      transform 0.8s cubic-bezier(0.16, 1, 0.3, 1),
-      border-color 0.5s ease,
-      filter 0.5s ease;
-  }
-  .intro-run.invoke .intro-tool {
-    opacity: 0.58;
-    transform: translate(-50%, 0) scale(1);
-  }
-  .intro-tool__head {
+  .intro-pipe {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    color: hsl(var(--foreground) / 0.75);
-    font-size: 11px;
-    white-space: nowrap;
+    justify-content: center;
   }
-  .intro-tool__call {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .intro-tool__status {
-    color: hsl(var(--primary) / 0.8);
-    font-size: 10px;
-  }
-  .intro-shards {
+  .intro-stage {
     display: flex;
-    flex-wrap: wrap;
-    gap: 5px;
-    margin-top: 7px;
+    align-items: center;
+    gap: 7px;
+    opacity: 0.36;
+    transition: opacity 0.45s ease;
   }
-  .intro-shard {
-    opacity: 0;
-    transform: translateY(6px);
-    color: hsl(var(--primary) / 0.7);
-    font-size: 10px;
-    line-height: 1;
-    padding: 4px 6px;
-    border-radius: 6px;
-    background: hsl(var(--primary) / 0.07);
-    border: 1px solid hsl(var(--primary) / 0.12);
-    transition:
-      opacity 0.55s ease,
-      transform 0.55s ease;
-  }
-  .intro-run.compose .intro-shard {
-    opacity: 0.72;
-    transform: translateY(0);
-  }
-  .intro-run.merge .intro-tool {
-    opacity: 0.2;
-    transform: translate(-50%, -10px) scale(0.97);
-    filter: blur(0.5px);
-  }
-  .intro-merge {
-    position: absolute;
-    left: 50%;
-    top: 65%;
-    opacity: 0;
-    transform: translate(-50%, 10px);
-    color: hsl(var(--primary) / 0.62);
-    font-size: 11px;
-    letter-spacing: 0.08em;
-    white-space: nowrap;
-    transition:
-      opacity 0.7s ease,
-      transform 0.7s ease;
-  }
-  .intro-run.merge .intro-merge {
-    opacity: 0.58;
-    transform: translate(-50%, 0);
-  }
-  .intro-run.leaving .intro-task {
-    opacity: 0;
-    transform: translate(-50%, -34px) scale(0.94);
-    filter: blur(2px);
-  }
-  .intro-run.leaving .intro-tool {
-    opacity: 0;
-    transform: translate(-50%, -34px) scale(0.94);
-    filter: blur(2px);
-  }
-  .intro-run.leaving .intro-merge {
-    opacity: 0;
-    transform: translate(-50%, -34px) scale(0.94);
-    filter: blur(2px);
-  }
-  .intro-enter {
-    position: absolute;
-    left: 50%;
-    top: calc(50% + clamp(96px, 18vh, 170px));
-    z-index: 3;
-    transform: translate(-50%, 10px);
-    opacity: 0;
-    pointer-events: none;
-    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-    font-size: 13px;
-    color: hsl(var(--foreground));
-    background: hsl(var(--card) / 0.68);
-    border: 1px solid hsl(var(--primary) / 0.34);
-    border-radius: 8px;
-    padding: 10px 15px;
-    cursor: pointer;
-    backdrop-filter: blur(10px);
-    box-shadow:
-      0 14px 36px -18px hsl(var(--foreground) / 0.45),
-      inset 0 1px 0 hsl(var(--foreground) / 0.08);
-    transition:
-      opacity 0.45s ease,
-      transform 0.45s ease,
-      background 0.2s ease,
-      border-color 0.2s ease,
-      box-shadow 0.2s ease;
-  }
-  .intro-enter.show {
-    transform: translate(-50%, 0);
+  .intro-stage.on {
     opacity: 1;
-    pointer-events: auto;
   }
-  .intro-enter:hover {
-    border-color: hsl(var(--primary) / 0.65);
-    background: hsl(var(--primary) / 0.11);
-    box-shadow:
-      0 18px 48px -20px hsl(var(--primary) / 0.72),
-      inset 0 1px 0 hsl(var(--foreground) / 0.12);
+  .intro-stage.done {
+    opacity: 0.64;
   }
-  .intro-enter:focus-visible {
-    outline: 2px solid hsl(var(--primary));
-    outline-offset: 3px;
+  .intro-stage i {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: rgba(125, 211, 252, 0.28);
+    transition: 0.45s ease;
   }
-  .intro-trace {
+  .intro-stage.on i {
+    background: #7dd3fc;
+    box-shadow: 0 0 12px rgba(125, 211, 252, 0.95);
+  }
+  .intro-stage.done i {
+    background: rgba(125, 211, 252, 0.7);
+  }
+  .intro-stage span {
+    font-size: 11px;
+    letter-spacing: 0.2em;
+    color: #7dd3fc;
+  }
+  .intro-seg {
+    width: 44px;
+    height: 1px;
+    margin: 0 12px;
+    background: rgba(125, 211, 252, 0.16);
+    position: relative;
+  }
+  .intro-seg b {
     position: absolute;
-    left: 50%;
-    top: calc(50% + clamp(164px, 26vh, 250px));
-    z-index: 3;
-    transform: translate(-50%, 8px);
-    opacity: 0;
-    pointer-events: none;
-    color: hsl(var(--muted-foreground));
-    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-    font-size: 10px;
-    letter-spacing: 0.08em;
-    text-align: center;
-    white-space: nowrap;
-    transition:
-      opacity 0.55s ease,
-      transform 0.55s ease;
+    inset: 0 auto 0 0;
+    width: 0;
+    background: #7dd3fc;
+    box-shadow: 0 0 8px rgba(125, 211, 252, 0.7);
   }
-  .intro-trace.show {
-    transform: translate(-50%, 0);
-    opacity: 0.46;
-  }
-  @media (max-width: 700px) {
-    .intro-task {
-      top: 6%;
-      max-width: calc(100vw - 32px);
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .intro-tool {
-      width: 138px;
-      max-width: 44vw;
-      padding: 7px 8px;
-    }
-    .intro-tool__head {
-      gap: 8px;
-      font-size: 10px;
-    }
-    .intro-shard {
-      font-size: 9px;
-      padding: 3px 5px;
-    }
-    .intro-merge {
-      top: 56%;
-      max-width: calc(100vw - 32px);
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-  }
-
-  /* skip button */
   .intro-skip {
     position: absolute;
     bottom: 22px;
@@ -327,294 +140,18 @@
     z-index: 2;
     font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
     font-size: 12px;
-    color: hsl(var(--muted-foreground));
-    background: hsl(var(--card) / 0.55);
-    border: 1px solid hsl(var(--border));
+    color: rgba(154, 166, 178, 0.7);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 8px;
     padding: 7px 12px;
     cursor: pointer;
     transition: 0.2s;
   }
   .intro-skip:hover {
-    color: hsl(var(--foreground));
-    border-color: hsl(var(--primary) / 0.5);
+    color: #faf9f8;
+    border-color: rgba(125, 211, 252, 0.5);
   }
-
-  /* Tweak panel (review aid) */
-  .intro-tweak {
-    position: fixed;
-    bottom: 18px;
-    left: 18px;
-    z-index: 10000;
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 6px;
-    max-width: calc(100vw - 36px);
-    padding: 6px;
-    border-radius: 12px;
-    background: hsl(var(--card) / 0.82);
-    border: 1px solid hsl(var(--border));
-    box-shadow: 0 10px 30px -12px rgba(0, 0, 0, 0.4);
-    backdrop-filter: blur(8px);
-    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-    font-size: 12px;
-  }
-  .intro-tweak__label {
-    padding: 0 6px 0 4px;
-    color: hsl(var(--muted-foreground));
-    opacity: 0.8;
-  }
-  .intro-tweak button {
-    font: inherit;
-    color: hsl(var(--muted-foreground));
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 8px;
-    padding: 6px 10px;
-    cursor: pointer;
-    transition: 0.15s;
-    white-space: nowrap;
-  }
-  .intro-tweak button:hover {
-    color: hsl(var(--foreground));
-    background: hsl(var(--muted) / 0.6);
-  }
-  .intro-tweak button.on {
-    color: hsl(var(--primary));
-    border-color: hsl(var(--primary) / 0.45);
-    background: hsl(var(--primary) / 0.08);
-  }
-  .intro-tweak #intro-replay {
-    color: hsl(var(--foreground));
-    border-color: hsl(var(--border));
-  }
-  .intro-tweak__sep {
-    width: 1px;
-    align-self: stretch;
-    margin: 2px 2px;
-    background: hsl(var(--border));
-  }
-
-  /* ── variant 2 · fullscreen CRT boot ── */
-  .intro-crt {
-    position: absolute;
-    inset: 0;
-    overflow: hidden;
-    background: radial-gradient(120% 120% at 50% 42%, #0a1117 0%, #04070a 100%);
-    color: #d7f5e6;
-    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-    font-size: clamp(11px, 1.5vw, 16px);
-    line-height: 1.72;
-    text-shadow: 0 0 6px rgba(125, 211, 252, 0.22);
-    transform-origin: 50% 50%;
-    animation: intro-crt-flicker 4s infinite steps(40);
-  }
-  .intro-crt__inner {
-    position: absolute;
-    inset: 0;
-    padding: clamp(22px, 5.5vh, 70px) clamp(20px, 6vw, 96px);
-    overflow: hidden;
-  }
-  .intro-crt::after {
-    /* scanlines */
-    content: '';
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    background: repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.3) 0 1px, transparent 1px 3px);
-    mix-blend-mode: multiply;
-  }
-  .intro-crt__vignette {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    box-shadow: inset 0 0 220px 70px rgba(0, 0, 0, 0.72);
-  }
-  .intro-crt .ln {
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-  .intro-crt .p {
-    color: #7dd3fc;
-  }
-  .intro-crt .ok {
-    color: #41d18a;
-  }
-  .intro-crt .dim {
-    color: #5e7385;
-  }
-  .intro-crt .c {
-    color: #7dd3fc;
-  }
-  .intro-crt .hd {
-    color: #9effd0;
-  }
-  .intro-crt .art {
-    color: #7dd3fc;
-    white-space: pre;
-    line-height: 1.12;
-    text-shadow: 0 0 16px rgba(125, 211, 252, 0.4);
-  }
-  .intro-crt .cr {
-    display: inline-block;
-    width: 0.6em;
-    height: 1.05em;
-    background: #7dd3fc;
-    margin-left: 2px;
-    transform: translateY(2px);
-    box-shadow: 0 0 8px rgba(125, 211, 252, 0.7);
-    animation: intro-blink 1s steps(1) infinite;
-  }
-  .intro-crt.intro-crt--off {
-    animation: intro-crt-off 0.55s ease-in forwards;
-  }
-  @keyframes intro-blink {
-    50% {
-      opacity: 0;
-    }
-  }
-  @keyframes intro-crt-flicker {
-    0%, 46%, 54%, 100% {
-      filter: brightness(1);
-    }
-    50% {
-      filter: brightness(1.06);
-    }
-    52% {
-      filter: brightness(0.96);
-    }
-  }
-  @keyframes intro-crt-off {
-    0% {
-      transform: scale(1, 1);
-      opacity: 1;
-      filter: brightness(1.3);
-    }
-    48% {
-      transform: scale(1, 0.004);
-      opacity: 1;
-      filter: brightness(3.2);
-    }
-    70% {
-      transform: scale(1, 0.004);
-      filter: brightness(3.2);
-    }
-    100% {
-      transform: scale(0, 0.004);
-      opacity: 0;
-      filter: brightness(3.4);
-    }
-  }
-
-  /* ── variant 3 · kinetic type ── */
-  .intro-kin {
-    position: absolute;
-    inset: 0;
-    display: grid;
-    place-items: center;
-    overflow: hidden;
-  }
-  .intro-kin .wd {
-    position: absolute;
-    display: flex;
-    gap: 0.02em;
-    font-weight: 900;
-    letter-spacing: -0.03em;
-    line-height: 0.9;
-    font-size: clamp(56px, 13vw, 170px);
-    color: hsl(var(--foreground));
-  }
-  .intro-kin .ch {
-    display: inline-block;
-    opacity: 0;
-    transform: translateY(0.9em);
-    font-variation-settings: 'wght' 200;
-  }
-  .intro-kin .wd.in .ch {
-    animation: intro-rise 0.62s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-  }
-  .intro-kin .wd.out {
-    animation: intro-leave 0.45s cubic-bezier(0.7, 0, 0.84, 0) forwards;
-  }
-  .intro-kin .ac {
-    color: hsl(var(--primary));
-  }
-  .intro-kin .th {
-    font-weight: 200;
-  }
-  .intro-kin__bar {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 42vw;
-    left: -46vw;
-    pointer-events: none;
-    background: linear-gradient(
-      90deg,
-      transparent,
-      hsl(var(--primary) / 0.16),
-      hsl(var(--primary) / 0.5) 92%,
-      hsl(var(--primary))
-    );
-    box-shadow: 0 0 80px 20px hsl(var(--primary) / 0.18);
-  }
-  .intro-kin__bar.go {
-    animation: intro-wipe 1.05s cubic-bezier(0.7, 0, 0.2, 1) forwards;
-  }
-  @keyframes intro-rise {
-    0% {
-      opacity: 0;
-      transform: translateY(0.9em);
-      font-variation-settings: 'wght' 200;
-    }
-    60% {
-      opacity: 1;
-    }
-    100% {
-      opacity: 1;
-      transform: none;
-      font-variation-settings: 'wght' 800;
-    }
-  }
-  @keyframes intro-leave {
-    to {
-      opacity: 0;
-      transform: translateY(-0.35em);
-      filter: blur(6px);
-    }
-  }
-  @keyframes intro-wipe {
-    to {
-      left: 104vw;
-    }
-  }
-
-  /* ── variant 4 · multi-agent orchestration ── */
-  .intro-agent {
-    position: absolute;
-    inset: 0;
-    overflow: hidden;
-    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-  }
-  .intro-agent__cap {
-    position: absolute;
-    top: 7%;
-    left: 0;
-    right: 0;
-    z-index: 1;
-    text-align: center;
-    color: hsl(var(--primary));
-    font-size: 12px;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    opacity: 0;
-    transition: opacity 0.7s ease;
-  }
-  .intro-agent__cap.show {
-    opacity: 0.78;
-  }
-
   @media (prefers-reduced-motion: reduce) {
     .intro-overlay {
       display: none;
@@ -625,651 +162,171 @@
 <script is:inline>
   ;(function () {
     var overlay = document.getElementById('intro-overlay')
-    var stage = document.getElementById('intro-stage')
-    var panel = document.getElementById('intro-tweak')
-    if (!overlay || !stage) return
+    var canvas = document.getElementById('intro-canvas')
+    var hud = document.getElementById('intro-hud')
+    if (!overlay || !canvas) return
+    try { sessionStorage.setItem('intro-seen', '1') } catch (e) {}
 
+    var ctx = canvas.getContext('2d')
     var reduce = window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches
-    var active = null
-    var exiting = false
 
-    function getVariant() {
-      try {
-        var v = localStorage.getItem('intro-variant') || '2'
-        return /^(1|2|3|4)$/.test(v) ? v : '2'
-      } catch (e) {
-        return '2'
+    var W = 0, H = 0, DPR = 1, parts = [], pulse = 0, d = 0, dTarget = 0
+    var stepShown = -1, doneAt = 0, raf = 0, t0 = 0, revealing = false
+    var mouse = { x: -1e9, y: -1e9 }
+    var STAGE_EL = null, SEG_EL = null
+
+    // soft glow sprite (cheap bloom)
+    var sprite = document.createElement('canvas')
+    sprite.width = sprite.height = 64
+    ;(function () {
+      var g = sprite.getContext('2d')
+      var r = g.createRadialGradient(32, 32, 0, 32, 32, 32)
+      r.addColorStop(0, 'rgba(214,243,255,1)')
+      r.addColorStop(0.25, 'rgba(138,214,255,.6)')
+      r.addColorStop(0.6, 'rgba(110,190,240,.14)')
+      r.addColorStop(1, 'rgba(110,190,240,0)')
+      g.fillStyle = r
+      g.fillRect(0, 0, 64, 64)
+    })()
+
+    // denoise schedule: noise → ... → resolved
+    var STEPS = [
+      { t: 0.55, d: 0.14 }, { t: 1.05, d: 0.32 }, { t: 1.55, d: 0.52 },
+      { t: 2.05, d: 0.72 }, { t: 2.5, d: 0.88 }, { t: 2.95, d: 1.0 }
+    ]
+
+    function vw() { var w = innerWidth || document.documentElement.clientWidth || 0; return w > 20 ? w : 1280 }
+    function vh() { var h = innerHeight || document.documentElement.clientHeight || 0; return h > 20 ? h : 800 }
+    function resize() {
+      DPR = Math.min(devicePixelRatio || 1, 2)
+      W = canvas.width = Math.round(vw() * DPR)
+      H = canvas.height = Math.round(vh() * DPR)
+      canvas.style.width = vw() + 'px'
+      canvas.style.height = vh() + 'px'
+    }
+    addEventListener('mousemove', function (e) { mouse.x = e.clientX * DPR; mouse.y = e.clientY * DPR })
+    addEventListener('mouseleave', function () { mouse.x = mouse.y = -1e9 })
+
+    function sampleJOYE() {
+      if (!W || !H) return []
+      var off = document.createElement('canvas'); off.width = W; off.height = H
+      var o = off.getContext('2d')
+      o.fillStyle = '#fff'; o.textBaseline = 'middle'; o.textAlign = 'left'
+      var tracking = 0.18, size = Math.min(H * 0.4, W * 0.32)
+      var setFont = function () { o.font = '700 ' + size + 'px Satoshi, system-ui, sans-serif' }
+      setFont()
+      var adv = function () { var w = 0; for (var i = 0; i < 4; i++) w += o.measureText('JOYE'[i]).width + size * tracking; return w - size * tracking }
+      if (adv() > W * 0.72) { size *= W * 0.72 / adv(); setFont() }
+      var x = (W - adv()) / 2, y = H * 0.46
+      for (var i = 0; i < 4; i++) { var ch = 'JOYE'[i]; o.fillText(ch, x, y); x += o.measureText(ch).width + size * tracking }
+      var data = o.getImageData(0, 0, W, H).data, gap = Math.max(5, Math.round(6.5 * DPR)), pts = []
+      for (var yy = 0; yy < H; yy += gap) for (var xx = 0; xx < W; xx += gap) if (data[(yy * W + xx) * 4 + 3] > 140) pts.push({ x: xx, y: yy })
+      return pts
+    }
+
+    function build() {
+      var pts = sampleJOYE(), R = Math.min(W, H) * 0.62
+      parts = pts.map(function (p) {
+        var ang = Math.random() * 6.283, mag = Math.pow(Math.random(), 0.6) * R
+        return {
+          tx: p.x, ty: p.y, ox: Math.cos(ang) * mag, oy: Math.sin(ang) * mag,
+          x: p.x + Math.cos(ang) * mag, y: p.y + Math.sin(ang) * mag,
+          ph: Math.random() * 6.28, fr: 0.6 + Math.random() * 1.4, r: (Math.random() * 0.8 + 0.7) * DPR, seed: Math.random()
+        }
+      })
+    }
+
+    function updateStages() {
+      if (!STAGE_EL) { STAGE_EL = hud.querySelectorAll('.intro-stage'); SEG_EL = hud.querySelectorAll('.intro-seg b') }
+      if (!STAGE_EL.length) return
+      var cur = d < 0.30 ? 0 : d < 0.82 ? 1 : 2
+      for (var i = 0; i < STAGE_EL.length; i++) { STAGE_EL[i].classList.toggle('on', i === cur); STAGE_EL[i].classList.toggle('done', i < cur) }
+      if (SEG_EL[0]) SEG_EL[0].style.width = (d < 0.30 ? d / 0.30 : 1) * 100 + '%'
+      if (SEG_EL[1]) SEG_EL[1].style.width = (d < 0.30 ? 0 : d < 0.82 ? (d - 0.30) / 0.52 : 1) * 100 + '%'
+    }
+
+    function frame(ts) {
+      if (!t0) t0 = ts
+      var el = (ts - t0) / 1000
+      ctx.globalCompositeOperation = 'source-over'
+      ctx.fillStyle = 'rgba(6,9,13,0.32)'; ctx.fillRect(0, 0, W, H)   // trail-fade
+      if (el > 0.1) hud.classList.add('show')
+
+      var step = -1
+      for (var i = 0; i < STEPS.length; i++) if (el >= STEPS[i].t) { dTarget = STEPS[i].d; step = i }
+      d += (dTarget - d) * 0.13
+      if (step !== stepShown) { stepShown = step; if (step >= 0) pulse = 1 }
+      if (d > 0.985 && !doneAt && el > STEPS[STEPS.length - 1].t + 0.5) doneAt = ts
+      if (doneAt && ts - doneAt > 1000 && !revealing) reveal()
+      var dim = doneAt ? Math.min(1, (ts - doneAt) / 900) : 0
+      updateStages()
+      if (doneAt) hud.style.opacity = String(1 - dim)
+
+      var noiseK = Math.pow(1 - d, 2)
+      pulse *= 0.86
+      ctx.globalCompositeOperation = 'lighter'
+
+      for (var k = 0; k < parts.length; k++) {
+        var p = parts[k]
+        var ax = p.tx + p.ox * noiseK, ay = p.ty + p.oy * noiseK
+        p.x += (ax - p.x) * (0.18 + pulse * 0.5); p.y += (ay - p.y) * (0.18 + pulse * 0.5)
+        // hover — disperse away from the cursor + enlarge + light up; spring back when it leaves
+        var hb = 0
+        if (d > 0.5) {
+          var mdx = p.x - mouse.x, mdy = p.y - mouse.y, m2 = mdx * mdx + mdy * mdy, RR = (118 * DPR) * (118 * DPR)
+          if (m2 < RR) { hb = 1 - m2 / RR; var dd = Math.sqrt(m2) || 1, f = hb * 26 * DPR; p.x += mdx / dd * f; p.y += mdy / dd * f }
+        }
+        var turb = noiseK * 34 * DPR
+        var rx = p.x + Math.sin(p.y * 0.012 + el * 1.7 + p.seed * 6.28) * turb
+        var ry = p.y + Math.cos(p.x * 0.012 - el * 1.4 + p.seed * 4) * turb
+        var tw = 0.55 + Math.sin(p.tw = (p.tw || 0) + 0.04) * 0.2 * (1 - dim * 0.92)
+        var a = (0.30 + d * 0.6) * tw * (1 + pulse * 1.1) * (1 + hb * 1.6)
+        var s = p.r * (7.5 - d * 4.6) * (1 + pulse * 0.5 + hb * 1.0)
+        ctx.globalAlpha = Math.min(1, a)
+        ctx.drawImage(sprite, rx - s / 2, ry - s / 2, s, s)
       }
-    }
-    function setVariant(v) {
-      try {
-        localStorage.setItem('intro-variant', v)
-      } catch (e) {}
-      highlight(v)
-    }
-    function highlight(v) {
-      if (!panel) return
-      var btns = panel.querySelectorAll('[data-variant]')
-      for (var i = 0; i < btns.length; i++) {
-        btns[i].classList.toggle('on', btns[i].getAttribute('data-variant') === v)
+
+      // structure mesh — faint links weave between neighbours as JOYE resolves
+      if (d > 0.5) {
+        var R2 = (16 * DPR) * (16 * DPR)
+        ctx.strokeStyle = 'rgba(125,211,252,' + (d - 0.5) * 0.42 + ')'; ctx.lineWidth = DPR * 0.5
+        ctx.beginPath()
+        for (var i2 = 0; i2 < parts.length; i2++) {
+          var pp = parts[i2]
+          for (var j = i2 + 1; j <= i2 + 2 && j < parts.length; j++) {
+            var q = parts[j], dx = pp.x - q.x, dy = pp.y - q.y
+            if (dx * dx + dy * dy < R2) { ctx.moveTo(pp.x, pp.y); ctx.lineTo(q.x, q.y) }
+          }
+        }
+        ctx.stroke()
       }
+      ctx.globalAlpha = 1; ctx.globalCompositeOperation = 'source-over'
+      raf = requestAnimationFrame(frame)
     }
-    function stopActive() {
-      if (active && active.stop) {
-        try {
-          active.stop()
-        } catch (e) {}
-      }
-      active = null
-    }
-    function hideOverlay() {
-      stopActive()
-      overlay.classList.add('intro-idle')
-      overlay.classList.remove('intro-done')
-      stage.innerHTML = ''
-    }
+
     function reveal() {
-      if (exiting) return
-      exiting = true
-      overlay.classList.add('intro-done')
-      setTimeout(hideOverlay, 950)
-    }
-    function crtExit(screen) {
-      // variant 2's own outro: CRT power-off collapse, then hide
-      if (exiting) return
-      exiting = true
-      if (screen) screen.classList.add('intro-crt--off')
-      setTimeout(hideOverlay, 560)
-    }
-    function play() {
-      stopActive()
-      exiting = false
-      stage.innerHTML = ''
-      overlay.classList.remove('intro-idle')
-      overlay.classList.remove('intro-done')
-      try {
-        sessionStorage.setItem('intro-seen', '1')
-      } catch (e) {}
-      var v = getVariant()
-      highlight(v)
-      if (v === '2') active = playTerminal(stage)
-      else if (v === '3') active = playKinetic(stage, reveal)
-      else if (v === '4') active = playMultiAgent(stage, reveal)
-      else active = playConstellation(stage, reveal)
+      if (revealing) return
+      revealing = true
+      overlay.classList.add('intro-done')   // fade overlay → real homepage
+      setTimeout(function () { cancelAnimationFrame(raf); overlay.remove() }, 1000)
     }
 
-    // ── variant 1 · constellation ───────────────────────────────────────────
-    function playConstellation(stage, done) {
-      var canvas = document.createElement('canvas')
-      canvas.className = 'intro-canvas'
-      stage.appendChild(canvas)
-      var context = document.createElement('div')
-      context.className = 'intro-run'
-      var task = document.createElement('div')
-      task.className = 'intro-task'
-      task.textContent = 'task: compose joye.dev/home'
-      context.appendChild(task)
-      var toolsWrap = document.createElement('div')
-      toolsWrap.className = 'intro-tools'
-      var TOOLS = [
-        { call: 'agent.runtime()', shards: ['plan', 'loop'], pos: [50, 15] },
-        { call: 'mcp.filesystem()', shards: ['posts', 'projects'], pos: [22, 27] },
-        { call: 'mcp.github()', shards: ['OpenHarness', 'ship log'], pos: [78, 29] },
-        { call: 'memory.search()', shards: ['design taste', 'frontend'], pos: [22, 56] },
-        { call: 'examples.unitize()', shards: ['tool call', 'UI case'], pos: [78, 56] },
-        { call: 'merge_context()', shards: ['identity', 'JOYE'], pos: [50, 82] }
-      ]
-      for (var ti = 0; ti < TOOLS.length; ti++) {
-        var item = TOOLS[ti]
-        var tool = document.createElement('div')
-        tool.className = 'intro-tool'
-        tool.style.left = item.pos[0] + '%'
-        tool.style.top = item.pos[1] + '%'
-        tool.style.transitionDelay = (0.12 + ti * 0.08) + 's'
-        var head = document.createElement('div')
-        head.className = 'intro-tool__head'
-        var call = document.createElement('span')
-        call.className = 'intro-tool__call'
-        call.textContent = item.call
-        var status = document.createElement('span')
-        status.className = 'intro-tool__status'
-        status.textContent = 'ok'
-        head.appendChild(call)
-        head.appendChild(status)
-        tool.appendChild(head)
-        var shards = document.createElement('div')
-        shards.className = 'intro-shards'
-        for (var si = 0; si < item.shards.length; si++) {
-          var shard = document.createElement('span')
-          shard.className = 'intro-shard'
-          shard.textContent = item.shards[si]
-          shard.style.transitionDelay = (0.24 + ti * 0.07 + si * 0.08) + 's'
-          shards.appendChild(shard)
-        }
-        tool.appendChild(shards)
-        toolsWrap.appendChild(tool)
-      }
-      context.appendChild(toolsWrap)
-      var merge = document.createElement('div')
-      merge.className = 'intro-merge'
-      merge.textContent = 'merge: context shards → JOYE'
-      context.appendChild(merge)
-      stage.appendChild(context)
-      var enter = document.createElement('button')
-      enter.className = 'intro-enter'
-      enter.type = 'button'
-      enter.textContent = location.pathname.indexOf('/en') === 0 ? 'enter ~/joye →' : '进入 ~/joye →'
-      enter.setAttribute('aria-label', enter.textContent)
-      stage.appendChild(enter)
-      var trace = document.createElement('div')
-      trace.className = 'intro-trace'
-      trace.textContent = 'agent loop complete · context merged'
-      stage.appendChild(trace)
-      var ctx = canvas.getContext('2d')
-      var root = document.documentElement
-      var dark = root.classList.contains('dark')
-      var styles = getComputedStyle(root)
-      function parseHSL(v) {
-        var m = String(v).trim().match(/([\d.]+)\s+([\d.]+)%\s+([\d.]+)%/)
-        return m ? { h: +m[1], s: +m[2], l: +m[3] } : { h: 200, s: 30, l: 50 }
-      }
-      var PRI = parseHSL(styles.getPropertyValue('--primary'))
-      var baseL = dark ? PRI.l : Math.min(PRI.l, 40)
-      var sat = dark ? PRI.s : Math.min(PRI.s + 18, 62)
-      var SPAN = dark ? 18 : 14
-      var linkA = dark ? 0.1 : 0.18
-      function dot(k, a) {
-        var l = Math.max(4, Math.min(96, baseL + (k - 0.5) * SPAN))
-        return 'hsl(' + PRI.h + ' ' + sat + '% ' + l + '% / ' + a + ')'
-      }
-      var linkColor = 'hsl(' + PRI.h + ' ' + sat + '% ' + baseL + '%'
-      var W = 0, H = 0, DPR = 1, particles = [], phase = 'gather', t0 = 0, raf = 0, stopped = false
-      var mouse = { x: -1e9, y: -1e9 }
-      var enterShown = false, exitingLocal = false, autoExit = 0, revealDelay = 0, scatterStart = 0
-      function showEnter() {
-        if (enterShown || exitingLocal || stopped) return
-        enterShown = true
-        context.classList.add('merge')
-        enter.classList.add('show')
-        trace.classList.add('show')
-        autoExit = setTimeout(beginExit, 12000)
-      }
-      function beginExit() {
-        if (exitingLocal || stopped) return
-        exitingLocal = true
-        phase = 'scatter'
-        scatterStart = 0
-        context.classList.add('leaving')
-        enter.classList.remove('show')
-        trace.classList.remove('show')
-        enter.disabled = true
-        clearTimeout(autoExit)
-        revealDelay = setTimeout(done, 850)
-      }
-      function onEnter(e) {
-        e.stopPropagation()
-        beginExit()
-      }
-      function vw() { return innerWidth || document.documentElement.clientWidth || 1280 }
-      function vh() { return innerHeight || document.documentElement.clientHeight || 800 }
-      function resize() {
-        DPR = Math.min(devicePixelRatio || 1, 2)
-        var w = vw(), h = vh()
-        W = canvas.width = Math.round(w * DPR)
-        H = canvas.height = Math.round(h * DPR)
-        canvas.style.width = w + 'px'
-        canvas.style.height = h + 'px'
-      }
-      function sampleText(text) {
-        if (!W || !H) return []
-        var off = document.createElement('canvas')
-        off.width = W
-        off.height = H
-        var o = off.getContext('2d')
-        o.fillStyle = '#fff'
-        o.textBaseline = 'middle'
-        o.textAlign = 'left'
-        var tracking = 0.18
-        var size = Math.min(H * 0.4, W * 0.32)
-        function setFont() { o.font = '700 ' + size + 'px Satoshi, system-ui, sans-serif' }
-        setFont()
-        function advance() {
-          var w = 0
-          for (var i = 0; i < text.length; i++) w += o.measureText(text[i]).width + size * tracking
-          return w - size * tracking
-        }
-        var maxW = W * 0.72
-        if (advance() > maxW) { size *= maxW / advance(); setFont() }
-        var x = (W - advance()) / 2
-        var y = H * 0.47
-        for (var i = 0; i < text.length; i++) {
-          o.fillText(text[i], x, y)
-          x += o.measureText(text[i]).width + size * tracking
-        }
-        var data = o.getImageData(0, 0, W, H).data
-        var gap = Math.max(5, Math.round(7 * DPR))
-        var pts = []
-        for (var yy = 0; yy < H; yy += gap)
-          for (var xx = 0; xx < W; xx += gap)
-            if (data[(yy * W + xx) * 4 + 3] > 128) pts.push({ x: xx, y: yy })
-        return pts
-      }
-      function build() {
-        var pts = sampleText('JOYE')
-        while (particles.length < pts.length)
-          particles.push({ x: 0, y: 0, vx: 0, vy: 0, tx: 0, ty: 0, sx: 0, sy: 0, r: (Math.random() * 0.9 + 0.7) * DPR, tw: Math.random() * 6.28, delay: 0, drift: Math.random() * 6.28 })
-        particles.length = pts.length
-        pts.sort(function () { return Math.random() - 0.5 })
-        for (var i = 0; i < particles.length; i++) {
-          var source = TOOLS[i % TOOLS.length].pos
-          particles[i].tx = pts[i].x
-          particles[i].ty = pts[i].y
-          particles[i].sx = W * source[0] / 100 + (Math.random() - 0.5) * 150 * DPR
-          particles[i].sy = H * source[1] / 100 + (Math.random() - 0.5) * 76 * DPR
-          particles[i].delay = 0.9 + (i % TOOLS.length) * 0.16 + Math.random() * 0.85
-          if (!particles[i].drift) particles[i].drift = Math.random() * 6.28
-        }
-      }
-      function frame(ts) {
-        if (stopped) return
-        if (!t0) t0 = ts
-        var el = (ts - t0) / 1000
-        if (phase === 'scatter' && !scatterStart) scatterStart = ts
-        var scatterAge = scatterStart ? (ts - scatterStart) / 1000 : 0
-        ctx.clearRect(0, 0, W, H)
-        if (el > 0.12) context.classList.add('start')
-        if (el > 0.72) context.classList.add('invoke')
-        if (el > 1.55) context.classList.add('compose')
-        if (el > 2.95 && phase !== 'scatter') context.classList.add('merge')
-        if (el > 3.7 && phase === 'gather') phase = 'hold'
-        if (el > 4.35 && phase === 'hold') showEnter()
-        var ease = phase === 'gather' ? 0.045 : phase === 'hold' ? 0.11 : 0.018
-        if (phase !== 'scatter' && el > 0.72) {
-          var linkFade = Math.min(1, (el - 0.72) / 0.75)
-          if (el > 2.85) linkFade *= Math.max(0.18, 1 - (el - 2.85) / 1.2)
-          ctx.lineWidth = DPR * 0.7
-          for (var li = 0; li < TOOLS.length; li++) {
-            var src = TOOLS[li].pos
-            ctx.strokeStyle = linkColor + ' / ' + (0.085 * linkFade) + ')'
-            ctx.beginPath()
-            ctx.moveTo(W * src[0] / 100, H * src[1] / 100)
-            ctx.quadraticCurveTo(W / 2, H * 0.35, W / 2, H * 0.47)
-            ctx.stroke()
-          }
-        }
-        if (phase !== 'scatter') {
-          ctx.lineWidth = DPR * 0.6
-          for (var i = 0; i < particles.length; i += 2) {
-            var p = particles[i]
-            for (var j = i + 2; j < i + 10 && j < particles.length; j++) {
-              var q = particles[j]
-              var dx = p.x - q.x, dy = p.y - q.y, d2 = dx * dx + dy * dy, R = 26 * DPR
-              if (d2 < R * R) {
-                ctx.strokeStyle = linkColor + ' / ' + (linkA * (1 - d2 / (R * R))) + ')'
-                ctx.beginPath(); ctx.moveTo(p.x, p.y); ctx.lineTo(q.x, q.y); ctx.stroke()
-              }
-            }
-          }
-        }
-        for (var k = 0; k < particles.length; k++) {
-          var pt = particles[k]
-          if (phase === 'scatter') {
-            var odx = (pt.x - W / 2) / Math.max(W, 1)
-            pt.vx += (Math.random() - 0.5) * 0.16 * DPR + odx * 0.09 * DPR
-            pt.vy += ((Math.random() - 0.5) * 0.08 - 0.11) * DPR
-          } else {
-            var pull = phase === 'hold' ? 1 : Math.max(0, Math.min(1, (el - pt.delay) / 2.05))
-            if (pull < 1) {
-              pt.vx += Math.sin(el * 0.9 + pt.drift) * 0.012 * DPR
-              pt.vy += Math.cos(el * 0.7 + pt.drift) * 0.012 * DPR
-            }
-            var localEase = ease * (0.2 + pull * 0.8)
-            pt.vx += (pt.tx - pt.x) * localEase * pull
-            pt.vy += (pt.ty - pt.y) * localEase * pull
-            var mdx = pt.x - mouse.x, mdy = pt.y - mouse.y, md2 = mdx * mdx + mdy * mdy, MR = 110 * DPR
-            if (md2 < MR * MR) { var f = (1 - md2 / (MR * MR)) * 4, d = Math.sqrt(md2) || 1; pt.vx += (mdx / d) * f; pt.vy += (mdy / d) * f }
-          }
-          var damp = phase === 'scatter' ? 0.91 : 0.87
-          pt.vx *= damp; pt.vy *= damp; pt.x += pt.vx; pt.y += pt.vy; pt.tw += 0.05
-          var near = (pt.x - pt.tx) * (pt.x - pt.tx) + (pt.y - pt.ty) * (pt.y - pt.ty) < (8 * DPR) * (8 * DPR)
-          var tw = (dark ? 0.6 : 0.8) + Math.sin(pt.tw) * (dark ? 0.22 : 0.15)
-          var fade = phase === 'scatter' ? Math.max(0, 1 - scatterAge / 1.45) : 1
-          var born = (phase === 'scatter' || phase === 'hold') ? 1 : Math.max(0, Math.min(1, (el - pt.delay + 0.28) / 0.55))
-          var a = phase === 'scatter' ? (dark ? 0.5 : 0.62) * fade : (near ? (dark ? 0.95 : 1) : dark ? 0.7 : 0.86) * tw
-          a *= born
-          ctx.beginPath()
-          ctx.fillStyle = dot(pt.x / W, Math.min(1, a))
-          ctx.arc(pt.x, pt.y, pt.r * (near ? 1.25 : 1) * (phase === 'scatter' ? 0.95 + scatterAge * 0.08 : 1), 0, 7)
-          ctx.fill()
-        }
-        raf = requestAnimationFrame(frame)
-      }
-      function onMove(e) { mouse.x = e.clientX * DPR; mouse.y = e.clientY * DPR }
-      function onLeave() { mouse.x = -1e9; mouse.y = -1e9 }
-      function onResize() { if (!stopped) { resize(); build() } }
-      enter.addEventListener('click', onEnter)
-      addEventListener('mousemove', onMove)
-      addEventListener('mouseleave', onLeave)
-      addEventListener('resize', onResize)
+    function start() {
       resize(); build()
-      if (particles.length === 0) { done() }
-      else {
-        for (var i = 0; i < particles.length; i++) {
-          particles[i].x = particles[i].sx
-          particles[i].y = particles[i].sy
-          particles[i].vx = (Math.random() - 0.5) * DPR
-          particles[i].vy = (Math.random() - 0.5) * DPR
-        }
-        raf = requestAnimationFrame(frame)
-      }
-      return {
-        blockOverlayClick: true,
-        stop: function () {
-          stopped = true
-          clearTimeout(autoExit)
-          clearTimeout(revealDelay)
-          cancelAnimationFrame(raf)
-          enter.removeEventListener('click', onEnter)
-          removeEventListener('mousemove', onMove)
-          removeEventListener('mouseleave', onLeave)
-          removeEventListener('resize', onResize)
-        }
-      }
+      if (parts.length === 0) { setTimeout(start, 120); return }
+      raf = requestAnimationFrame(frame)
     }
 
-    // ── variant 2 · fullscreen CRT boot ──────────────────────────────────────
-    function playTerminal(stage) {
-      var screen = document.createElement('div')
-      screen.className = 'intro-crt'
-      screen.innerHTML = '<div class="intro-crt__inner"></div><div class="intro-crt__vignette"></div>'
-      stage.appendChild(screen)
-      var out = screen.querySelector('.intro-crt__inner')
-      var timers = [], stopped = false
-      function sleep(ms) { return new Promise(function (r) { timers.push(setTimeout(r, ms)) }) }
-      function line(html, cls) { var d = document.createElement('div'); d.className = 'ln ' + (cls || ''); d.innerHTML = html; out.appendChild(d); return d }
-      function boot(ts, label) { return line('<span class="dim">[ ' + ts + ' ]</span> ' + label + ' <span class="ok">[  OK  ]</span>') }
-      function caret(prefix, cmd, sp) {
-        sp = sp || 32
-        var el = line('<span class="p">' + prefix + '</span> ')
-        var c = document.createElement('span'); c.className = 'cr'; el.appendChild(c)
-        var i = 0
-        return new Promise(function (resolve) {
-          function step() {
-            if (stopped) return resolve()
-            if (i >= cmd.length) { timers.push(setTimeout(function () { c.remove(); resolve() }, 220)); return }
-            c.parentNode.insertBefore(document.createTextNode(cmd[i]), c); i++
-            timers.push(setTimeout(step, sp))
-          }
-          step()
-        })
-      }
-      var ART = '   ___ ___  _   _ ___\n  |_  / _ \\| | | | __|\n   / / (_) | |_| | _|\n  /___\\___/ \\___/|___|'
-      ;(async function () {
-        await sleep(200); if (stopped) return
-        line('<span class="hd">JoyeOS 4.8.0</span> <span class="dim">(tty1)</span>')
-        line('&nbsp;'); await sleep(180)
-        boot('0.000000', 'Booting <span class="hd">joye.dev</span> kernel'); await sleep(85)
-        boot('0.013002', 'Loading design-system'); await sleep(80)
-        boot('0.041190', 'Mounting /home/joye'); await sleep(80)
-        boot('0.072551', 'Starting personality daemon (<span class="c">JoJo</span>)'); await sleep(80)
-        line('<span class="dim">[ 0.105324 ]</span> compiling <span class="dim">8 years of</span> frontend <span class="p">→</span> ai-agent'); await sleep(120)
-        boot('0.151002', 'Initializing multi-agent runtime'); await sleep(280); if (stopped) return
-        var a = line('', 'art'); a.textContent = ART; await sleep(200)
-        line('&nbsp;'); await sleep(140)
-        await caret('joye@dev:~$', 'whoami'); if (stopped) return
-        line('<span class="hd">Joye</span> <span class="dim">· Full-Stack &amp; AI Agent Developer · Melbourne 🇦🇺</span>'); await sleep(440)
-        await caret('joye@dev:~$', 'open ~/'); await sleep(180)
-        line('<span class="dim">[ launching interface ... ]</span>'); await sleep(360)
-        if (!stopped) crtExit(screen)
-      })()
-      return { stop: function () { stopped = true; for (var i = 0; i < timers.length; i++) clearTimeout(timers[i]); timers = [] } }
-    }
-
-    // ── variant 3 · kinetic type ─────────────────────────────────────────────
-    function playKinetic(stage, done) {
-      var kin = document.createElement('div'); kin.className = 'intro-kin'
-      var bar = document.createElement('div'); bar.className = 'intro-kin__bar'
-      var seq = document.createElement('div'); seq.style.position = 'absolute'; seq.style.inset = '0'
-      seq.style.display = 'grid'; seq.style.placeItems = 'center'
-      kin.appendChild(bar); kin.appendChild(seq); stage.appendChild(kin)
-      var timers = [], stopped = false
-      function sleep(ms) { return new Promise(function (r) { timers.push(setTimeout(r, ms)) }) }
-      var WORDS = [
-        [{ t: 'FRONT' }, { t: 'END', c: 'ac' }],
-        [{ t: 'DESIGN' }],
-        [{ t: '×', c: 'th' }, { t: ' AI', c: 'ac' }],
-        [{ t: 'JOYE' }]
-      ]
-      function makeWord(parts) {
-        var w = document.createElement('div'); w.className = 'wd'
-        parts.forEach(function (p) {
-          var s = document.createElement('span'); if (p.c) s.className = p.c
-          for (var i = 0; i < p.t.length; i++) {
-            var c = document.createElement('span'); c.className = 'ch'
-            c.textContent = p.t[i] === ' ' ? ' ' : p.t[i]
-            c.style.animationDelay = i * 0.045 + 's'
-            s.appendChild(c)
-          }
-          w.appendChild(s)
-        })
-        return w
-      }
-      async function show(parts, hold, last) {
-        if (stopped) return null
-        var w = makeWord(parts); seq.appendChild(w)
-        bar.classList.remove('go'); void bar.offsetWidth; bar.classList.add('go')
-        await sleep(140); if (stopped) return w
-        w.classList.add('in')
-        await sleep(hold)
-        if (!last && !stopped) { w.classList.add('out'); await sleep(420); w.remove() }
-        return w
-      }
-      ;(async function () {
-        await sleep(220)
-        await show(WORDS[0], 720); await show(WORDS[1], 600); await show(WORDS[2], 680)
-        var j = await show(WORDS[3], 820, true); if (stopped) return
-        await sleep(160); if (j) j.classList.add('out'); await sleep(320)
-        if (!stopped) done()
-      })()
-      return { stop: function () { stopped = true; for (var i = 0; i < timers.length; i++) clearTimeout(timers[i]); timers = []; kin.remove() } }
-    }
-
-    // ── variant 4 · multi-agent orchestration ────────────────────────────────
-    function playMultiAgent(stage, done) {
-      var wrap = document.createElement('div'); wrap.className = 'intro-agent'
-      var canvas = document.createElement('canvas'); canvas.className = 'intro-canvas'
-      var cap = document.createElement('div'); cap.className = 'intro-agent__cap'; cap.textContent = 'multi-agent runtime'
-      wrap.appendChild(canvas); wrap.appendChild(cap); stage.appendChild(wrap)
-      var ctx = canvas.getContext('2d')
-      if (!ctx) { done(); return { stop: function () { wrap.remove() } } }
-
-      var root = document.documentElement
-      var styles = getComputedStyle(root)
-      var dark = root.classList.contains('dark')
-      function parseHSL(v) {
-        var m = String(v).trim().match(/([\d.]+)\s+([\d.]+)%\s+([\d.]+)%/)
-        return m ? { h: +m[1], s: +m[2], l: +m[3] } : { h: 200, s: 36, l: 56 }
-      }
-      var PRI = parseHSL(styles.getPropertyValue('--primary'))
-      var SAT = Math.min(90, PRI.s + 16)
-      function tone(l, a) { return 'hsl(' + PRI.h + ' ' + SAT + '% ' + l + '% / ' + a + ')' }
-      function textTone(a) { return dark ? 'rgba(250,249,248,' + a + ')' : 'rgba(24,30,36,' + a + ')' }
-
-      var W = 0, H = 0, DPR = 1, raf = 0, t0 = 0, stopped = false, converged = false, finished = false
-      var nodes = [], edges = [], messages = [], schedule = [], schedPtr = 0, parts = []
-      var ROLES = ['planner', 'router', 'search', 'code', 'memory', 'judge', 'tool', 'writer']
-
-      function vw() { return innerWidth || document.documentElement.clientWidth || 1280 }
-      function vh() { return innerHeight || document.documentElement.clientHeight || 800 }
-      function resize() {
-        DPR = Math.min(devicePixelRatio || 1, 2)
-        var w = vw(), h = vh()
-        W = canvas.width = Math.round(w * DPR)
-        H = canvas.height = Math.round(h * DPR)
-        canvas.style.width = w + 'px'
-        canvas.style.height = h + 'px'
-      }
-      function buildGraph() {
-        nodes = []; edges = []
-        var cx = W / 2, cy = H * 0.45
-        var roles = W / DPR < 560 ? ['plan', 'route', 'code', 'memory', 'judge', 'write'] : ROLES
-        var R = Math.min(W, H) * (roles.length > 6 ? 0.3 : 0.33)
-        nodes.push({ x: cx, y: cy, label: 'orchestrator', hub: true, act: 0, appear: 0, r: 7 * DPR })
-        for (var i = 0; i < roles.length; i++) {
-          var a = -Math.PI / 2 + (i / roles.length) * Math.PI * 2
-          var jitter = Math.sin(i * 12.9) * R * 0.05
-          nodes.push({ x: cx + Math.cos(a) * (R + jitter), y: cy + Math.sin(a) * (R + jitter), label: roles[i], hub: false, act: 0, appear: 0.18 + i * 0.06, r: 5.5 * DPR })
-        }
-        for (var j = 1; j < nodes.length; j++) edges.push({ a: 0, b: j, appear: 0.4 + j * 0.05, lit: 0 })
-        for (var k = 1; k < nodes.length; k++) edges.push({ a: k, b: (k % roles.length) + 1, appear: 0.8 + k * 0.03, lit: 0 })
-        buildSchedule()
-      }
-      function buildSchedule() {
-        schedule = []; schedPtr = 0
-        for (var i = 1; i < nodes.length; i++) schedule.push({ t: 0.95 + i * 0.055, a: 0, b: i })
-        for (var j = 1; j < nodes.length; j++) schedule.push({ t: 1.5 + j * 0.05, a: j, b: (j % (nodes.length - 1)) + 1 })
-        for (var k = 1; k < nodes.length; k++) schedule.push({ t: 2.05 + k * 0.05, a: k, b: 0 })
-        schedule.sort(function (a, b) { return a.t - b.t })
-      }
-      function sampleJOYE() {
-        var off = document.createElement('canvas')
-        off.width = W; off.height = H
-        var o = off.getContext('2d')
-        o.fillStyle = '#fff'; o.textBaseline = 'middle'; o.textAlign = 'left'
-        var tracking = 0.18, size = Math.min(H * 0.4, W * 0.34)
-        function setFont() { o.font = '700 ' + size + 'px Satoshi, system-ui, sans-serif' }
-        setFont()
-        function advance() {
-          var w = 0
-          for (var i = 0; i < 4; i++) w += o.measureText('JOYE'[i]).width + size * tracking
-          return w - size * tracking
-        }
-        if (advance() > W * 0.74) { size *= (W * 0.74) / advance(); setFont() }
-        var x = (W - advance()) / 2, y = H * 0.45
-        for (var i = 0; i < 4; i++) { var ch = 'JOYE'[i]; o.fillText(ch, x, y); x += o.measureText(ch).width + size * tracking }
-        var data = o.getImageData(0, 0, W, H).data
-        var gap = Math.max(5, Math.round(7 * DPR))
-        var pts = []
-        for (var yy = 0; yy < H; yy += gap)
-          for (var xx = 0; xx < W; xx += gap)
-            if (data[(yy * W + xx) * 4 + 3] > 128) pts.push({ x: xx, y: yy })
-        return pts
-      }
-      function spawnMessage(a, b) {
-        for (var i = 0; i < edges.length; i++) {
-          var e = edges[i]
-          if ((e.a === a && e.b === b) || (e.a === b && e.b === a)) e.lit = 1
-        }
-        messages.push({ a: a, b: b, t: 0, dur: 0.5 })
-      }
-      function converge() {
-        converged = true; cap.classList.remove('show')
-        var pts = sampleJOYE()
-        if (pts.length === 0) { finished = true; done(); return }
-        parts = []
-        for (var i = 0; i < pts.length; i++) {
-          var src = nodes[(Math.random() * nodes.length) | 0]
-          parts.push({ x: src.x, y: src.y, vx: 0, vy: 0, tx: pts[i].x, ty: pts[i].y, r: (Math.random() * 0.9 + 0.7) * DPR })
-        }
-      }
-      function frame(ts) {
-        if (stopped) return
-        if (!t0) t0 = ts
-        var el = (ts - t0) / 1000
-        ctx.clearRect(0, 0, W, H)
-        if (el > 1.4 && !converged) cap.classList.add('show')
-        if (el > 2.65 && !converged) converge()
-        if (converged && el > 3.8 && !finished) { finished = true; done() }
-
-        if (!converged) {
-          while (schedPtr < schedule.length && el >= schedule[schedPtr].t) { var s = schedule[schedPtr++]; spawnMessage(s.a, s.b) }
-          for (var i = 0; i < edges.length; i++) {
-            var edge = edges[i], ap = Math.max(0, Math.min(1, (el - edge.appear) / 0.5))
-            if (ap <= 0) continue
-            var A = nodes[edge.a], B = nodes[edge.b]
-            ctx.strokeStyle = tone(dark ? 68 : 46, (0.1 + edge.lit * 0.35) * ap)
-            ctx.lineWidth = (0.7 + edge.lit * 1.2) * DPR
-            ctx.beginPath(); ctx.moveTo(A.x, A.y); ctx.lineTo(B.x, B.y); ctx.stroke()
-            edge.lit *= 0.92
-          }
-          for (var j = 0; j < messages.length; j++) {
-            var m = messages[j]
-            m.t += 0.016 / m.dur
-            var MA = nodes[m.a], MB = nodes[m.b], ease = m.t < 1 ? m.t * m.t * (3 - 2 * m.t) : 1
-            var mx = MA.x + (MB.x - MA.x) * ease, my = MA.y + (MB.y - MA.y) * ease
-            ctx.beginPath(); ctx.fillStyle = tone(dark ? 82 : 38, 0.95); ctx.shadowColor = tone(dark ? 76 : 45, 0.9); ctx.shadowBlur = 10 * DPR
-            ctx.arc(mx, my, 2.4 * DPR, 0, 7); ctx.fill(); ctx.shadowBlur = 0
-            if (m.t >= 1) MB.act = 1
-          }
-          messages = messages.filter(function (m) { return m.t < 1 })
-          for (var k = 0; k < nodes.length; k++) {
-            var n = nodes[k], nap = Math.max(0, Math.min(1, (el - n.appear) / 0.3))
-            if (nap <= 0) continue
-            n.act *= 0.94
-            var rr = n.r * nap * (1 + n.act * 0.5)
-            if (n.act > 0.02) { ctx.beginPath(); ctx.fillStyle = tone(dark ? 72 : 44, 0.12 * n.act); ctx.arc(n.x, n.y, rr * 3.4, 0, 7); ctx.fill() }
-            ctx.beginPath(); ctx.fillStyle = dark ? 'rgba(13, 20, 28, 0.9)' : 'rgba(255, 255, 255, 0.82)'; ctx.arc(n.x, n.y, rr, 0, 7); ctx.fill()
-            ctx.lineWidth = (n.hub ? 2 : 1.4) * DPR
-            ctx.strokeStyle = tone(n.hub ? (dark ? 72 : 43) : (dark ? 78 : 48), (0.55 + n.act * 0.45) * nap)
-            ctx.beginPath(); ctx.arc(n.x, n.y, rr, 0, 7); ctx.stroke()
-            ctx.font = (n.hub ? 12 : 11) * DPR + 'px JetBrains Mono, monospace'
-            ctx.textAlign = 'center'; ctx.textBaseline = 'middle'
-            ctx.fillStyle = n.act > 0.3 ? tone(dark ? 84 : 35, nap) : textTone((0.48 + n.act * 0.28) * nap)
-            ctx.fillText(n.label, n.x, n.y + rr + 11 * DPR)
-          }
-        } else {
-          var since = el - 2.65
-          var nodeA = Math.max(0, 1 - since * 1.6)
-          if (nodeA > 0.02) {
-            for (var eix = 0; eix < edges.length; eix++) { var ge = edges[eix], GA = nodes[ge.a], GB = nodes[ge.b]; ctx.strokeStyle = tone(dark ? 68 : 46, 0.08 * nodeA); ctx.lineWidth = 0.7 * DPR; ctx.beginPath(); ctx.moveTo(GA.x, GA.y); ctx.lineTo(GB.x, GB.y); ctx.stroke() }
-            for (var nix = 0; nix < nodes.length; nix++) { var gn = nodes[nix]; ctx.beginPath(); ctx.fillStyle = tone(dark ? 72 : 43, 0.5 * nodeA); ctx.arc(gn.x, gn.y, gn.r, 0, 7); ctx.fill() }
-          }
-          for (var pix = 0; pix < parts.length; pix++) {
-            var p = parts[pix]
-            if (finished) { p.vx += (Math.random() - 0.5) * 0.6 * DPR; p.vy += ((Math.random() - 0.5) * 0.6 - 0.12) * DPR }
-            else { p.vx += (p.tx - p.x) * 0.12; p.vy += (p.ty - p.y) * 0.12 }
-            p.vx *= 0.84; p.vy *= 0.84; p.x += p.vx; p.y += p.vy
-            var shade = dark ? 74 + (p.x / W) * 10 : 42 + (p.x / W) * 12
-            ctx.beginPath(); ctx.fillStyle = tone(shade, dark ? 0.92 : 0.98); ctx.arc(p.x, p.y, p.r, 0, 7); ctx.fill()
-          }
-        }
-        raf = requestAnimationFrame(frame)
-      }
-      function onResize() { if (!stopped) { resize(); if (!converged) buildGraph() } }
-      addEventListener('resize', onResize)
-      resize(); buildGraph(); raf = requestAnimationFrame(frame)
-      return {
-        stop: function () { stopped = true; cancelAnimationFrame(raf); removeEventListener('resize', onResize); wrap.remove() }
-      }
-    }
-
-    // ── wiring ───────────────────────────────────────────────────────────────
+    addEventListener('resize', function () { if (!revealing) { resize(); build() } })
     var skipBtn = document.getElementById('intro-skip')
     if (skipBtn) skipBtn.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
-    overlay.addEventListener('click', function () {
-      if (active && active.blockOverlayClick) return
-      reveal()
-    })
-    var replayBtn = document.getElementById('intro-replay')
-    if (replayBtn) replayBtn.addEventListener('click', function () { play() })
-    if (panel) {
-      var btns = panel.querySelectorAll('[data-variant]')
-      for (var i = 0; i < btns.length; i++) {
-        ;(function (b) {
-          b.addEventListener('click', function () { setVariant(b.getAttribute('data-variant')); play() })
-        })(btns[i])
-      }
-    }
-    highlight(getVariant())
+    overlay.addEventListener('click', reveal)
 
-    // auto-play once per session
-    var seen = false
-    try { seen = sessionStorage.getItem('intro-seen') === '1' } catch (e) {}
-    if (!seen && !reduce) {
-      var fontReady = document.fonts && document.fonts.load ? document.fonts.load('700 120px "Satoshi"') : null
-      Promise.race([Promise.resolve(fontReady).catch(function () {}), new Promise(function (r) { setTimeout(r, 700) })]).then(play)
+    if (reduce) {
+      overlay.remove()
     } else {
-      overlay.classList.add('intro-idle')
+      var fontReady = document.fonts && document.fonts.load ? document.fonts.load('700 120px "Satoshi"') : null
+      Promise.race([Promise.resolve(fontReady).catch(function () {}), new Promise(function (r) { setTimeout(r, 700) })]).then(start)
     }
   })()
 </script>

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -353,6 +353,7 @@ import avatar from 'src/assets/avatar.png'
       if (d > 0.985 && !doneAt && el > STEPS[STEPS.length - 1].t + 0.5) doneAt = ts
       if (doneAt && ts - doneAt > 700 && !landed) land()
       var dim = doneAt ? Math.min(1, (ts - doneAt) / 900) : 0
+      var breathe = 1 + Math.sin(el * 0.85) * 0.3 * dim   // slow breathing glow once landed (~7s)
       updateStages()
       if (doneAt) hud.style.opacity = String(1 - dim)
 
@@ -367,14 +368,14 @@ import avatar from 'src/assets/avatar.png'
         // hover — disperse away from the cursor + enlarge + light up; spring back when it leaves
         var hb = 0
         if (d > 0.5) {
-          var mdx = p.x - mouse.x, mdy = p.y - mouse.y, m2 = mdx * mdx + mdy * mdy, RR = (84 * DPR) * (84 * DPR)
-          if (m2 < RR) { hb = 1 - m2 / RR; var dd = Math.sqrt(m2) || 1, f = hb * 18 * DPR; p.x += mdx / dd * f; p.y += mdy / dd * f }
+          var mdx = p.x - mouse.x, mdy = p.y - mouse.y, m2 = mdx * mdx + mdy * mdy, RR = (42 * DPR) * (42 * DPR)
+          if (m2 < RR) { hb = 1 - m2 / RR; var dd = Math.sqrt(m2) || 1, f = hb * 12 * DPR; p.x += mdx / dd * f; p.y += mdy / dd * f }
         }
         var turb = noiseK * 34 * DPR
         var rx = p.x + Math.sin(p.y * 0.012 + el * 1.7 + p.seed * 6.28) * turb
         var ry = p.y + Math.cos(p.x * 0.012 - el * 1.4 + p.seed * 4) * turb
         var tw = 0.55 + Math.sin(p.tw = (p.tw || 0) + 0.04) * 0.2 * (1 - dim * 0.92)
-        var a = (0.30 + d * 0.6) * tw * (1 + pulse * 1.1) * (1 + hb * 2.4)   // hover lights it up
+        var a = (0.30 + d * 0.6) * tw * (1 + pulse * 1.1) * (1 - dim * 0.4) * breathe * (1 + hb * 2.4)   // recede + slow breathe when landed; hover lights it up
         var s = p.r * (7.5 - d * 4.6) * (1 + pulse * 0.5 + hb * 1.8)         // + bigger glow under hover
         ctx.globalAlpha = Math.min(1, a)
         ctx.drawImage(sprite, rx - s / 2, ry - s / 2, s, s)

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -367,15 +367,15 @@ import avatar from 'src/assets/avatar.png'
         // hover — disperse away from the cursor + enlarge + light up; spring back when it leaves
         var hb = 0
         if (d > 0.5) {
-          var mdx = p.x - mouse.x, mdy = p.y - mouse.y, m2 = mdx * mdx + mdy * mdy, RR = (118 * DPR) * (118 * DPR)
-          if (m2 < RR) { hb = 1 - m2 / RR; var dd = Math.sqrt(m2) || 1, f = hb * 26 * DPR; p.x += mdx / dd * f; p.y += mdy / dd * f }
+          var mdx = p.x - mouse.x, mdy = p.y - mouse.y, m2 = mdx * mdx + mdy * mdy, RR = (84 * DPR) * (84 * DPR)
+          if (m2 < RR) { hb = 1 - m2 / RR; var dd = Math.sqrt(m2) || 1, f = hb * 18 * DPR; p.x += mdx / dd * f; p.y += mdy / dd * f }
         }
         var turb = noiseK * 34 * DPR
         var rx = p.x + Math.sin(p.y * 0.012 + el * 1.7 + p.seed * 6.28) * turb
         var ry = p.y + Math.cos(p.x * 0.012 - el * 1.4 + p.seed * 4) * turb
         var tw = 0.55 + Math.sin(p.tw = (p.tw || 0) + 0.04) * 0.2 * (1 - dim * 0.92)
-        var a = (0.30 + d * 0.6) * tw * (1 + pulse * 1.1) * (1 + hb * 1.6)
-        var s = p.r * (7.5 - d * 4.6) * (1 + pulse * 0.5 + hb * 1.0)
+        var a = (0.30 + d * 0.6) * tw * (1 + pulse * 1.1) * (1 + hb * 2.4)   // hover lights it up
+        var s = p.r * (7.5 - d * 4.6) * (1 + pulse * 0.5 + hb * 1.8)         // + bigger glow under hover
         ctx.globalAlpha = Math.min(1, a)
         ctx.drawImage(sprite, rx - s / 2, ry - s / 2, s, s)
       }

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -14,7 +14,11 @@
  *
  * Scripts use `is:inline` so the runtime-created <canvas> is styled by the
  * `is:global` block (Astro scoped styles don't reach nodes made at runtime).
+ *
+ * After the name resolves it holds on a landing card (avatar + 进入 button);
+ * the page is only revealed when the visitor chooses to enter.
  */
+import avatar from 'src/assets/avatar.png'
 ---
 
 <div id='intro-overlay' class='intro-overlay' aria-hidden='true'>
@@ -27,6 +31,11 @@
       <div class='intro-seg'><b></b></div>
       <div class='intro-stage'><i></i><span>decode</span></div>
     </div>
+  </div>
+  <div class='intro-card' id='intro-card' aria-hidden='true'>
+    <img class='intro-av' id='intro-av' src={avatar.src} alt='Joye' width='112' height='112' />
+    <div class='intro-nm'>Joye</div>
+    <button class='intro-enter' id='intro-enter' type='button'>进入 ~/joye →</button>
   </div>
   <button id='intro-skip' class='intro-skip' type='button' aria-label='跳过入场动画'>跳过 →</button>
 </div>
@@ -152,6 +161,66 @@
     color: #faf9f8;
     border-color: rgba(125, 211, 252, 0.5);
   }
+  /* landing card — avatar + enter, held until the visitor chooses */
+  .intro-card {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -44%);
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    text-align: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.7s ease, transform 0.9s cubic-bezier(0.2, 0.7, 0.2, 1);
+  }
+  .intro-card.show {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translate(-50%, -50%);
+  }
+  .intro-av {
+    width: 108px;
+    height: 108px;
+    border-radius: 50%;
+    padding: 4px;
+    object-fit: cover;
+    cursor: pointer;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    background: #0b1016;
+    box-shadow: 0 0 0 4px rgba(125, 211, 252, 0.1), 0 0 60px rgba(125, 211, 252, 0.35);
+  }
+  .intro-nm {
+    font-family: 'Satoshi', system-ui, sans-serif;
+    font-weight: 800;
+    font-size: 30px;
+    letter-spacing: -0.02em;
+    color: #faf9f8;
+  }
+  .intro-enter {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 13px;
+    color: #dbeefb;
+    background: rgba(125, 211, 252, 0.06);
+    border: 1px solid rgba(125, 211, 252, 0.4);
+    border-radius: 10px;
+    padding: 11px 18px;
+    cursor: pointer;
+    transition: 0.25s;
+    animation: intro-breathe 2.4s ease-in-out infinite;
+  }
+  .intro-enter:hover {
+    background: rgba(125, 211, 252, 0.14);
+    border-color: rgba(125, 211, 252, 0.8);
+    box-shadow: 0 0 28px -6px rgba(125, 211, 252, 0.8);
+  }
+  @keyframes intro-breathe {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(125, 211, 252, 0); }
+    50% { box-shadow: 0 0 22px -4px rgba(125, 211, 252, 0.55); }
+  }
   @media (prefers-reduced-motion: reduce) {
     .intro-overlay {
       display: none;
@@ -171,9 +240,10 @@
     var reduce = window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches
 
     var W = 0, H = 0, DPR = 1, parts = [], pulse = 0, d = 0, dTarget = 0
-    var stepShown = -1, doneAt = 0, raf = 0, t0 = 0, revealing = false
+    var stepShown = -1, doneAt = 0, raf = 0, t0 = 0, revealing = false, landed = false
     var mouse = { x: -1e9, y: -1e9 }
     var STAGE_EL = null, SEG_EL = null
+    var card = document.getElementById('intro-card')
 
     // soft glow sprite (cheap bloom)
     var sprite = document.createElement('canvas')
@@ -257,7 +327,7 @@
       d += (dTarget - d) * 0.13
       if (step !== stepShown) { stepShown = step; if (step >= 0) pulse = 1 }
       if (d > 0.985 && !doneAt && el > STEPS[STEPS.length - 1].t + 0.5) doneAt = ts
-      if (doneAt && ts - doneAt > 1000 && !revealing) reveal()
+      if (doneAt && ts - doneAt > 700 && !landed) land()
       var dim = doneAt ? Math.min(1, (ts - doneAt) / 900) : 0
       updateStages()
       if (doneAt) hud.style.opacity = String(1 - dim)
@@ -304,10 +374,16 @@
       raf = requestAnimationFrame(frame)
     }
 
-    function reveal() {
+    function land() {                        // hold on the avatar + 进入 button
+      if (landed) return
+      landed = true
+      if (card) card.classList.add('show')
+    }
+    function reveal() {                       // visitor chose to enter → fade to real homepage
       if (revealing) return
       revealing = true
-      overlay.classList.add('intro-done')   // fade overlay → real homepage
+      if (card) card.classList.remove('show')
+      overlay.classList.add('intro-done')
       setTimeout(function () { cancelAnimationFrame(raf); overlay.remove() }, 1000)
     }
 
@@ -320,7 +396,10 @@
     addEventListener('resize', function () { if (!revealing) { resize(); build() } })
     var skipBtn = document.getElementById('intro-skip')
     if (skipBtn) skipBtn.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
-    overlay.addEventListener('click', reveal)
+    var enterBtn = document.getElementById('intro-enter')
+    if (enterBtn) enterBtn.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
+    var avEl = document.getElementById('intro-av')
+    if (avEl) avEl.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
 
     if (reduce) {
       overlay.remove()

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -353,11 +353,13 @@ import avatar from 'src/assets/avatar.png'
       if (d > 0.985 && !doneAt && el > STEPS[STEPS.length - 1].t + 0.5) doneAt = ts
       if (doneAt && ts - doneAt > 700 && !landed) land()
       var dim = doneAt ? Math.min(1, (ts - doneAt) / 900) : 0
-      // slow breath when landed: scattered+dim → gathered+bright (held ~2s) → scattered+dim (~8s)
-      var bt = (el * 0.125) % 1, bc
-      if (bt < 0.34) bc = bt / 0.34
-      else if (bt < 0.6) bc = 1
-      else bc = Math.max(0, 1 - (bt - 0.6) / 0.34)
+      // slow breath, phased from the resolve moment so the first bright hold isn't truncated (~9s cycle)
+      var bphase = doneAt ? (((ts - doneAt) / 9000) % 1) : 0
+      var bc
+      if (bphase < 0.34) bc = 1                                // hold at brightest (~3s)
+      else if (bphase < 0.54) bc = 1 - (bphase - 0.34) / 0.2   // exhale → dim + scatter
+      else if (bphase < 0.62) bc = 0                           // brief dark
+      else bc = (bphase - 0.62) / 0.38                         // inhale → bright + gather
       bc = bc * bc * (3 - 2 * bc)
       var breathScatter = (1 - bc) * 0.05 * dim
       var bf = 1 - dim + dim * (0.4 + bc)

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -10,6 +10,7 @@ import LinkCard from '@/components/home/LinkCard.astro'
 import Section from '@/components/home/Section.astro'
 import SiteStats from '@/components/home/SiteStats.astro'
 import SkillLayout from '@/components/home/SkillLayout.astro'
+import IntroOverlay from '@/components/intro/IntroOverlay.astro'
 import JoJo from '@/components/mascot/JoJo'
 import PostPreviewEn from '@/components/PostPreviewEn.astro'
 import Terminal from '@/components/terminal/Terminal.astro'
@@ -92,6 +93,7 @@ const latestNotes = (await getCollection('archiveEn'))
 ---
 
 <PageLayout meta={{ title: 'Home' }} highlightColor='#659EB9'>
+  <IntroOverlay />
   <main class='flex w-full flex-col items-center'>
     <section
       class='animate mb-10 flex flex-col items-center gap-y-7 relative z-50'

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,7 @@ import LinkCard from '@/components/home/LinkCard.astro'
 import Section from '@/components/home/Section.astro'
 import SiteStats from '@/components/home/SiteStats.astro'
 import SkillLayout from '@/components/home/SkillLayout.astro'
+import IntroOverlay from '@/components/intro/IntroOverlay.astro'
 import JoJo from '@/components/mascot/JoJo'
 import Terminal from '@/components/terminal/Terminal.astro'
 import config from '@/site-config'
@@ -91,6 +92,7 @@ const latestTalk = talks[0]
 ---
 
 <PageLayout meta={{ title: 'Home' }} highlightColor='#659EB9'>
+  <IntroOverlay />
   <main class='flex w-full flex-col items-center'>
     <section
       class='animate mb-10 flex flex-col items-center gap-y-7 relative z-50'


### PR DESCRIPTION
## 这是什么

首页入场动画:一个 **agent 通过去噪(diffusion)把 Joye 生成出来**。

1. 满屏**噪声** → 三阶段管线 **sample → refine → decode** 逐步去噪,显出粒子组成的 **JOYE**;
2. 不自动进站,而是**停在保留页**:头像浮现(发光圆环)+ 呼吸微光的 **「进入 ~/joye →」** 按钮,背景 JOYE 缓慢"散↔聚 / 暗↔亮"地**呼吸**(~9s 一循环,峰值停留 ~3s);
3. 由访客**点「进入」/ 头像 / 跳过**,overlay 淡出,露出真实首页;
4. **hover** 时,光标那一小块粒子会**扩散 + 放大 + 点亮**(放大镜);
5. 左下角常驻 **「↻ 重播入场」**,随时重看。

**只播一次/会话**(sessionStorage)、可跳过、`prefers-reduced-motion` 直接跳过、`<noscript>` 兜底。手写 Canvas,无动画库。

## 改了哪里

- `src/components/intro/IntroOverlay.astro` —— 入场动画组件(接入首页 `src/pages/index.astro` 与 `src/pages/en/index.astro`)。
- `demos/intro/` —— 探索期的几个方案(粒子/终端/排版/multi-agent/diffusion)+ 设计说明,**仅作素材参考,不参与构建**。

## 验证

- `bun run check` 0 errors。
- 本地实测:去噪成形 → 保留页(头像+进入)→ 点进入露出真实首页;刷新/重访直接显示首页 + 重播按钮;hover 放大镜;无 console 报错。

> 入场细节(呼吸/放大/保留页)在真机 60fps 下最准 —— 预览环境会节流 rAF。

🤖 Generated with [Claude Code](https://claude.com/claude-code)