### PR TITLE
[codex] Add home analytics events

### DIFF
--- a/src/components/AnalyticsEvents.astro
+++ b/src/components/AnalyticsEvents.astro
@@ -1,0 +1,21 @@
+<script>
+  import { track } from '@vercel/analytics'
+
+  document.addEventListener('click', (event) => {
+    const target =
+      event.target instanceof Element
+        ? event.target.closest<HTMLElement>('[data-analytics-event]')
+        : null
+
+    if (!target) return
+
+    const eventName = target.dataset.analyticsEvent
+    if (!eventName) return
+
+    track(eventName, {
+      href: target instanceof HTMLAnchorElement ? target.href : null,
+      section: target.dataset.analyticsSection ?? null,
+      target: target.dataset.analyticsTarget ?? target.textContent?.trim().slice(0, 80) ?? null
+    })
+  })
+</script>

--- a/src/components/home/LinkCard.astro
+++ b/src/components/home/LinkCard.astro
@@ -8,6 +8,7 @@ interface Props {
   subheading?: string
   date?: string
   target?: string
+  [key: string]: unknown
 }
 
 const {
@@ -16,7 +17,8 @@ const {
   heading,
   subheading,
   date,
-  target = '_blank'
+  target = '_blank',
+  ...props
 } = Astro.props
 ---
 
@@ -24,6 +26,7 @@ const {
   href={href}
   target={target}
   rel={target === '_blank' ? 'noopener noreferrer' : undefined}
+  {...props}
   class={cn(
     'not-prose block relative rounded-2xl border bg-muted px-5 py-3 transition-all hover:border-foreground/25 hover:shadow-sm no-underline',
     className

--- a/src/components/terminal/TerminalShell.tsx
+++ b/src/components/terminal/TerminalShell.tsx
@@ -1,3 +1,4 @@
+import { track } from '@vercel/analytics'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
@@ -5,7 +6,9 @@ import { commands, completeInput } from './commands'
 import { ROOT_LABEL } from './fs/content'
 import { displayPath } from './fs/path'
 import type { FsNode } from './fs/types'
+
 import './terminal.css'
+
 import type { HistoryEntry, OutputLine, Tone } from './types'
 
 type Props = {
@@ -84,7 +87,9 @@ function MatrixRain() {
     window.addEventListener('resize', resize)
 
     const chars =
-      'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホ0123456789$#%&*+-/<>{}[]'.split('')
+      'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホ0123456789$#%&*+-/<>{}[]'.split(
+        ''
+      )
     let raf = 0
     const tick = () => {
       ctx.fillStyle = 'rgba(0, 0, 0, 0.08)'
@@ -163,11 +168,20 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
     }
   }, [])
 
-  const expand = useCallback(() => {
-    persistCollapsed(false)
-    // focus input after transition settles
-    setTimeout(() => inputRef.current?.focus(), 220)
-  }, [persistCollapsed])
+  const expand = useCallback(
+    (method = 'shell_click') => {
+      track('home_terminal_open', {
+        method,
+        section: 'terminal',
+        target: 'terminal_shell'
+      })
+
+      persistCollapsed(false)
+      // focus input after transition settles
+      setTimeout(() => inputRef.current?.focus(), 220)
+    },
+    [persistCollapsed]
+  )
 
   const collapse = useCallback(() => {
     persistCollapsed(true)
@@ -249,6 +263,12 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
 
       const parts = trimmed.split(/\s+/)
       const name = parts[0].toLowerCase()
+      track('home_terminal_command', {
+        command: name,
+        section: 'terminal',
+        target: 'terminal_shell'
+      })
+
       const args = parts.slice(1)
       const spec = commands[name]
       if (!spec) {
@@ -274,11 +294,7 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
           appendEntry({ kind: 'stream', id, lines: [], done: false })
         },
         appendStream: (id: string, line: OutputLine) => {
-          updateStream(id, (e) =>
-            e.kind === 'stream'
-              ? { ...e, lines: [...e.lines, line] }
-              : e
-          )
+          updateStream(id, (e) => (e.kind === 'stream' ? { ...e, lines: [...e.lines, line] } : e))
         },
         endStream: (id: string) => {
           updateStream(id, (e) => (e.kind === 'stream' ? { ...e, done: true } : e))
@@ -304,7 +320,13 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
   useEffect(() => {
     appendEntry({
       kind: 'output',
-      lines: [{ kind: 'text', tone: 'muted', text: "type 'help' to get started · 'whoami' for the short version" }]
+      lines: [
+        {
+          kind: 'text',
+          tone: 'muted',
+          text: "type 'help' to get started · 'whoami' for the short version"
+        }
+      ]
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -321,14 +343,20 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
     const onKey = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null
       const inField =
-        target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+        target &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
       if (e.key === '`' && !inField) {
         e.preventDefault()
-        if (collapsed) expand()
+        if (collapsed) expand('keyboard_backtick')
         else inputRef.current?.focus()
         bodyRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
       }
-      if (e.key === 'Escape' && !collapsed && document.activeElement === inputRef.current && !input) {
+      if (
+        e.key === 'Escape' &&
+        !collapsed &&
+        document.activeElement === inputRef.current &&
+        !input
+      ) {
         e.preventDefault()
         collapse()
       }
@@ -403,7 +431,7 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
   return (
     <div
       className={`wt-shell ${collapsed ? 'wt-shell--collapsed' : ''}`}
-      onClick={collapsed ? expand : focusInput}
+      onClick={collapsed ? () => expand('shell_click') : focusInput}
       role={collapsed ? 'button' : undefined}
       aria-expanded={!collapsed}
       tabIndex={collapsed ? 0 : undefined}
@@ -412,7 +440,7 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
           ? (e) => {
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault()
-                expand()
+                expand('keyboard_activate')
               }
             }
           : undefined
@@ -449,7 +477,7 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
             className='wt-light wt-light--g'
             onClick={(e) => {
               stopPropagation(e)
-              if (collapsed) expand()
+              if (collapsed) expand('window_control')
             }}
             aria-label={collapsed ? 'open terminal' : 'expand'}
             tabIndex={-1}
@@ -462,13 +490,19 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
             <span className='wt-caret wt-caret--idle' aria-hidden />
           </div>
         ) : (
-          <div className='wt-title'>{promptUser}@{promptHost} — terminal</div>
+          <div className='wt-title'>
+            {promptUser}@{promptHost} — terminal
+          </div>
         )}
         <div className='wt-hint'>
           {collapsed ? (
-            <>click or <span className='wt-kbd'>`</span> to open</>
+            <>
+              click or <span className='wt-kbd'>`</span> to open
+            </>
           ) : (
-            <>press <span className='wt-kbd'>`</span> to focus</>
+            <>
+              press <span className='wt-kbd'>`</span> to focus
+            </>
           )}
         </div>
       </div>
@@ -477,7 +511,8 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
         <div className='wt-banner'>
           <span className='wt-banner-title'>wterm v0.1 · joye.sh</span>
           <span className='wt-banner-sub'>
-            an interactive shell into this site — try <code>help</code>, <code>chat</code>, <code>ls blog</code>.
+            an interactive shell into this site — try <code>help</code>, <code>chat</code>,{' '}
+            <code>ls blog</code>.
           </span>
         </div>
 
@@ -501,9 +536,7 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
           return (
             <div key={entry.id} className='wt-entry'>
               {entry.lines.map((l, j) => renderLine(l, `${entry.id}-${j}`))}
-              {!entry.done && i === entries.length - 1 && (
-                <span className='wt-thinking'>···</span>
-              )}
+              {!entry.done && i === entries.length - 1 && <span className='wt-thinking'>···</span>}
             </div>
           )
         })}
@@ -515,7 +548,8 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
             <span className={`wt-caret ${focused ? '' : 'wt-caret--idle'}`} aria-hidden />
             {!input && !focused && (
               <span className='wt-tone-muted wt-input-hint'>
-                click or press <span className='wt-kbd'>`</span> then type <span className='wt-tone-primary'>help</span>
+                click or press <span className='wt-kbd'>`</span> then type{' '}
+                <span className='wt-tone-primary'>help</span>
               </span>
             )}
           </span>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ import SpeedInsights from '@vercel/speed-insights/astro'
 
 import { Footer } from 'astro-pure/components/basic'
 import type { SiteMeta } from 'astro-pure/types'
+import AnalyticsEvents from '@/components/AnalyticsEvents.astro'
 import BaseHead from '@/components/BaseHead.astro'
 import ViewCounter from '@/components/comment/ViewCounter.astro'
 import Header from '@/components/Header.astro'
@@ -58,6 +59,7 @@ const fs = await buildSiteFs()
     </div>
     <DevModeHost client:only='react' fs={fs} />
     <Analytics />
+    <AnalyticsEvents />
     <SpeedInsights />
     <ViewCounter />
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import { Image } from 'astro:assets'
 import { getCollection } from 'astro:content'
+import { formatTalkDateCN, sortTalks } from '@/lib/talks'
 import avatar from 'src/assets/avatar.png'
 
 import { Quote } from 'astro-pure/advanced'
@@ -15,7 +16,6 @@ import SkillLayout from '@/components/home/SkillLayout.astro'
 import JoJo from '@/components/mascot/JoJo'
 import Terminal from '@/components/terminal/Terminal.astro'
 import config from '@/site-config'
-import { formatTalkDateCN, sortTalks } from '@/lib/talks'
 
 export const prerender = true
 
@@ -111,7 +111,15 @@ const agentHackathonLink =
           <Label title='Melbourne, Australia'>
             <Icon name='location' class='size-5' slot='icon' />
           </Label>
-          <Label title='GitHub' as='a' href='https://github.com/joyehuang' target='_blank'>
+          <Label
+            title='GitHub'
+            as='a'
+            href='https://github.com/joyehuang'
+            target='_blank'
+            data-analytics-event='home_github_click'
+            data-analytics-section='profile_header'
+            data-analytics-target='profile'
+          >
             <Icon name='github' class='size-5' slot='icon' />
           </Label>
         </div>
@@ -122,6 +130,9 @@ const agentHackathonLink =
         <a
           href='/contact'
           class='flex flex-row items-center gap-x-3 rounded-full border bg-background px-4 py-2 text-sm shadow-sm transition-shadow hover:shadow-md'
+          data-analytics-event='home_cta_click'
+          data-analytics-section='hero'
+          data-analytics-target='contact'
         >
           <span class='relative flex items-center justify-center'>
             <span
@@ -144,12 +155,20 @@ const agentHackathonLink =
       <Section title='About'>
         <p class='text-muted-foreground'>AI Agent & Full-Stack Developer</p>
         <p class='text-muted-foreground'>
-          墨尔本大学在读，目前在 Adastra Labs（石墨文档海外）参与 Playyy.ai，
-          同时在特赞 Tezign 做 atypica（商业研究 Multi-Agent），并在 fAIshion.ai 与 Goshu Tech
-          做 AI 全栈与剪辑 Agent。 在意 LLM 的底层机制，也在意产品能不能真正跑起来。 Build fast,
-          learn faster — 平时弹琴、拉大提琴、玩摄影。
+          墨尔本大学在读，目前在 Adastra Labs（石墨文档海外）参与 Playyy.ai， 同时在特赞 Tezign 做
+          atypica（商业研究 Multi-Agent），并在 fAIshion.ai 与 Goshu Tech 做 AI 全栈与剪辑 Agent。
+          在意 LLM 的底层机制，也在意产品能不能真正跑起来。 Build fast, learn faster —
+          平时弹琴、拉大提琴、玩摄影。
         </p>
-        <Button title='More about me' class='w-fit self-end' href='/about' style='ahead' />
+        <Button
+          title='More about me'
+          class='w-fit self-end'
+          href='/about'
+          style='ahead'
+          data-analytics-event='home_cta_click'
+          data-analytics-section='about'
+          data-analytics-target='more_about'
+        />
       </Section>
       {
         allPostsByDate.length > 0 && (
@@ -161,7 +180,15 @@ const agentHackathonLink =
                 </li>
               ))}
             </ul>
-            <Button title='More blogs' class='w-fit self-end' href='/blog' style='ahead' />
+            <Button
+              title='More blogs'
+              class='w-fit self-end'
+              href='/blog'
+              style='ahead'
+              data-analytics-event='home_cta_click'
+              data-analytics-section='blog'
+              data-analytics-target='more_blogs'
+            />
           </Section>
         )
       }
@@ -212,7 +239,15 @@ const agentHackathonLink =
                 </li>
               ))}
             </ul>
-            <Button title='More notes' class='w-fit self-end' href='/archive' style='ahead' />
+            <Button
+              title='More notes'
+              class='w-fit self-end'
+              href='/archive'
+              style='ahead'
+              data-analytics-event='home_cta_click'
+              data-analytics-section='notes'
+              data-analytics-target='more_notes'
+            />
           </Section>
         )
       }
