### PR TITLE
[codex] track intro animation engagement

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -88,6 +88,11 @@ input, comment text, search text, or free-form user input.
 | `article_slug` | Article identifier for article-scoped events. | `20260517---agentonboardingguide` |
 | `episode` | Talk episode number. | `1`, `2` |
 | `resource` | Talk or article resource type. | `deck`, `video`, `record`, `slide` |
+| `source` | How the surface was reached when relevant. | `first_visit`, `replay` |
+| `duration_ms` | Elapsed interaction time in milliseconds. | `4200`, `9300` |
+| `time_to_cta_ms` | Elapsed time from surface start to CTA view. | `3600`, `4100` |
+| `played` | Whether the visitor interacted with a playful surface. | `true`, `false` |
+| `interactions` | Low-cardinality interaction burst count. | `1`, `3` |
 
 Use `null` for unavailable optional properties rather than inventing placeholders.
 
@@ -156,6 +161,126 @@ Required properties:
 - `href`: Feishu/doc URL for external link actions, otherwise `null`
 
 Use this to compare real activity interest with dismissals.
+
+### `intro_start`
+
+Home page entrance animation starts.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: `/`
+- `surface`: `intro_overlay`
+- `target`: `animation`
+- `source`: `first_visit` | `replay`
+
+Use this to measure how many visitors actually see the intro animation,
+separate from repeat visitors where the session gate hides it.
+
+### `intro_cta_view`
+
+The entrance animation resolves and the final CTA is shown.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: `/`
+- `surface`: `intro_overlay`
+- `target`: `enter`
+- `source`: `first_visit` | `replay`
+- `time_to_cta_ms`: milliseconds from animation start to CTA view
+
+Use this with `intro_start` to measure how many visitors stay through the
+animation until the CTA appears.
+
+### `intro_play`
+
+User meaningfully interacts with the entrance animation particle field.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: `/`
+- `surface`: `intro_overlay`
+- `target`: `particle_hover`
+- `source`: `first_visit` | `replay`
+- `duration_ms`: milliseconds from animation start to first particle hover
+- `percent`: approximate animation resolve progress when interaction happened
+- `interactions`: number of interaction bursts counted so far
+
+Use this to measure whether visitors are "playing" with the hover-reactive
+particle animation instead of only watching it.
+
+### `intro_cta_click`
+
+User enters the home page from the entrance animation CTA.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: `/`
+- `surface`: `intro_overlay`
+- `target`: `enter` | `avatar`
+- `source`: `first_visit` | `replay`
+- `duration_ms`: milliseconds from animation start to enter click
+- `time_to_cta_ms`: milliseconds from animation start to CTA view
+- `played`: whether `intro_play` fired before the click
+- `interactions`: number of particle-hover interaction bursts before the click
+
+Use this with `intro_cta_view` to measure CTA conversion from the entrance
+animation.
+
+### `intro_skip`
+
+User skips the entrance animation before entering the home page.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: `/`
+- `surface`: `intro_overlay`
+- `target`: `skip`
+- `source`: `first_visit` | `replay`
+- `duration_ms`: milliseconds from animation start to skip click
+- `time_to_cta_ms`: milliseconds from animation start to CTA view, or `null` if skipped before CTA view
+- `played`: whether `intro_play` fired before the skip
+- `interactions`: number of particle-hover interaction bursts before the skip
+
+Use this to tell whether the intro animation is getting dismissed before the
+CTA.
+
+### `intro_replay`
+
+User replays the entrance animation from the persistent home page control.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: `/`
+- `surface`: `intro_overlay`
+- `target`: `replay`
+- `source`: `replay`
+
+Use this to measure voluntary replay interest separately from first-visit
+exposure.
+
+### `intro_abandon`
+
+User leaves the page while the entrance animation is still active.
+
+Required properties:
+
+- `locale`: `zh` | `en`
+- `page`: `/`
+- `surface`: `intro_overlay`
+- `target`: `pagehide`
+- `source`: `first_visit` | `replay`
+- `duration_ms`: milliseconds from animation start to page hide
+- `time_to_cta_ms`: milliseconds from animation start to CTA view, or `null` if the CTA was never shown
+- `played`: whether `intro_play` fired before leaving
+- `interactions`: number of particle-hover interaction bursts before leaving
+
+Use this to estimate watch time for visitors who do not click enter or skip.
 
 ### `contact_method_reveal`
 
@@ -334,6 +459,13 @@ Implemented in current code:
 - `terminal_command`
 - `github_link_click`
 - `agent_competition_click`
