### PR TITLE
[codex] define analytics event contract

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -104,7 +104,7 @@ Required properties:
 
 - `locale`: `zh` | `en`
 - `page`: current pathname
-- `surface`: `home_terminal`
+- `surface`: `home_terminal` | `dev_mode`
 - `method`: `shell_click` | `keyboard_backtick` | `keyboard_activate` | `window_control`
 - `target`: `terminal_shell`
 
@@ -229,7 +229,7 @@ User clicks a resource attached to a Talk.
 Required properties:
 
 - `locale`: `zh` | `en`
-- `page`: `/talks`
+- `page`: current pathname
 - `surface`: `talks_feed` | `article_callout` | `article_slide`
 - `episode`: talk episode number when available
 - `resource`: `deck` | `video` | `record` | `slide`
@@ -269,8 +269,9 @@ driven by users switching from Chinese pages.
 
 ## Legacy Events
 
-These events exist in older code/data. Do not add new instrumentation with these
-names unless maintaining backward compatibility during a migration.
+These events exist in older analytics data and may appear in historical Vercel
+dashboards. Do not add new instrumentation with these names unless maintaining
+backward compatibility during a migration.
 
 ### `home_terminal_open`
 
@@ -327,16 +328,7 @@ Prefer `project_link_click` with `surface: home_experience`.
 
 ## Implementation Status
 
-Implemented at the time this contract was written:
-
-- `home_terminal_open`
-- `home_terminal_command`
-- `home_github_click`
-- `home_agent_activity_click`
-- `home_cta_click`
-- `home_external_click`
-
-Target events still need implementation or migration:
+Implemented in current code:
 
 - `terminal_open`
 - `terminal_command`
@@ -349,6 +341,15 @@ Target events still need implementation or migration:
 - `talk_resource_click`
 - `talk_join_intent`
 - `language_switch_click`
+
+Legacy events retained only for historical data interpretation:
+
+- `home_terminal_open`
+- `home_terminal_command`
+- `home_github_click`
+- `home_agent_activity_click`
+- `home_cta_click`
+- `home_external_click`
 
 ## Adding Or Changing Events
 

--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -1,133 +1,363 @@
 # Analytics Events
 
-This file is the tracking contract for the site. Keep event names stable so Vercel Analytics data stays comparable over time.
+This file is the tracking contract for the site. Check it before adding,
+renaming, or changing Vercel Analytics events.
 
-## Principles
+The site uses Vercel Analytics only. Do not add another analytics provider
+unless the project explicitly decides to do that later.
 
-- Use one event for one user intent, not one event for every implementation detail.
-- Prefer `snake_case` event names.
-- Name events as `surface_object_action` when possible.
-- Put context in properties such as `section`, `target`, `method`, `href`, `slug`, and `percent`.
-- Do not send personal data such as email, IP address, display name, or free-form user input.
-- Keep property values flat: strings, numbers, booleans, or `null`.
+## Tracking Boundary
+
+Use Vercel Analytics Pages for routing questions:
+
+- Which pages get traffic.
+- Whether `/blog`, `/talks`, `/projects`, `/contact`, `/en/*`, or individual
+  article pages are visited.
+- Whether English pages have natural traffic.
+
+Use Vercel Analytics Events only for behavior Pages cannot answer:
+
+- In-page interactions that do not necessarily route.
+- External exits such as GitHub, project sites, decks, videos, and docs.
+- Reveals, hovers, or focus states that expose contact or sponsorship info.
+- Terminal commands and terminal-driven navigation.
+- Activity-specific intent such as Agent competition clicks or Talk join intent.
+
+Do not track ordinary internal navigation as an event if the destination pageview
+already answers the question. Examples to avoid:
+
+- `more_blogs_click`
+- `more_talks_click`
+- `blog_card_click`
+- `tag_click`
+- `back_click`
+- Generic header nav clicks
+
+The rule of thumb:
+
+- Pages answer "where did the visitor go?"
+- Events answer "what did the visitor do that pageviews cannot see?"
+
+## Naming Rules
+
+- Use `snake_case`.
+- Prefer names that describe a stable user intent, not current UI text.
+- Do not include the page name unless the behavior is truly page-specific.
+- Avoid generic names such as `button_click`, `cta_click`, or `link_click`.
+- Keep event names stable after deploy. If meaning changes, create a new event.
+- Put variable context in properties, not in the event name.
+
+Good:
+
+- `terminal_open`
+- `terminal_command`
+- `github_link_click`
+- `agent_competition_click`
+- `contact_method_reveal`
+
+Bad:
+
+- `home_cta_click`
+- `more_blogs_click`
+- `click_green_button`
+- `talks_page_button_click`
 
 ## Common Properties
 
-| Property  | Meaning                                                          | Examples                                                         |
-| --------- | ---------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `section` | Page area or content group where the event happened.             | `profile_header`, `terminal`, `open_source`, `agent_popout`      |
-| `target`  | Specific clicked or interacted object.                           | `profile`, `terminal_shell`, `feishu_link`, `Learn-Open-Harness` |
-| `href`    | Link destination when the target is an anchor.                   | `https://github.com/joyehuang`                                   |
-| `method`  | Interaction method when relevant.                                | `shell_click`, `keyboard_backtick`, `keyboard_activate`          |
-| `command` | Terminal command name only, without arguments.                   | `help`, `chat`, `ls`                                             |
-| `slug`    | Content identifier for articles, notes, talks, or archive items. | `20260517---agentonboardingguide`                                |
-| `percent` | Progress threshold for reading or scroll events.                 | `50`, `75`, `90`                                                 |
+Keep properties flat: strings, numbers, booleans, or `null`. Do not send
+personal data such as email addresses, IP addresses, display names, full command
+input, comment text, search text, or free-form user input.
 
