### PR TITLE
fix(toc): fix broken heading jumps and laggy sidebar follow

### DIFF
--- a/src/components/navigation/TableOfContents.astro
+++ b/src/components/navigation/TableOfContents.astro
@@ -166,9 +166,16 @@ const toc = generateToc(headings)
 
       if (!isAbove && !isBelow) return
 
+      // Scroll only the sidebar container — never `activeLink.scrollIntoView()`, which
+      // also scrolls every scrollable ancestor (the window included) and would hijack
+      // the smooth page scroll started when a TOC link is clicked.
+      const centerOffset = (containerRect.height - linkRect.height) / 2
+      const targetScrollTop =
+        scrollContainer.scrollTop + (linkRect.top - containerRect.top) - centerOffset
+
       const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-      activeLink.scrollIntoView({
-        block: 'center',
+      scrollContainer.scrollTo({
+        top: targetScrollTop,
         behavior: reducedMotion ? 'auto' : 'smooth'
       })
     }

--- a/src/components/navigation/TableOfContents.astro
+++ b/src/components/navigation/TableOfContents.astro
@@ -39,6 +39,8 @@ const toc = generateToc(headings)
     headingProgress: Record<string, HeadingProgress> = {}
     activeSlug = ''
     animationFrame = 0
+    suppressFollow = false
+    pendingClickSlug = ''
 
     connectedCallback() {
       const articleHeadings = Array.from(
@@ -66,6 +68,14 @@ const toc = generateToc(headings)
           }
 
           history.pushState(null, directHeading.textContent || '', link.element.getAttribute('href'))
+
+          // User-initiated jump: move the sidebar straight to the target once and mute
+          // the intermediate active-heading chase, so the TOC doesn't keep sliding after
+          // the page has already landed. Released on arrival or the next scroll gesture.
+          this.pendingClickSlug = link.slug
+          this.suppressFollow = true
+          this.activeSlug = link.slug
+          this.ensureLinkVisible(link.element)
           directHeading.scrollIntoView({ behavior: 'smooth' })
         })
       })
@@ -73,11 +83,17 @@ const toc = generateToc(headings)
       this.updatePositionAndStyle()
       window.addEventListener('scroll', this.scheduleUpdate, { passive: true })
       window.addEventListener('resize', this.scheduleUpdate)
+      window.addEventListener('wheel', this.releaseFollow, { passive: true })
+      window.addEventListener('touchstart', this.releaseFollow, { passive: true })
+      window.addEventListener('keydown', this.releaseFollow)
     }
 
     disconnectedCallback() {
       window.removeEventListener('scroll', this.scheduleUpdate)
       window.removeEventListener('resize', this.scheduleUpdate)
+      window.removeEventListener('wheel', this.releaseFollow)
+      window.removeEventListener('touchstart', this.releaseFollow)
+      window.removeEventListener('keydown', this.releaseFollow)
       if (this.animationFrame) window.cancelAnimationFrame(this.animationFrame)
     }
 
@@ -87,6 +103,11 @@ const toc = generateToc(headings)
         this.animationFrame = 0
         this.updatePositionAndStyle()
       })
+    }
+
+    // A genuine user scroll gesture ends the click-jump mute so manual reading follows again.
+    releaseFollow = () => {
+      this.suppressFollow = false
     }
 
     updatePositionAndStyle = () => {
@@ -135,6 +156,16 @@ const toc = generateToc(headings)
         activeLink = this.findNearestPassedLink()
       }
 
+      if (this.suppressFollow) {
+        // Stop muting once the page has actually reached the clicked section. Check the
+        // target heading's own position rather than the highlighted item — right after a
+        // jump the previous section can still sit at the very top and read as "active".
+        const targetHeading = this.headings.find((heading) => heading.id === this.pendingClickSlug)
+        const arrived = !targetHeading || Math.abs(targetHeading.getBoundingClientRect().top) <= 150
+        if (arrived) this.suppressFollow = false
+        return
+      }
+
       this.scrollActiveLinkIntoView(activeLink)
     }
 
@@ -157,18 +188,23 @@ const toc = generateToc(headings)
       if (slug === this.activeSlug) return
       this.activeSlug = slug
 
+      this.ensureLinkVisible(activeLink)
+    }
+
+    // Keep a TOC link within the sidebar's viewport, centering it when it drifts past an
+    // edge. Scrolls only the #sidebar container — never `link.scrollIntoView()`, which
+    // also scrolls every scrollable ancestor (the window included) and would hijack the
+    // smooth page scroll started when a TOC link is clicked.
+    ensureLinkVisible(link: HTMLAnchorElement) {
       const scrollContainer = this.closest('#sidebar') ?? this
       const containerRect = scrollContainer.getBoundingClientRect()
-      const linkRect = activeLink.getBoundingClientRect()
+      const linkRect = link.getBoundingClientRect()
       const edgePadding = 56
       const isAbove = linkRect.top < containerRect.top + edgePadding
       const isBelow = linkRect.bottom > containerRect.bottom - edgePadding
 
       if (!isAbove && !isBelow) return
 
-      // Scroll only the sidebar container — never `activeLink.scrollIntoView()`, which
-      // also scrolls every scrollable ancestor (the window included) and would hijack
-      // the smooth page scroll started when a TOC link is clicked.
       const centerOffset = (containerRect.height - linkRect.height) / 2
       const targetScrollTop =
         scrollContainer.scrollTop + (linkRect.top - containerRect.top) - centerOffset


### PR DESCRIPTION
## Summary

Fixes two issues with the blog post right-hand Table of Contents (`src/components/navigation/TableOfContents.astro`).

### 1. Clicking a TOC item could fail to jump

**Repro:** scroll so the highlighted TOC item is scrolled out of the sidebar's visible area, then click a distant TOC item — the page fails to jump to it.

**Cause:** the sidebar's auto-follow used `activeLink.scrollIntoView({ block: 'center' })`, which scrolls *every* scrollable ancestor — the window included. During the click's smooth page-scroll, the scroll handler recomputed the active link; when that link was outside the sidebar's viewport, this call started a competing window scroll that hijacked (overrode) the page jump. It only reproduced in that scroll state because a guard (`if (!isAbove && !isBelow) return`) skips the call when the active item is already visible.

**Fix:** scroll only the `#sidebar` container via a manual `scrollTo` (computed target `scrollTop`), never touching the window.

### 2. The jump scroll felt unnatural

After the jump worked, the sidebar sat frozen and then rushed to catch up *after* the page had already landed — the TOC trailed the content instead of tracking it. The auto-follow is built for slow reading (chase each heading one step at a time), so a long jump made it chase ~15 intermediate sections in sequence.

**Fix:** on an explicit click, move the sidebar straight to the target once and mute the intermediate chase (`suppressFollow`) until the page arrives (detected via the target heading's own position) or the next real scroll gesture (`wheel` / `touchstart` / `keydown`). The TOC now leads the page instead of lagging it.

## Testing

Verified in a browser against the longest-TOC post (48 headings) via scroll-timing instrumentation:

- Broken-jump repro now lands correctly (window scrolls to the target); root-cause A/B confirmed the old call moved the window −273px while the new one moves it 0px.
- Sidebar follow is now front-loaded and in sync (starts immediately, settles ~640ms) vs. back-loaded before (frozen ~645ms, then rushed).
- Regression pass green: downward + upward jumps land, target ends highlighted and visible, mute releases on arrival and on scroll gesture, and normal slow-reading auto-follow still keeps the active item visible.
- `bun run check` passes (0 errors); no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)