+- `intro_start`
+- `intro_cta_view`
+- `intro_play`
+- `intro_cta_click`
+- `intro_skip`
+- `intro_replay`
+- `intro_abandon`
 - `contact_method_reveal`
 - `article_contact_reveal`
 - `sponsorship_method_reveal`

--- a/src/components/AnalyticsEvents.astro
+++ b/src/components/AnalyticsEvents.astro
@@ -6,6 +6,27 @@
     type AnalyticsProperties
   } from '@/lib/analytics'
 
+  type AnalyticsDetail = { eventName?: unknown; properties?: unknown }
+
+  const analyticsWindow = window as typeof window & {
+    __siteAnalyticsQueue?: AnalyticsDetail[]
+    __trackSiteAnalytics?: (detail: AnalyticsDetail) => void
+  }
+
+  function trackCustomEvent(detail: AnalyticsDetail | null) {
+    if (!detail || typeof detail.eventName !== 'string') return
+
+    trackSiteEvent(
+      detail.eventName,
+      (detail.properties && typeof detail.properties === 'object'
+        ? detail.properties
+        : {}) as AnalyticsProperties
+    )
+  }
+
+  analyticsWindow.__trackSiteAnalytics = trackCustomEvent
+  analyticsWindow.__siteAnalyticsQueue?.splice(0).forEach(trackCustomEvent)
+
   document.addEventListener('click', (event) => {
     const target =
       event.target instanceof Element
@@ -64,5 +85,10 @@
 
     if (!target) return
     trackReveal(target, 'focus')
+  })
+
+  document.addEventListener('site:analytics', (event) => {
+    if (!(event instanceof CustomEvent)) return
+    trackCustomEvent(event.detail as AnalyticsDetail | null)
   })
 </script>

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -265,6 +265,8 @@ import avatar from 'src/assets/avatar.png'
 
     var W = 0, H = 0, DPR = 1, parts = [], pulse = 0, d = 0, dTarget = 0
     var stepShown = -1, doneAt = 0, raf = 0, t0 = 0, revealing = false, landed = false
+    var playSource = 'first_visit'
+    var introStartedAt = 0, ctaShownAt = 0, playTracked = false, interactionCount = 0, lastInteractionAt = 0, abandonTracked = false
     var mouse = { x: -1e9, y: -1e9 }
     var STAGE_EL = null, SEG_EL = null
     var card = document.getElementById('intro-card')
@@ -379,7 +381,7 @@ import avatar from 'src/assets/avatar.png'
         var hb = 0
         if (d > 0.5) {
           var mdx = p.x - mouse.x, mdy = p.y - mouse.y, m2 = mdx * mdx + mdy * mdy, RR = (21 * DPR) * (21 * DPR)
-          if (m2 < RR) { hb = 1 - m2 / RR; var dd = Math.sqrt(m2) || 1, f = hb * 8 * DPR; p.x += mdx / dd * f; p.y += mdy / dd * f }
+          if (m2 < RR) { hb = 1 - m2 / RR; markInteraction(); var dd = Math.sqrt(m2) || 1, f = hb * 8 * DPR; p.x += mdx / dd * f; p.y += mdy / dd * f }
         }
         var turb = noiseK * 34 * DPR
         var rx = p.x + Math.sin(p.y * 0.012 + el * 1.7 + p.seed * 6.28) * turb
@@ -413,6 +415,8 @@ import avatar from 'src/assets/avatar.png'
       if (landed) return
       landed = true
       if (card) card.classList.add('show')
+      ctaShownAt = performance.now()
+      trackIntro('intro_cta_view', 'enter', { time_to_cta_ms: elapsedMs() })
     }
     function reveal() {                       // visitor chose to enter → fade to real homepage (kept in DOM for 重播)
       if (revealing) return
@@ -431,32 +435,78 @@ import avatar from 'src/assets/avatar.png'
       if (parts.length === 0) { setTimeout(start, 120); return }
       raf = requestAnimationFrame(frame)
     }