-## Current Events
+| Property | Meaning | Examples |
+| --- | --- | --- |
+| `locale` | Current site locale. | `zh`, `en` |
+| `page` | Current pathname. | `/`, `/en`, `/contact`, `/talks` |
+| `surface` | UI area where the interaction happened. | `home_profile`, `agent_popout`, `projects`, `article_inline` |
+| `section` | Content section when useful. | `open_source`, `programs`, `sponsorship` |
+| `target` | Specific interacted object. | `profile`, `repo`, `wechat`, `pill` |
+| `action` | Interaction action. | `click`, `reveal`, `close`, `minimize`, `external_link` |
+| `method` | Interaction method. | `shell_click`, `keyboard_backtick`, `hover`, `focus` |
+| `href` | Destination for anchors. | `https://github.com/joyehuang` |
+| `destination_type` | Normalized destination kind. | `internal`, `external`, `github`, `mailto`, `doc`, `video` |
+| `command` | Terminal command name only. | `help`, `open`, `mail`, `connect` |
+| `command_result` | Safe terminal outcome bucket. | `success`, `unknown_command`, `navigation`, `external_open`, `mailto_open` |
+| `repo` | Repository name for GitHub clicks. | `Learn-Open-Harness`, `interview-prep` |
+| `project` | Project identifier for project clicks. | `atypica`, `aixcut`, `prepwise` |
+| `link_type` | Project link type. | `site`, `github`, `doc`, `release` |
+| `method_name` | Contact or payment method. | `wechat`, `qq_group`, `wechat_pay`, `alipay` |
+| `article_slug` | Article identifier for article-scoped events. | `20260517---agentonboardingguide` |
+| `episode` | Talk episode number. | `1`, `2` |
+| `resource` | Talk or article resource type. | `deck`, `video`, `record`, `slide` |
+
+Use `null` for unavailable optional properties rather than inventing placeholders.
+
+## Target Event Contract
+
+These are the intended events for the site. Some may not be implemented yet.
+When implementing them, update the "Implementation Status" section below.
+
+### `terminal_open`
+
+User opens the interactive terminal.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: current pathname
+- `surface`: `home_terminal`
+- `method`: `shell_click` | `keyboard_backtick` | `keyboard_activate` | `window_control`
+- `target`: `terminal_shell`
+
+Use this to measure whether the terminal is a real interactive entry point or
+only a visual element.
+
+### `terminal_command`
+
+User runs a command in the terminal.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: current pathname
+- `surface`: `terminal`
+- `target`: `terminal_shell`
+- `command`: command name only, for example `help`, `open`, `mail`, `connect`
+- `command_result`: safe bucket, not raw command text
+- `destination_type`: optional destination bucket for commands that open something
+
+Never send full raw terminal input because it may contain user-written text.
+
+### `github_link_click`
+
+User clicks a GitHub destination from any meaningful surface.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: current pathname
+- `surface`: `home_profile` | `home_open_source` | `about_social` | `projects` | `terminal_contact` | `footer`
+- `target`: `profile` | `repo`
+- `repo`: repo name when `target` is `repo`, otherwise `null`
+- `href`: GitHub URL
+
+Use this to understand whether visitors continue from the site to GitHub, and
+from which surface.
+
+### `agent_competition_click`
+
+User interacts with the Agent competition surface.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: current pathname
+- `surface`: `agent_popout` | `agent_pill` | `projects`
+- `action`: `external_link` | `close` | `minimize` | `pill_open`
+- `href`: Feishu/doc URL for external link actions, otherwise `null`
+
+Use this to compare real activity interest with dismissals.
+
+### `contact_method_reveal`
+
+User reveals contact information on the Contact page.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: `/contact` | `/en/contact`
+- `surface`: `contact_page`
+- `method_name`: `wechat` | `qq_group`
+- `action`: `reveal`
+- `method`: `hover` | `focus`
+
+Fire once per method per pageview. Do not fire repeatedly on every mouse move.
+
+### `article_contact_reveal`
+
+User reveals inline WeChat contact information inside an article.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: current article pathname
+- `surface`: `article_inline`
+- `article_slug`: article identifier
+- `method_name`: `wechat`
+- `action`: `reveal`
+- `method`: `hover` | `focus`
+
+This is a stronger consulting/contact intent signal than a generic Contact page
+view because it happens inside article context.
+
+### `sponsorship_method_reveal`
+
+User reveals a sponsorship QR code on the Projects page.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: `/projects` | `/en/projects`
+- `surface`: `sponsorship`
+- `method_name`: `wechat_pay` | `alipay`
+- `action`: `reveal`
+- `method`: `hover` | `focus`
+
+Fire once per method per pageview.
+
+### `project_link_click`
+
+User clicks a project destination from the Projects page or homepage experience
+section.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: current pathname
+- `surface`: `home_experience` | `projects`
+- `section`: `experience` | `open_source` | `programs` | `learnings` | `theme`
+- `project`: stable project identifier
+- `link_type`: `site` | `github` | `doc` | `release`
+- `href`: destination URL
+
+Do not also fire `github_link_click` for the same click unless there is an
+explicit need to duplicate the signal. Prefer one event per user action.
+
+### `talk_resource_click`
+
+User clicks a resource attached to a Talk.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: `/talks`
+- `surface`: `talks_feed` | `article_callout` | `article_slide`
+- `episode`: talk episode number when available
+- `resource`: `deck` | `video` | `record` | `slide`
+- `href`: destination URL
+
+Use this because Pages can show `/talks` traffic, but cannot show whether people
+opened the deck or watched the recording.
+
+### `talk_join_intent`
+
+User clicks a Talk-specific "join" or "participate" entry point.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: current pathname
+- `surface`: `talks_hero` | `talks_preview` | `talks_upcoming`
+- `target`: `contact`
+- `href`: contact URL
+
+This is allowed even though it routes to Contact because the source intent
+("join the talks") is lost in a plain Contact pageview.
+
+### `language_switch_click`
+
+User switches site language.
+
+Required properties:
+
+- `page`: current pathname before navigation
+- `from_locale`: `zh` | `en`
+- `to_locale`: `zh` | `en`
+- `target_path`: destination pathname
+
+Use this alongside Pages to understand whether English traffic is natural or
+driven by users switching from Chinese pages.
+
+## Legacy Events
+
+These events exist in older code/data. Do not add new instrumentation with these
+names unless maintaining backward compatibility during a migration.
 
 ### `home_terminal_open`
 
-User opens the interactive terminal on the home page.
+Legacy name for `terminal_open`.
 
-Properties:
+Current properties:
 
 - `section`: `terminal`
 - `target`: `terminal_shell`
 - `method`: `shell_click` | `keyboard_backtick` | `keyboard_activate` | `window_control`
 
-Use this to measure whether the terminal is a real interactive entry point or only a visual element.
-
 ### `home_terminal_command`
 
-User runs a command in the home page terminal.
+Legacy name for `terminal_command`.
 
-Properties:
+Current properties:
 
 - `section`: `terminal`
 - `target`: `terminal_shell`
-- `command`: command name only, for example `help`, `chat`, `ls`
-
-Do not send full raw commands because they may contain user-written text.
+- `command`: command name only
 
 ### `home_github_click`
 
-User clicks a GitHub destination from the home page.
+Legacy name for `github_link_click` when the click starts from the homepage.
 
-Properties:
+Current properties:
 
 - `section`: `profile_header` | `open_source`
 - `target`: `profile` or repository name
 - `href`: GitHub URL
 
-Use this to compare top profile GitHub intent with project-specific GitHub intent.
-
 ### `home_agent_activity_click`
 
-User interacts with the Agent activity popout on the home page.
+Legacy name for `agent_competition_click` on the homepage popout.
 
-Properties:
+Current properties:
 
 - `section`: `agent_popout`
 - `target`: `feishu_link` | `pill_open` | `minimize` | `close`
 - `href`: Feishu link when clicking the activity link
 
-Use this to evaluate whether the popout drives activity interest or mostly gets dismissed.
-
 ### `home_cta_click`
 
-User clicks a primary internal home page CTA.
+Deprecated.
 
-Properties:
-
-- `section`: `hero` | `about` | `blog` | `notes` | `talks`
-- `target`: `contact` | `more_about` | `more_blogs` | `more_notes` | `latest_talk` | `all_talks`
-- `href`: internal URL
-
-Use this to understand which internal paths the home page sends readers toward.
+This event mixed ordinary internal navigation with real intent signals. Do not
+extend it. Pages already answer most of what it tried to measure.
 
 ### `home_external_click`
 
-User clicks an external experience/project destination from the home page.
+Legacy name for homepage project/work outbound clicks.
 
-Properties:
+Prefer `project_link_click` with `surface: home_experience`.
 
-- `section`: `experience`
-- `target`: `playyy` | `atypica` | `aixcut` | `faishion`
-- `href`: external URL
+## Implementation Status
 
-Use this to measure outbound interest in work/project links.
+Implemented at the time this contract was written:
 
-## Planned Events
+- `home_terminal_open`
+- `home_terminal_command`
+- `home_github_click`
+- `home_agent_activity_click`
+- `home_cta_click`
+- `home_external_click`
 
-These are not implemented yet. Add them when article and content analytics are instrumented.
+Target events still need implementation or migration:
 
-### `article_read_progress`
+- `terminal_open`
+- `terminal_command`
+- `github_link_click`
+- `agent_competition_click`
+- `contact_method_reveal`
+- `article_contact_reveal`
+- `sponsorship_method_reveal`
+- `project_link_click`
+- `talk_resource_click`
+- `talk_join_intent`
+- `language_switch_click`
 
-User reaches a reading progress threshold on an article.
+## Adding Or Changing Events
 
-Properties:
-
-- `slug`: article identifier
-- `percent`: `50` | `75` | `90`
-
-Use this for read-depth and completion-rate analysis.
-
-### `article_external_link_click`
-
-User clicks an external link inside an article.
-
-Properties:
-
-- `slug`: article identifier
-- `section`: optional content section or heading id
-- `target`: normalized link label or domain
-- `href`: external URL
-
-Use this to learn which references and outbound resources readers care about.
-
-## Adding A New Event
-
-1. Add the event to this file first.
-2. Reuse existing properties before inventing new ones.
-3. Keep the event name stable after deploy. If the meaning changes, create a new event.
-4. Verify in production with DevTools Network by checking for `/_vercel/insights/event`.
+1. Start from the tracking boundary above. If Pages answer the question, do not
+   add an event.
+2. Add or update the event in this file before changing code.
+3. Reuse existing properties before inventing new ones.
+4. Keep event names stable after deploy. If the meaning changes, create a new
+   event and mark the old one as legacy.
+5. Avoid high-cardinality or personal fields. Do not send raw user input.
+6. Verify in production with DevTools Network by checking for
+   `/_vercel/insights/event`.