@@ -221,15 +256,28 @@ const agentHackathonLink =
         latestTalk && (
           <Section title='Talks'>
             <p class='text-muted-foreground'>
-              群里每周一次的线上交流会，轮流分享技术、求职和 AI 行业 —— 每期的内容与幻灯片都公开沉淀在这里。
+              群里每周一次的线上交流会，轮流分享技术、求职和 AI 行业 ——
+              每期的内容与幻灯片都公开沉淀在这里。
             </p>
             <LinkCard
               heading={latestTalk.data.title}
               subheading={latestTalk.data.subtitle ?? ''}
               date={`最新一期 · ${formatTalkDateCN(latestTalk.data.date)}`}
               href='/talks'
+              target='_self'
+              data-analytics-event='home_cta_click'
+              data-analytics-section='talks'
+              data-analytics-target='latest_talk'
             />
-            <Button title='全部分享' class='w-fit self-end' href='/talks' style='ahead' />
+            <Button
+              title='全部分享'
+              class='w-fit self-end'
+              href='/talks'
+              style='ahead'
+              data-analytics-event='home_cta_click'
+              data-analytics-section='talks'
+              data-analytics-target='all_talks'
+            />
           </Section>
         )
       }
@@ -239,6 +287,9 @@ const agentHackathonLink =
           heading='Adastra Labs（石墨文档海外）'
           subheading='AI 全栈工程师'
           href='https://playyy.ai/'