-    function play() {                         // (re)run the intro from noise — first visit + 重播
+    function elapsedMs() {
+      return introStartedAt ? Math.round(performance.now() - introStartedAt) : null
+    }
+    function markInteraction() {
+      var now = performance.now()
+      if (!lastInteractionAt || now - lastInteractionAt > 500) interactionCount++
+      lastInteractionAt = now
+      if (playTracked) return
+      playTracked = true
+      trackIntro('intro_play', 'particle_hover', { duration_ms: elapsedMs(), percent: Math.round(d * 100), interactions: interactionCount })
+    }
+    function exitProperties() {
+      return {
+        duration_ms: elapsedMs(),
+        time_to_cta_ms: ctaShownAt ? Math.round(ctaShownAt - introStartedAt) : null,
+        played: playTracked,
+        interactions: interactionCount
+      }
+    }
+    function trackIntro(eventName, target, properties) {
+      var detail = {
+        eventName: eventName,
+        properties: {
+          surface: 'intro_overlay',
+          target: target,
+          source: playSource,
+          ...(properties || {})
+        }
+      }
+      if (window.__trackSiteAnalytics) {
+        window.__trackSiteAnalytics(detail)
+        return
+      }
+      window.__siteAnalyticsQueue = window.__siteAnalyticsQueue || []
+      window.__siteAnalyticsQueue.push(detail)
+      document.dispatchEvent(new CustomEvent('site:analytics', { detail: detail }))
+    }
+
+    function play(source) {                   // (re)run the intro from noise — first visit + 重播
       cancelAnimationFrame(raf)
       d = 0; dTarget = 0; pulse = 0; stepShown = -1; doneAt = 0; t0 = 0
       revealing = false; landed = false
+      introStartedAt = performance.now(); ctaShownAt = 0; playTracked = false; interactionCount = 0; lastInteractionAt = 0; abandonTracked = false
+      playSource = source || 'replay'
       if (card) card.classList.remove('show')
       hud.style.opacity = ''; hud.classList.remove('show')
       overlay.classList.remove('intro-idle'); overlay.classList.remove('intro-done')
       try { sessionStorage.setItem('intro-seen', '1') } catch (e) {}
+      trackIntro('intro_start', 'animation')
       start()
     }
 
     addEventListener('resize', function () { if (!revealing && !overlay.classList.contains('intro-idle')) { resize(); build() } })
+    addEventListener('pagehide', function () {
+      if (!introStartedAt || revealing || overlay.classList.contains('intro-idle') || abandonTracked) return
+      abandonTracked = true
+      trackIntro('intro_abandon', 'pagehide', exitProperties())
+    })
     var skipBtn = document.getElementById('intro-skip')
-    if (skipBtn) skipBtn.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
+    if (skipBtn) skipBtn.addEventListener('click', function (e) { e.stopPropagation(); trackIntro('intro_skip', 'skip', exitProperties()); reveal() })
     var enterBtn = document.getElementById('intro-enter')
-    if (enterBtn) enterBtn.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
+    if (enterBtn) enterBtn.addEventListener('click', function (e) { e.stopPropagation(); trackIntro('intro_cta_click', 'enter', exitProperties()); reveal() })
     var avEl = document.getElementById('intro-av')
-    if (avEl) avEl.addEventListener('click', function (e) { e.stopPropagation(); reveal() })
+    if (avEl) avEl.addEventListener('click', function (e) { e.stopPropagation(); trackIntro('intro_cta_click', 'avatar', exitProperties()); reveal() })
     var replayBtn = document.getElementById('intro-replay')
-    if (replayBtn) replayBtn.addEventListener('click', play)
+    if (replayBtn) replayBtn.addEventListener('click', function () { playSource = 'replay'; trackIntro('intro_replay', 'replay'); play('replay') })
 
     var seen = false
     try { seen = sessionStorage.getItem('intro-seen') === '1' } catch (e) {}
     if (!seen && !reduce) {
       var fontReady = document.fonts && document.fonts.load ? document.fonts.load('700 120px "Satoshi"') : null
-      Promise.race([Promise.resolve(fontReady).catch(function () {}), new Promise(function (r) { setTimeout(r, 700) })]).then(play)
+      Promise.race([Promise.resolve(fontReady).catch(function () {}), new Promise(function (r) { setTimeout(r, 700) })]).then(function () { play('first_visit') })
     } else {
       overlay.classList.add('intro-idle')   // hidden on repeat visits; 重播 re-runs it
     }


### PR DESCRIPTION
## Summary

- Add a queued custom analytics path for entrance-animation events so early intro events are not dropped before the analytics listener loads.
- Track intro exposure, CTA view/click, skip, replay, page-abandon, first particle-hover play, elapsed time, and interaction counts.
- Document the new intro analytics event contract in `ANALYTICS.md`.

## Validation

- `bun run check`
- `bun run build`

Note: local build still reports the existing Vercel warning that local Node 24 is unsupported for Serverless Functions and Vercel will use Node 18 runtime.