--- a/src/components/AnalyticsEvents.astro
+++ b/src/components/AnalyticsEvents.astro
@@ -1,5 +1,10 @@
 <script>
-  import { track } from '@vercel/analytics'
+  import {
+    normalizeHref,
+    propertiesFromDataset,
+    trackSiteEvent,
+    type AnalyticsProperties
+  } from '@/lib/analytics'
 
   document.addEventListener('click', (event) => {
     const target =
@@ -12,10 +17,52 @@
     const eventName = target.dataset.analyticsEvent
     if (!eventName) return
 
-    track(eventName, {
-      href: target instanceof HTMLAnchorElement ? target.href : null,
-      section: target.dataset.analyticsSection ?? null,
-      target: target.dataset.analyticsTarget ?? target.textContent?.trim().slice(0, 80) ?? null
+    trackSiteEvent(eventName, {
+      href: normalizeHref(target),
+      target: target.dataset.analyticsTarget ?? target.textContent?.trim().slice(0, 80) ?? null,
+      ...propertiesFromDataset(target)
     })
+  })
+
+  const revealed = new Set<string>()
+
+  function trackReveal(target: HTMLElement, method: 'hover' | 'focus') {
+    const eventName = target.dataset.analyticsRevealEvent
+    if (!eventName) return
+
+    const properties: AnalyticsProperties = {
+      href: normalizeHref(target),
+      method,
+      target: target.dataset.analyticsTarget ?? null,
+      ...propertiesFromDataset(target)
+    }
+    if (eventName === 'article_contact_reveal' && !properties.article_slug) {
+      properties.article_slug = decodeURIComponent(location.pathname.split('/').filter(Boolean).pop() ?? '')
+    }
+    const key = `${eventName}:${location.pathname}:${JSON.stringify(properties)}`
+    if (revealed.has(key)) return
+    revealed.add(key)
+    trackSiteEvent(eventName, properties)
+  }
+
+  document.addEventListener('pointerover', (event) => {
+    const target =
+      event.target instanceof Element
+        ? event.target.closest<HTMLElement>('[data-analytics-reveal-event]')
+        : null
+
+    if (!target) return
+    if (event.relatedTarget instanceof Node && target.contains(event.relatedTarget)) return
+    trackReveal(target, 'hover')
+  })
+
+  document.addEventListener('focusin', (event) => {
+    const target =
+      event.target instanceof Element
+        ? event.target.closest<HTMLElement>('[data-analytics-reveal-event]')
+        : null
+
+    if (!target) return
+    trackReveal(target, 'focus')
   })
 </script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -113,6 +113,7 @@ const searchHref = localizedPath('/search', lang)
 </script>
 <script>
   import { setTheme, showToast } from 'astro-pure/utils'
+  import { trackSiteEvent } from '@/lib/analytics'
 
   class Header extends HTMLElement {
     private toggleMenuBtn: HTMLElement | null = null
@@ -159,6 +160,13 @@ const searchHref = localizedPath('/search', lang)
       })
 
       this.querySelector('#toggleDevMode')?.addEventListener('click', () => {
+        if (document.documentElement.dataset.mode !== 'dev') {
+          trackSiteEvent('terminal_open', {
+            method: 'window_control',
+            surface: 'dev_mode',
+            target: 'terminal_shell'
+          })
+        }
         window.dispatchEvent(new CustomEvent('joye:toggle-dev'))
       })
 

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -21,6 +21,8 @@ const label = lang === 'en' ? '中' : 'EN'
 </button>
 
 <script>
+  import { trackSiteEvent } from '@/lib/analytics'
+
   function targetPathname(pathname: string, current: 'zh' | 'en'): string {
     if (current === 'en') {
       if (pathname === '/en' || pathname === '/en/') return '/'
@@ -37,6 +39,12 @@ const label = lang === 'en' ? '中' : 'EN'
     if (!btn) return
     const current = (btn.dataset.lang === 'en' ? 'en' : 'zh') as 'zh' | 'en'
     const next = targetPathname(window.location.pathname, current)
+    trackSiteEvent('language_switch_click', {
+      page: window.location.pathname,
+      from_locale: current,
+      to_locale: current === 'en' ? 'zh' : 'en',
+      target_path: next
+    })
     window.location.href = next + window.location.search + window.location.hash
   })
 </script>

--- a/src/components/WechatReveal.astro
+++ b/src/components/WechatReveal.astro
@@ -14,6 +14,10 @@ const { class: className, label = '微信号', prefix = 'joye', suffix = '050604
   tabindex='0'
   data-a={prefix}
   data-b={suffix}
+  data-analytics-reveal-event='article_contact_reveal'
+  data-analytics-surface='article_inline'
+  data-analytics-method-name='wechat'
+  data-analytics-action='reveal'
   aria-label={`${label}，悬停或聚焦显示`}></span>
 
 <style>

--- a/src/components/about/Substats.astro
+++ b/src/components/about/Substats.astro
@@ -98,6 +98,9 @@ await Promise.all(stats.map(fetchCount))
         href={link}
         target='_blank'
         rel='noopener noreferrer'
+        data-analytics-event={platform === 'GitHub' ? 'github_link_click' : undefined}
+        data-analytics-surface={platform === 'GitHub' ? 'about_social' : undefined}
+        data-analytics-target={platform === 'GitHub' ? 'profile' : undefined}
       >
         <div class='flex items-center gap-3 rounded-lg border border-transparent px-3 py-2 transition-all hover:border-border hover:bg-muted'>
           {icon && (

--- a/src/components/blog/FeatureCalloutCard.astro
+++ b/src/components/blog/FeatureCalloutCard.astro
@@ -1,5 +1,7 @@
 ---
 interface Action {
+  analyticsEvent?: string
+  analyticsProps?: Record<string, string | number>
   href: string
   label: string
   external?: boolean
@@ -39,6 +41,13 @@ const ariaLabel = Astro.props.ariaLabel ?? title
             href={action.href}
             target={action.external ? '_blank' : undefined}
             rel={action.external ? 'noopener' : undefined}
+            data-analytics-event={action.analyticsEvent}
+            {...Object.fromEntries(
+              Object.entries(action.analyticsProps ?? {}).map(([key, value]) => [
+                `data-analytics-${key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)}`,
+                value
+              ])
+            )}
           >
             {action.label}
           </a>

--- a/src/components/blog/TalkEpisodeCard.astro
+++ b/src/components/blog/TalkEpisodeCard.astro
@@ -13,7 +13,19 @@ const videoHref = 'https://www.bilibili.com/video/BV1sQJN6rE1D'
   description='这篇文章是这期分享的文字版。如果你想看原始分享记录、幻灯片或录屏，可以从这里跳过去。'
   actions={[
     { label: '看分享会记录', href: talkHref, primary: true },
-    { label: '打开幻灯片', href: deckHref, external: true },
-    { label: '看录屏', href: videoHref, external: true }
+    {
+      label: '打开幻灯片',
+      href: deckHref,
+      external: true,
+      analyticsEvent: 'talk_resource_click',
+      analyticsProps: { surface: 'article_callout', episode: 1, resource: 'deck' }
+    },
+    {
+      label: '看录屏',
+      href: videoHref,
+      external: true,
+      analyticsEvent: 'talk_resource_click',
+      analyticsProps: { surface: 'article_callout', episode: 1, resource: 'video' }
+    }
   ]}
 />

--- a/src/components/blog/TalkSlideFigure.astro
+++ b/src/components/blog/TalkSlideFigure.astro
@@ -5,15 +5,27 @@ interface Props {
   caption?: string
   href?: string
   label?: string
+  analyticsEpisode?: number
+  analyticsResource?: 'deck' | 'slide'
 }
 
-const { alt, caption, href, label, src } = Astro.props
+const { alt, analyticsEpisode, analyticsResource = 'slide', caption, href, label, src } = Astro.props
 ---
 
 <figure class='talk-slide-figure not-prose'>
   {
     href ? (
-      <a class='talk-slide-frame' href={href} target='_blank' rel='noopener' aria-label={caption ?? alt}>
+      <a
+        class='talk-slide-frame'
+        href={href}
+        target='_blank'
+        rel='noopener'
+        aria-label={caption ?? alt}
+        data-analytics-event='talk_resource_click'
+        data-analytics-surface='article_slide'
+        data-analytics-episode={analyticsEpisode}
+        data-analytics-resource={analyticsResource}
+      >
         <img src={src} alt={alt} loading='lazy' />
       </a>
     ) : (

--- a/src/components/contact/ContactQR.astro
+++ b/src/components/contact/ContactQR.astro
@@ -9,6 +9,7 @@ interface Props {
     name: string
     hint: string
     image: ImageMetadata
+    methodName: 'wechat' | 'qq_group'
     note?: string
   }[]
 }
@@ -20,7 +21,14 @@ const { class: className, items, ...props } = Astro.props
   {
     items.map((item) => (
       <div class='contact-card flex flex-col items-center gap-3'>
-        <div class='contact-card-frame relative w-60 max-w-full overflow-hidden rounded-xl border bg-white'>
+        <div
+          class='contact-card-frame relative w-60 max-w-full overflow-hidden rounded-xl border bg-white'
+          tabindex='0'
+          data-analytics-reveal-event='contact_method_reveal'
+          data-analytics-surface='contact_page'
+          data-analytics-method-name={item.methodName}
+          data-analytics-action='reveal'
+        >
           <div class='contact-card-cover absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 bg-muted/60 px-4 text-center text-muted-foreground transition-opacity'>
             <span class='text-base font-medium text-foreground'>{item.name}</span>
             <span class='text-xs'>{item.hint}</span>

--- a/src/components/projects/GitHubContributions.astro
+++ b/src/components/projects/GitHubContributions.astro
@@ -138,6 +138,9 @@ const formattedTotal = total.toLocaleString('en-US')
         href={`https://github.com/${username}`}
         target='_blank'
         rel='noreferrer'
+        data-analytics-event='github_link_click'
+        data-analytics-surface='projects'
+        data-analytics-target='profile'
       >
         @{username}
       </a>

--- a/src/components/projects/ProjectSection.astro
+++ b/src/components/projects/ProjectSection.astro
@@ -8,7 +8,10 @@ import { cn } from 'astro-pure/utils'
 
 interface Props {
   class?: string
+  analyticsSection?: string
   project: {
+    id?: string
+    analyticsEvent?: 'agent_competition_click' | 'project_link_click'
     image?: string
     name: string
     description: string
@@ -18,7 +21,7 @@ interface Props {
     }[]
   }[]
 }
-const { class: className, project, ...props } = Astro.props
+const { analyticsSection, class: className, project, ...props } = Astro.props
 const images = import.meta.glob<{ default: ImageMetadata }>(
   '/src/assets/projects/*.{jpeg,jpg,png,gif}'
 )
@@ -27,6 +30,34 @@ const projectIconSet: Record<string, iconsType> = {
   site: 'earth',
   doc: 'document',
   release: 'package'
+}
+
+const projectId = (name: string) =>
+  name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+
+const analyticsAttrs = (
+  project: Props['project'][number],
+  link: Props['project'][number]['links'][number]
+) => {
+  const eventName = project.analyticsEvent ?? 'project_link_click'
+  if (eventName === 'agent_competition_click') {
+    return {
+      'data-analytics-event': 'agent_competition_click',
+      'data-analytics-surface': 'projects',
+      'data-analytics-action': 'external_link'
+    }
+  }
+
+  return {
+    'data-analytics-event': 'project_link_click',
+    'data-analytics-surface': 'projects',
+    'data-analytics-section': analyticsSection,
+    'data-analytics-project': project.id ?? projectId(project.name),
+    'data-analytics-link-type': link.type
+  }
 }
 ---
 
@@ -71,6 +102,8 @@ const projectIconSet: Record<string, iconsType> = {
                 class='project-title font-medium text-foreground no-underline transition-colors'
                 href={project.links[0].href}
                 target='_blank'
+                rel='noopener noreferrer'
+                {...analyticsAttrs(project, project.links[0])}
               >
                 {project.name}
               </a>
@@ -86,6 +119,8 @@ const projectIconSet: Record<string, iconsType> = {
                       class='rounded-full bg-muted p-1 text-muted-foreground transition-colors sm:p-1.5'
                       aria-label={link.type}
                       target='_blank'
+                      rel='noopener noreferrer'
+                      {...analyticsAttrs(project, link)}
                     >
                       <Icon class='size-5' name={icon} />
                     </a>

--- a/src/components/projects/Sponsorship.astro
+++ b/src/components/projects/Sponsorship.astro
@@ -11,6 +11,7 @@ interface Props {
     name: string
     icon: string
     image: ImageMetadata
+    methodName: 'wechat_pay' | 'alipay'
   }[]
 }
 
@@ -20,7 +21,14 @@ const { class: className, methods, ...props } = Astro.props
 <div class={cn('flex flex-col justify-center gap-4 sm:flex-row', className)} {...props}>
   {
     methods.map((item) => (
-      <div class='sponsorship-card relative justify-center overflow-hidden rounded-xl border bg-white'>
+      <div
+        class='sponsorship-card relative justify-center overflow-hidden rounded-xl border bg-white'
+        tabindex='0'
+        data-analytics-reveal-event='sponsorship_method_reveal'
+        data-analytics-surface='sponsorship'
+        data-analytics-method-name={item.methodName}
+        data-analytics-action='reveal'
+      >
         <div class='sponsorship-card-icon absolute bottom-0 end-0 start-0 top-0 flex items-center justify-center transition-opacity'>
           <Icon class='size-20' name={item.icon as iconsType} />
         </div>

--- a/src/components/talks/TalksSeries.astro
+++ b/src/components/talks/TalksSeries.astro
@@ -49,7 +49,13 @@ const takeawayHtml = (title: string, desc?: string) =>
           <b class='waline-comment-count' data-path='/talks'></b> 条留言
         </a>
       </div>
-      <a class='tk-join' href='/contact'>想来参加？→</a>
+      <a
+        class='tk-join'
+        href='/contact'
+        data-analytics-event='talk_join_intent'
+        data-analytics-surface='talks_hero'
+        data-analytics-target='contact'
+      >想来参加？→</a>
     </div>
   </section>
 
@@ -96,7 +102,13 @@ const takeawayHtml = (title: string, desc?: string) =>
                   <span class='tk-preview-brand'>
                     分享人 Joye · joyehuang.me · AI Agent &amp; Full-Stack Dev
                   </span>
-                  <a class='tk-preview-cta' href='/contact'>
+                  <a
+                    class='tk-preview-cta'
+                    href='/contact'
+                    data-analytics-event='talk_join_intent'
+                    data-analytics-surface='talks_preview'
+                    data-analytics-target='contact'
+                  >
                     想来参加？→
                   </a>
                 </div>
@@ -214,12 +226,25 @@ const takeawayHtml = (title: string, desc?: string) =>
                       href={d.video.url ?? `https://www.bilibili.com/video/${d.video.bvid}`}
                       target='_blank'
                       rel='noopener'
+                      data-analytics-event='talk_resource_click'
+                      data-analytics-surface='talks_feed'
+                      data-analytics-episode={d.episode}
+                      data-analytics-resource='video'
                     >
                       看录屏回放 →
                     </a>
                   )}
                   {d.deckUrl && (
-                    <a class='tk-cta tk-cta-ghost' href={d.deckUrl} target='_blank' rel='noopener'>
+                    <a
+                      class='tk-cta tk-cta-ghost'
+                      href={d.deckUrl}
+                      target='_blank'
+                      rel='noopener'
+                      data-analytics-event='talk_resource_click'
+                      data-analytics-surface='talks_feed'
+                      data-analytics-episode={d.episode}
+                      data-analytics-resource='deck'
+                    >
                       打开这期幻灯片 →
                     </a>
                   )}
@@ -242,7 +267,13 @@ const takeawayHtml = (title: string, desc?: string) =>
           <span class='tk-ep tk-ep-ghost'>下一期</span>
           <span class='tk-rail-date'>待定</span>
         </div>
-        <a class='tk-upcoming-row' href='/contact'>
+        <a
+          class='tk-upcoming-row'
+          href='/contact'
+          data-analytics-event='talk_join_intent'
+          data-analytics-surface='talks_upcoming'
+          data-analytics-target='contact'
+        >
           <span class='tk-node tk-node-ghost' aria-hidden='true'></span>
           <span class='tk-upcoming-tag'>下一期 · 待定</span>
           <span class='tk-upcoming-main'>

--- a/src/components/terminal/DevMode.tsx
+++ b/src/components/terminal/DevMode.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { trackSiteEvent } from '@/lib/analytics'
+
+import { classifyTerminalCommand } from './analytics'
 import { commands, completeInput } from './commands'
 import { ROOT_LABEL } from './fs/content'
 import { displayPath, getNode } from './fs/path'
@@ -254,6 +257,12 @@ export default function DevMode({
       const name = parts[0].toLowerCase()
       const args = parts.slice(1)
       const spec = commands[name]
+      trackSiteEvent('terminal_command', {
+        command: name,
+        surface: 'terminal',
+        target: 'terminal_shell',
+        ...classifyTerminalCommand(name, args, fs, cwd, Boolean(spec))
+      })
       if (!spec) {
         appendEntry({
           kind: 'output',

--- a/src/components/terminal/DevModeHost.tsx
+++ b/src/components/terminal/DevModeHost.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 
+import { trackSiteEvent } from '@/lib/analytics'
+
 import DevMode from './DevMode'
 import type { FsNode } from './fs/types'
 
@@ -26,7 +28,14 @@ function isEditable(target: EventTarget | null): boolean {
 export default function DevModeHost({ fs }: { fs: FsNode }) {
   const [mode, setMode] = useState<Mode>('human')
 
-  const enter = useCallback(() => setMode('dev'), [])
+  const enter = useCallback((method: string) => {
+    trackSiteEvent('terminal_open', {
+      method,
+      surface: 'dev_mode',
+      target: 'terminal_shell'
+    })
+    setMode('dev')
+  }, [])
   const exit = useCallback(() => setMode('human'), [])
 
   // global `\`` hotkey — only fires when nothing editable is focused
@@ -38,7 +47,7 @@ export default function DevModeHost({ fs }: { fs: FsNode }) {
       // while already in dev mode, the overlay's own input owns the backtick
       if (mode === 'dev') return
       e.preventDefault()
-      enter()
+      enter('keyboard_backtick')
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
@@ -47,7 +56,7 @@ export default function DevModeHost({ fs }: { fs: FsNode }) {
   // custom events from non-React callers (Header button, future callers)
   useEffect(() => {
     const onToggle = () => setMode((m) => (m === 'dev' ? 'human' : 'dev'))
-    const onEnter = () => setMode('dev')
+    const onEnter = () => enter('window_control')
     const onExit = () => setMode('human')
     window.addEventListener('joye:toggle-dev', onToggle)
     window.addEventListener('joye:enter-dev', onEnter)
@@ -57,7 +66,7 @@ export default function DevModeHost({ fs }: { fs: FsNode }) {
       window.removeEventListener('joye:enter-dev', onEnter)
       window.removeEventListener('joye:exit-dev', onExit)
     }
-  }, [])
+  }, [enter])
 
   // keep the Header's button icon in sync so non-React code can read
   // the current mode without importing this component

--- a/src/components/terminal/TerminalShell.tsx
+++ b/src/components/terminal/TerminalShell.tsx
@@ -1,7 +1,9 @@
-import { track } from '@vercel/analytics'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
+import { trackSiteEvent } from '@/lib/analytics'
+
+import { classifyTerminalCommand } from './analytics'
 import { commands, completeInput } from './commands'
 import { ROOT_LABEL } from './fs/content'
 import { displayPath } from './fs/path'
@@ -170,9 +172,9 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
 
   const expand = useCallback(
     (method = 'shell_click') => {
-      track('home_terminal_open', {
+      trackSiteEvent('terminal_open', {
         method,
-        section: 'terminal',
+        surface: 'home_terminal',
         target: 'terminal_shell'
       })
 
@@ -263,14 +265,15 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
 
       const parts = trimmed.split(/\s+/)
       const name = parts[0].toLowerCase()
-      track('home_terminal_command', {
-        command: name,
-        section: 'terminal',
-        target: 'terminal_shell'
-      })
-
       const args = parts.slice(1)
       const spec = commands[name]
+      trackSiteEvent('terminal_command', {
+        command: name,
+        surface: 'terminal',
+        target: 'terminal_shell',
+        ...classifyTerminalCommand(name, args, fs, cwd, Boolean(spec))
+      })
+
       if (!spec) {
         appendEntry({
           kind: 'output',

--- a/src/components/terminal/analytics.ts
+++ b/src/components/terminal/analytics.ts
@@ -1,0 +1,67 @@
+import { getDestinationType } from '@/lib/analytics'
+
+import { getNode, resolvePath } from './fs'
+import type { FsNode } from './fs/types'
+
+type TerminalCommandAnalytics = {
+  command_result: string
+  destination_type: string | null
+}
+
+export function classifyTerminalCommand(
+  command: string,
+  args: string[],
+  fs: FsNode,
+  cwd: string,
+  known: boolean
+): TerminalCommandAnalytics {
+  if (!known) {
+    return {
+      command_result: 'unknown_command',
+      destination_type: null
+    }
+  }
+
+  if (command === 'mail') {
+    return {
+      command_result: 'mailto_open',
+      destination_type: 'mailto'
+    }
+  }
+
+  if (command === 'open') {
+    const input = args[0]
+    if (!input) {
+      return {
+        command_result: 'error',
+        destination_type: null
+      }
+    }
+
+    if (/^\/(blog|archive|search|projects|links|about|contact)(\/|$)/.test(input)) {
+      return {
+        command_result: 'navigation',
+        destination_type: 'internal'
+      }
+    }
+
+    const node = getNode(fs, resolvePath(cwd, input))
+    if (node?.type === 'link') {
+      return {
+        command_result: 'external_open',
+        destination_type: getDestinationType(node.href)
+      }
+    }
+    if (node?.type === 'file' && node.href) {
+      return {
+        command_result: 'navigation',
+        destination_type: 'internal'
+      }
+    }
+  }
+
+  return {
+    command_result: 'success',
+    destination_type: null
+  }
+}

--- a/src/content/blog/20260615 - fromInternshipInterviewsToAgentEngineering/post.mdx
+++ b/src/content/blog/20260615 - fromInternshipInterviewsToAgentEngineering/post.mdx
@@ -72,6 +72,7 @@ import TalkSlideFigure from '@/components/blog/TalkSlideFigure.astro'
   label='配图 1'
   caption='工程的“对象”一直在向外扩：Prompt → Context → Harness → Loop。'
   href='/talks/2026-from-interview-to-agent.html'
+  analyticsEpisode={1}
 />
 
 一句话：**词 → 上下文 → 环境 → 机制。** 名词在变，但它做的事是同一件——围着那个不变的模型核心，一层层向外搭一个**系统**。换句话说，这条名词演进史，本身就是一部「系统不断向外扩」的历史。
@@ -155,6 +156,7 @@ import TalkSlideFigure from '@/components/blog/TalkSlideFigure.astro'
   label='配图 2'
   caption='体力活交给 agent：你只接收筛过的那部分。'
   href='/talks/2026-from-interview-to-agent.html'
+  analyticsEpisode={1}
 />
 
 这里有个容易踩的坑：直接让 LLM「推荐几篇论文」，它很可能编出根本不存在的标题和链接。更稳的做法，是给它接上**真实可信的工具**——比如调用 arXiv 的 skill（本质是 web extract，直接从源站抓取），拿回来的就是真链接、真元数据，而不是模型脑补的。拿到候选之后，再加一步**核实校验**：让 agent 逐条确认链接可达、标题和摘要对得上，再进入筛选和摘要。
@@ -173,6 +175,7 @@ import TalkSlideFigure from '@/components/blog/TalkSlideFigure.astro'
   label='配图 3'
   caption='一个常驻 agent，把你所有 App 变成指挥入口。'
   href='/talks/2026-from-interview-to-agent.html'
+  analyticsEpisode={1}
 />
 
 一个跑在你机器上的常驻「网关」，把你已经在用的 App 变成指挥它的入口；它有**持久记忆**、上百个**技能**，还带「**心跳**」——会自己定时醒来，帮你跟进邮件和日程。
@@ -225,6 +228,7 @@ import TalkSlideFigure from '@/components/blog/TalkSlideFigure.astro'
   label='配图 4'
   caption='把学习痕迹公开，变成一个循环。'
   href='/talks/2026-from-interview-to-agent.html'
+  analyticsEpisode={1}
 />
 
 先做个小东西，你一定会撞上真实问题，把它沉淀成文章 / skills / 笔记，然后公开——博客、视频、自媒体都行，再简单点，发到社群里也算。公开之后，要么收到反馈、要么直接开始下一个，又回到起点。

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,62 @@
+import { track } from '@vercel/analytics'
+
+type AnalyticsValue = string | number | boolean | null
+export type AnalyticsProperties = Record<string, AnalyticsValue>
+
+export function getLocale(pathname = globalThis.location?.pathname ?? '/'): 'zh' | 'en' {
+  return pathname === '/en' || pathname.startsWith('/en/') ? 'en' : 'zh'
+}
+
+export function getDestinationType(href: string | null): string | null {
+  if (!href) return null
+
+  const url = new URL(href, globalThis.location?.origin ?? 'https://www.joyehuang.me')
+  if (url.protocol === 'mailto:') return 'mailto'
+  if (url.hostname === 'github.com') return 'github'
+  if (url.hostname.includes('bilibili.com')) return 'video'
+  if (url.hostname.includes('feishu.cn')) return 'doc'
+  if (url.origin === globalThis.location?.origin) return 'internal'
+  return 'external'
+}
+
+export function normalizeHref(element: HTMLElement): string | null {
+  if (element instanceof HTMLAnchorElement) return element.href
+  return element.dataset.analyticsHref ?? null
+}
+
+function normalizeValue(value: string): AnalyticsValue {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  if (/^-?\d+(\.\d+)?$/.test(value)) return Number(value)
+  return value
+}
+
+export function propertiesFromDataset(element: HTMLElement): AnalyticsProperties {
+  const properties: AnalyticsProperties = {}
+
+  for (const [key, value] of Object.entries(element.dataset)) {
+    if (!key.startsWith('analytics') || key === 'analyticsEvent' || key === 'analyticsRevealEvent')
+      continue
+    const property = key
+      .replace(/^analytics/, '')
+      .replace(/^[A-Z]/, (match) => match.toLowerCase())
+      .replace(/[A-Z]/g, (match) => `_${match.toLowerCase()}`)
+
+    if (!property) continue
+    properties[property] = value === undefined ? null : normalizeValue(value)
+  }
+
+  return properties
+}
+
+export function trackSiteEvent(eventName: string, properties: AnalyticsProperties = {}) {
+  const page = globalThis.location?.pathname ?? '/'
+  const href = typeof properties.href === 'string' ? properties.href : null
+
+  track(eventName, {
+    locale: properties.locale ?? getLocale(page),
+    page: properties.page ?? page,
+    ...properties,
+    destination_type: properties.destination_type ?? getDestinationType(href)
+  })
+}

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -27,12 +27,14 @@ const headings = [
         name: '付费咨询 · 微信',
         hint: '悬停显示二维码',
         image: wechat,
+        methodName: 'wechat',
         note: '备注「付费咨询」+ 你的具体需求'
       },
       {
         name: 'cs 交流群（QQ）',
         hint: '悬停显示二维码',
         image: qqGroup,
+        methodName: 'qq_group',
         note: '群号 831907794 · 入群答题：博客最新一篇文章的标题'
       }
     ]}

--- a/src/pages/en/contact/index.astro
+++ b/src/pages/en/contact/index.astro
@@ -25,12 +25,14 @@ const headings = [
         name: 'WeChat · joye',
         hint: 'Hover to reveal QR',
         image: wechat,
+        methodName: 'wechat',
         note: 'Please add a note: "from the blog + topic you want to chat about".'
       },
       {
         name: 'cs Chat Group (QQ)',
         hint: 'Hover to reveal QR',
         image: qqGroup,
+        methodName: 'qq_group',
         note: 'Group number 831907794 · Verification: title of my latest blog post.'
       }
     ]}

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -112,7 +112,15 @@ const latestNotes = (await getCollection('archiveEn'))
           <Label title='Melbourne, Australia'>
             <Icon name='location' class='size-5' slot='icon' />
           </Label>
-          <Label title='GitHub' as='a' href='https://github.com/joyehuang' target='_blank'>
+          <Label
+            title='GitHub'
+            as='a'
+            href='https://github.com/joyehuang'
+            target='_blank'
+            data-analytics-event='github_link_click'
+            data-analytics-surface='home_profile'
+            data-analytics-target='profile'
+          >
             <Icon name='github' class='size-5' slot='icon' />
           </Label>
         </div>
@@ -223,6 +231,11 @@ const latestNotes = (await getCollection('archiveEn'))
           heading='Adastra Labs (Shimo Docs)'
           subheading='AI Full-Stack Engineer'
           href='https://playyy.ai/'
+          data-analytics-event='project_link_click'
+          data-analytics-surface='home_experience'
+          data-analytics-section='experience'
+          data-analytics-project='playyy'
+          data-analytics-link-type='site'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>Building Playyy.ai — an AI image generation and brand design platform</li>
@@ -232,12 +245,26 @@ const latestNotes = (await getCollection('archiveEn'))
           heading='Tezign (Shanghai)'
           subheading='Full-Stack Intern, AIGC R&D'
           href='https://atypica.ai/'
+          data-analytics-event='project_link_click'
+          data-analytics-surface='home_experience'
+          data-analytics-section='experience'
+          data-analytics-project='atypica'
+          data-analytics-link-type='site'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>Building atypica.ai — a multi-agent system for commercial research</li>
           </ul>
         </LinkCard>
-        <LinkCard heading='AIXCut' subheading='AI Full-Stack Engineer' href='https://aixcut.cn/'>
+        <LinkCard
+          heading='AIXCut'
+          subheading='AI Full-Stack Engineer'
+          href='https://aixcut.cn/'
+          data-analytics-event='project_link_click'
+          data-analytics-surface='home_experience'
+          data-analytics-section='experience'
+          data-analytics-project='aixcut'
+          data-analytics-link-type='site'
+        >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>Designing and shipping an AI video-editing agent</li>
           </ul>
@@ -246,6 +273,11 @@ const latestNotes = (await getCollection('archiveEn'))
           heading='fAIshion.ai'
           subheading='AI Full-Stack Engineer (Remote)'
           href='https://www.faishion.ai/'
+          data-analytics-event='project_link_click'
+          data-analytics-surface='home_experience'
+          data-analytics-section='experience'
+          data-analytics-project='faishion'
+          data-analytics-link-type='site'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>Full-stack development and model integration for an AI virtual try-on and outfit-matching platform</li>
@@ -260,6 +292,10 @@ const latestNotes = (await getCollection('archiveEn'))
               subheading={repo.description}
               date={`⭐ ${repo.stars}`}
               href={`https://github.com/joyehuang/${repo.name}`}
+              data-analytics-event='github_link_click'
+              data-analytics-surface='home_open_source'
+              data-analytics-target='repo'
+              data-analytics-repo={repo.name}
             />
           ))
         }

--- a/src/pages/en/projects/index.astro
+++ b/src/pages/en/projects/index.astro
@@ -30,8 +30,10 @@ const headings = [
 
   <h2 id='open-source'>Open Source</h2>
   <ProjectSection
+    analyticsSection='open_source'
     project={[
       {
+        id: 'learn_open_harness',
         name: 'Learn-Open-Harness',
         description:
           'A zero-to-hero interactive tutorial for OpenHarness — Agent Loop, Tools, Memory, Multi-Agent.',
@@ -40,6 +42,7 @@ const headings = [
         ]
       },
       {
+        id: 'minimind_notes',
         name: 'minimind-notes',
         description:
           'Building an LLM from scratch — principles and comparative experiments across Transformer, Pretraining, and SFT.',
@@ -52,8 +55,10 @@ const headings = [
 
   <h2 id='programs'>Programs</h2>
   <ProjectSection
+    analyticsSection='programs'
     project={[
       {
+        id: 'atypica',
         name: 'Atypica',
         description:
           'An AI consumer-research platform. I work on the Interview Agent that conducts research through AI personas.',
@@ -62,6 +67,7 @@ const headings = [
         ]
       },
       {
+        id: 'aixcut',
         name: 'AIXCut',
         description: 'An AI video-editing agent — involved in design and engineering rollout.',
         links: [
@@ -69,6 +75,7 @@ const headings = [
         ]
       },
       {
+        id: 'prepwise',
         name: 'PrepWise',
         description:
           'An AI interview-practice tool I built. Simulates real interviews via voice to help you speak with confidence and improve on the spot.',
@@ -78,6 +85,7 @@ const headings = [
         ]
       },
       {
+        id: 'qq_bot',
         name: 'QQ Bot',
         description:
           'A QQ group check-in bot that automatically manages records and reminders.',
@@ -91,8 +99,10 @@ const headings = [
   <h2 id='learnings'>Learnings</h2>
   <ProjectSection
     class='my-2'
+    analyticsSection='learnings'
     project={[
       {
+        id: 'ucb_cs61a',
         name: 'UCB CS61A',
         description: 'My own code for working through CS61A.',
         links: [{ type: 'github', href: 'https://github.com/joyehuang/interview-prep' }]
@@ -102,8 +112,10 @@ const headings = [
 
   <h2 id='theme'>Theme</h2>
   <ProjectSection
+    analyticsSection='theme'
     project={[
       {
+        id: 'astro_theme_pure',
         name: '🍭 Astro-theme-pure',
         description: 'A simple, clean but powerful blog theme built with Astro.',
         links: [
@@ -122,8 +134,8 @@ const headings = [
   <p>Please leave a message or reach out after sponsoring.</p>
   <Sponsorship
     methods={[
-      { name: 'WeChat', icon: 'wechat-pay', image: wechat },
-      { name: 'Alipay', icon: 'alipay', image: alipay }
+      { name: 'WeChat', icon: 'wechat-pay', image: wechat, methodName: 'wechat_pay' },
+      { name: 'Alipay', icon: 'alipay', image: alipay, methodName: 'alipay' }
     ]}
   />
   <p>Thanks to the following sponsors:</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -118,8 +118,8 @@ const agentHackathonLink =
             as='a'
             href='https://github.com/joyehuang'
             target='_blank'
-            data-analytics-event='home_github_click'
-            data-analytics-section='profile_header'
+            data-analytics-event='github_link_click'
+            data-analytics-surface='home_profile'
             data-analytics-target='profile'
           >
             <Icon name='github' class='size-5' slot='icon' />
@@ -132,9 +132,6 @@ const agentHackathonLink =
         <a
           href='/contact'
           class='flex flex-row items-center gap-x-3 rounded-full border bg-background px-4 py-2 text-sm shadow-sm transition-shadow hover:shadow-md'
-          data-analytics-event='home_cta_click'
-          data-analytics-section='hero'
-          data-analytics-target='contact'
         >
           <span class='relative flex items-center justify-center'>
             <span
@@ -167,9 +164,6 @@ const agentHackathonLink =
           class='w-fit self-end'
           href='/about'
           style='ahead'
-          data-analytics-event='home_cta_click'
-          data-analytics-section='about'
-          data-analytics-target='more_about'
         />
       </Section>
       {
@@ -187,9 +181,6 @@ const agentHackathonLink =
               class='w-fit self-end'
               href='/blog'
               style='ahead'
-              data-analytics-event='home_cta_click'
-              data-analytics-section='blog'
-              data-analytics-target='more_blogs'
             />
           </Section>
         )
@@ -246,9 +237,6 @@ const agentHackathonLink =
               class='w-fit self-end'
               href='/archive'
               style='ahead'
-              data-analytics-event='home_cta_click'
-              data-analytics-section='notes'
-              data-analytics-target='more_notes'
             />
           </Section>
         )
@@ -267,18 +255,12 @@ const agentHackathonLink =
               date={`最新一期 · ${formatTalkDateCN(latestTalk.data.date)}`}
               href='/talks'
               target='_self'
-              data-analytics-event='home_cta_click'
-              data-analytics-section='talks'
-              data-analytics-target='latest_talk'
             />
             <Button
               title='全部分享'
               class='w-fit self-end'
               href='/talks'
               style='ahead'
-              data-analytics-event='home_cta_click'
-              data-analytics-section='talks'
-              data-analytics-target='all_talks'
             />
           </Section>
         )
@@ -289,9 +271,11 @@ const agentHackathonLink =
           heading='Adastra Labs（石墨文档海外）'
           subheading='AI 全栈工程师'
           href='https://playyy.ai/'
-          data-analytics-event='home_external_click'
+          data-analytics-event='project_link_click'
+          data-analytics-surface='home_experience'
           data-analytics-section='experience'
-          data-analytics-target='playyy'
+          data-analytics-project='playyy'
+          data-analytics-link-type='site'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>参与 Playyy.ai —— AI 图像生成与品牌设计平台的产品与工程研发</li>
@@ -301,9 +285,11 @@ const agentHackathonLink =
           heading='上海特赞 Tezign'
           subheading='AIGC 研发部门全栈实习生'
           href='https://atypica.ai/'
-          data-analytics-event='home_external_click'
+          data-analytics-event='project_link_click'
+          data-analytics-surface='home_experience'
           data-analytics-section='experience'
-          data-analytics-target='atypica'
+          data-analytics-project='atypica'
+          data-analytics-link-type='site'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>参与 atypica.ai —— 面向商业研究场景的 Multi-Agent 系统</li>
@@ -313,9 +299,11 @@ const agentHackathonLink =
           heading='AIXCut'
           subheading='AI 全栈研发'
           href='https://aixcut.cn/'
-          data-analytics-event='home_external_click'
+          data-analytics-event='project_link_click'
+          data-analytics-surface='home_experience'
           data-analytics-section='experience'
-          data-analytics-target='aixcut'
+          data-analytics-project='aixcut'
+          data-analytics-link-type='site'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>参与 AI 视频剪辑 Agent 的设计与工程化落地</li>
@@ -325,9 +313,11 @@ const agentHackathonLink =
           heading='fAIshion.ai'
           subheading='AI 全栈工程师（远程）'
           href='https://www.faishion.ai/'
-          data-analytics-event='home_external_click'
+          data-analytics-event='project_link_click'
+          data-analytics-surface='home_experience'
           data-analytics-section='experience'
-          data-analytics-target='faishion'
+          data-analytics-project='faishion'
+          data-analytics-link-type='site'
         >
           <ul class='ms-4 list-disc text-muted-foreground'>
             <li>AI 虚拟试衣与服装搭配平台的全栈开发与模型集成</li>
@@ -342,9 +332,10 @@ const agentHackathonLink =
               subheading={repo.description}
               date={`⭐ ${repo.stars}`}
               href={`https://github.com/joyehuang/${repo.name}`}
-              data-analytics-event='home_github_click'
-              data-analytics-section='open_source'
-              data-analytics-target={repo.name}
+              data-analytics-event='github_link_click'
+              data-analytics-surface='home_open_source'
+              data-analytics-target='repo'
+              data-analytics-repo={repo.name}
             />
           ))
         }
@@ -445,9 +436,9 @@ const agentHackathonLink =
         data-agent-popout-close
         class='absolute end-2 top-2 z-10 flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
         aria-label='关闭 Agent 比赛弹窗'
-        data-analytics-event='home_agent_activity_click'
-        data-analytics-section='agent_popout'
-        data-analytics-target='close'
+        data-analytics-event='agent_competition_click'
+        data-analytics-surface='agent_popout'
+        data-analytics-action='close'
       >
         <svg
           xmlns='http://www.w3.org/2000/svg'
@@ -497,9 +488,9 @@ const agentHackathonLink =
               target='_blank'
               rel='noopener noreferrer'
               class='group inline-flex items-center gap-1.5 rounded-full bg-foreground px-3 py-1.5 text-sm font-medium text-background no-underline transition-transform hover:-translate-y-0.5'
-              data-analytics-event='home_agent_activity_click'
-              data-analytics-section='agent_popout'
-              data-analytics-target='feishu_link'
+              data-analytics-event='agent_competition_click'
+              data-analytics-surface='agent_popout'
+              data-analytics-action='external_link'
             >
               去看群比赛
               <svg
@@ -523,9 +514,9 @@ const agentHackathonLink =
               type='button'
               data-agent-popout-minimize
               class='rounded-full border bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
-              data-analytics-event='home_agent_activity_click'
-              data-analytics-section='agent_popout'
-              data-analytics-target='minimize'
+              data-analytics-event='agent_competition_click'
+              data-analytics-surface='agent_popout'
+              data-analytics-action='minimize'
             >
               收进角落
             </button>
@@ -539,9 +530,9 @@ const agentHackathonLink =
       data-agent-popout-pill
       class='agent-popout-pill hidden items-center gap-2 rounded-full border bg-background/95 px-3 py-2 text-sm font-medium shadow-lg backdrop-blur transition-all hover:-translate-y-0.5 hover:border-foreground/25 hover:shadow-xl'
       aria-label='展开第一届 Joye 粉丝 Agent 比赛弹窗'
-      data-analytics-event='home_agent_activity_click'
-      data-analytics-section='agent_popout'
-      data-analytics-target='pill_open'
+      data-analytics-event='agent_competition_click'
+      data-analytics-surface='agent_pill'
+      data-analytics-action='pill_open'
     >
       <span class='relative flex size-2'>
         <span

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -30,8 +30,10 @@ const headings = [
 
   <h2 id='open-source'>Open Source</h2>
   <ProjectSection
+    analyticsSection='open_source'
     project={[
       {
+        id: 'learn_open_harness',
         name: 'Learn-Open-Harness',
         description:
           'OpenHarness 零基础交互式教程 — Agent Loop、Tools、Memory、Multi-Agent。',
@@ -40,6 +42,7 @@ const headings = [
         ]
       },
       {
+        id: 'minimind_notes',
         name: 'minimind-notes',
         description: '从零构建 LLM — Transformer、Pretraining、SFT 的原理与对照实验。',
         links: [
@@ -51,13 +54,17 @@ const headings = [
 
   <h2 id='programs'>Programs</h2>
   <ProjectSection
+    analyticsSection='programs'
     project={[
       {
+        id: 'agent_competition',
+        analyticsEvent: 'agent_competition_click',
         name: '第一届 Joye 粉丝 Agent 比赛',
         description: '暑假一起做点东西。参赛、围观、聊天、找队友都欢迎，对 Agent 感兴趣就来玩。',
         links: [{ type: 'doc', href: agentHackathonLink }]
       },
       {
+        id: 'atypica',
         name: 'Atypica',
         description:
           'AI消费者研究平台，负责开发Interview Agent进行AI Persona访谈调研。',
@@ -66,6 +73,7 @@ const headings = [
         ]
       },
       {
+        id: 'aixcut',
         name: 'AIXCut',
         description: 'AI 视频剪辑 Agent，参与设计与工程化落地。',
         links: [
@@ -73,6 +81,7 @@ const headings = [
         ]
       },
       {
+        id: 'prepwise',
         name: 'PrepWise',
         description:
           'Prepwise 是我打造的一个AI面试陪练工具，通过语音模拟真实面试，帮你自信开口、即时提升。',
@@ -82,6 +91,7 @@ const headings = [
         ]
       },
       {
+        id: 'qq_bot',
         name: 'QQ Bot',
         description:
           'QQ群打卡机器人，自动管理群内打卡记录和提醒。',
@@ -115,8 +125,10 @@ const headings = [
   <h2 id='learnings'>Learnings</h2>
   <ProjectSection
     class='my-2'
+    analyticsSection='learnings'
     project={[
       {
+        id: 'ucb_cs61a',
         name: 'UCB CS61A',
         description: '我自己学习61a的代码',
         links: [{ type: 'github', href: 'https://github.com/joyehuang/interview-prep' }]
@@ -126,8 +138,10 @@ const headings = [
 
   <h2 id='theme'>Theme</h2>
   <ProjectSection
+    analyticsSection='theme'
     project={[
       {
+        id: 'astro_theme_pure',
         name: '🍭 Astro-theme-pure',
         description: 'A simple, clean but powerful blog theme build by astro.',
         links: [
@@ -166,8 +180,8 @@ const headings = [
   <p>Please leave a message or contact me proactively after sponsorship.</p>
   <Sponsorship
     methods={[
-      { name: 'WeChat', icon: 'wechat-pay', image: wechat },
-      { name: 'Alipay', icon: 'alipay', image: alipay }
+      { name: 'WeChat', icon: 'wechat-pay', image: wechat, methodName: 'wechat_pay' },
+      { name: 'Alipay', icon: 'alipay', image: alipay, methodName: 'alipay' }
     ]}
   />
   <p>Thanks to the following sponsors:</p>


### PR DESCRIPTION
## Summary

This PR upgrades the blog's Vercel Analytics setup from loose homepage CTA tracking into a documented event contract plus concrete instrumentation.

The main rule is now explicit: use Vercel Analytics Pages for route-level questions, and use custom Events only for behavior that pageviews cannot answer.

## What changed

### Analytics contract

- Rewrote `ANALYTICS.md` into the source-of-truth tracking contract.
- Added the boundary between Pages and Events.
- Added event naming rules and examples of events to avoid, including generic CTA events.
- Expanded the common property model around `locale`, `page`, `surface`, `action`, `destination_type`, `command_result`, `project`, `method_name`, `article_slug`, `episode`, and `resource`.
- Marked the previous `home_*` events as legacy historical data.

### Event implementation

- Added a shared analytics helper in `src/lib/analytics.ts` for locale/page enrichment, destination classification, and Vercel event dispatch.
- Upgraded the global data-attribute listener to support:
  - click events via `data-analytics-event`
  - reveal events via `data-analytics-reveal-event`
  - per-pageview reveal de-duplication
- Migrated homepage events away from `home_cta_click` / `home_external_click` toward targeted events.
- Added English homepage coverage for GitHub and project outbound clicks.
- Added terminal analytics for Human Mode and Dev Mode:
  - `terminal_open`
  - `terminal_command`
  - safe command result buckets such as `navigation`, `external_open`, `mailto_open`, and `unknown_command`
- Added GitHub intent tracking for homepage, About social card, Projects contribution card, and open-source links.
- Added Agent competition click tracking for popout dismissals, pill reopen, Feishu/doc clicks, and the Projects entry.
- Added contact reveal tracking for Contact page QR cards.
- Added inline article WeChat reveal tracking for consulting/contact intent inside article context.
- Added sponsorship QR reveal tracking on Projects pages.
- Added project outbound click tracking for homepage experience links and Projects sections.
- Added Talk resource and Talk join intent tracking.
- Added language switch tracking to distinguish natural English traffic from user-initiated locale switching.

## Why

The previous event model mixed ordinary internal navigation, real outbound intent, terminal behavior, and activity-specific clicks under broad names like `home_cta_click`. That duplicated what Vercel Pages already provides and made the event dashboard harder to interpret.

This PR keeps Vercel Analytics as the only provider, but makes custom events more product-like: events now represent behavior that pageviews cannot capture.

## Scope notes

- This PR intentionally does not add an external analytics provider.
- This PR does not add `CHANGELOG.md` / `ROADMAP.md`; that follow-up is tracked separately in #64.
- Ordinary internal navigation such as "More blogs", "More notes", normal post card clicks, tag clicks, and header nav clicks is intentionally not tracked as custom events.

## Validation

- `git diff --check`
- `bun run check`
- `bun run build`

`bun run build` completed successfully. It emitted the existing local Node 24 warning for Vercel Serverless Functions, but the build itself passed.