+          data-analytics-event='home_external_click'
+          data-analytics-section='experience'
+          data-analytics-target='playyy'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>参与 Playyy.ai —— AI 图像生成与品牌设计平台的产品与工程研发</li>
@@ -248,12 +299,22 @@ const agentHackathonLink =
           heading='上海特赞 Tezign'
           subheading='AIGC 研发部门全栈实习生'
           href='https://atypica.ai/'
+          data-analytics-event='home_external_click'
+          data-analytics-section='experience'
+          data-analytics-target='atypica'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>参与 atypica.ai —— 面向商业研究场景的 Multi-Agent 系统</li>
           </ul>
         </LinkCard>
-        <LinkCard heading='AIXCut' subheading='AI 全栈研发' href='https://aixcut.cn/'>
+        <LinkCard
+          heading='AIXCut'
+          subheading='AI 全栈研发'
+          href='https://aixcut.cn/'
+          data-analytics-event='home_external_click'
+          data-analytics-section='experience'
+          data-analytics-target='aixcut'
+        >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>参与 AI 视频剪辑 Agent 的设计与工程化落地</li>
           </ul>
@@ -262,6 +323,9 @@ const agentHackathonLink =
           heading='fAIshion.ai'
           subheading='AI 全栈工程师（远程）'
           href='https://www.faishion.ai/'
+          data-analytics-event='home_external_click'
+          data-analytics-section='experience'
+          data-analytics-target='faishion'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>AI 虚拟试衣与服装搭配平台的全栈开发与模型集成</li>
@@ -276,6 +340,9 @@ const agentHackathonLink =
               subheading={repo.description}
               date={`⭐ ${repo.stars}`}
               href={`https://github.com/joyehuang/${repo.name}`}
+              data-analytics-event='home_github_click'
+              data-analytics-section='open_source'
+              data-analytics-target={repo.name}
             />
           ))
         }
@@ -376,6 +443,9 @@ const agentHackathonLink =
         data-agent-popout-close
         class='absolute end-2 top-2 z-10 flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
         aria-label='关闭 Agent 比赛弹窗'
+        data-analytics-event='home_agent_activity_click'
+        data-analytics-section='agent_popout'
+        data-analytics-target='close'
       >
         <svg
           xmlns='http://www.w3.org/2000/svg'
@@ -425,6 +495,9 @@ const agentHackathonLink =
               target='_blank'
               rel='noopener noreferrer'
               class='group inline-flex items-center gap-1.5 rounded-full bg-foreground px-3 py-1.5 text-sm font-medium text-background no-underline transition-transform hover:-translate-y-0.5'
+              data-analytics-event='home_agent_activity_click'
+              data-analytics-section='agent_popout'
+              data-analytics-target='feishu_link'
             >
               去看群比赛
               <svg
@@ -448,6 +521,9 @@ const agentHackathonLink =
               type='button'
               data-agent-popout-minimize
               class='rounded-full border bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+              data-analytics-event='home_agent_activity_click'
+              data-analytics-section='agent_popout'
+              data-analytics-target='minimize'
             >
               收进角落
             </button>
@@ -461,6 +537,9 @@ const agentHackathonLink =
       data-agent-popout-pill
       class='agent-popout-pill hidden items-center gap-2 rounded-full border bg-background/95 px-3 py-2 text-sm font-medium shadow-lg backdrop-blur transition-all hover:-translate-y-0.5 hover:border-foreground/25 hover:shadow-xl'
       aria-label='展开第一届 Joye 粉丝 Agent 比赛弹窗'
+      data-analytics-event='home_agent_activity_click'
+      data-analytics-section='agent_popout'
+      data-analytics-target='pill_open'
     >
       <span class='relative flex size-2'>
         <span


### PR DESCRIPTION
## Summary

- Add a lightweight Vercel Analytics click-event delegate for `data-analytics-*` attributes.
- Track homepage terminal opens and terminal commands.
- Add homepage tracking for GitHub links, Agent activity actions, primary CTAs, and selected external links.
- Allow `LinkCard` to pass through analytics data attributes.

## Validation

- `bun run check`
- `bun run build`

Note: local build still reports the existing Vercel adapter warning that local Node 24 is not supported for Serverless Functions and Vercel will use Node 18 at runtime.