### PR TITLE
feat: real agent-teams tracks, homepage popout, and custom tracks

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -83,7 +83,7 @@ input, comment text, search text, or free-form user input.
 | `command_result` | Safe terminal outcome bucket. | `success`, `unknown_command`, `navigation`, `external_open`, `mailto_open` |
 | `repo` | Repository name for GitHub clicks. | `Learn-Open-Harness`, `interview-prep` |
 | `project` | Project identifier for project clicks. | `atypica`, `aixcut`, `prepwise` |
-| `team` | Agent competition team identifier. | `deep-research-agent`, `coding-agent` |
+| `team` | Agent competition team identifier. | `game-agent`, `rss-agent` |
 | `link_type` | Project link type. | `site`, `github`, `doc`, `release` |
 | `method_name` | Contact or payment method. | `wechat`, `qq_group`, `wechat_pay`, `alipay` |
 | `article_slug` | Article identifier for article-scoped events. | `20260517---agentonboardingguide` |
@@ -173,7 +173,7 @@ Required properties:
 - `page`: `/agent-teams`
 - `surface`: `agent_teams`
 - `action`: `open` | `submit`
-- `team`: team identifier, for example `deep-research-agent`
+- `team`: team identifier, for example `game-agent`
 
 `open` fires when a visitor opens a team's signup form; `submit` fires on a
 successful signup. Never send the submitted nickname, contact, or note — they

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "bun@1.3.10",
   "scripts": {
     "dev": "astro dev",
+    "test": "bun test src/",
     "dev:check": "astro check --watch & astro dev",
     "build": "astro build",
     "build:checked": "bun run check && bun run build",

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -415,13 +415,9 @@ import { activity, teams } from '@/data/agent-teams'
     }
   }
 
-  // 自定义赛道没有预渲染的卡：克隆一张静态卡当模板，重置后填入新赛道信息。
-  function buildCard(pristine: HTMLElement, team: Team): HTMLElement {
-    const card = pristine.cloneNode(true) as HTMLElement
-    card.dataset.teamId = team.id
+  // 标题 / 简介 / 标签以 DB 为准，每次拉到数据都覆盖到卡上（预渲染值只是首屏兜底）。
+  function renderMeta(card: HTMLElement, team: Team) {
     card.dataset.capacity = team.capacity != null ? String(team.capacity) : ''
-    delete card.dataset.full
-    delete card.dataset.detail
 
     const title = card.querySelector<HTMLElement>('[data-title]')
     if (title) title.textContent = team.title
@@ -429,20 +425,29 @@ import { activity, teams } from '@/data/agent-teams'
     if (summary) summary.textContent = team.summary
 
     const tags = card.querySelector<HTMLElement>('[data-tags]')
-    if (tags) {
-      if (team.tags && team.tags.length > 0) {
-        tags.replaceChildren(
-          ...team.tags.map((tag) => {
-            const span = document.createElement('span')
-            span.className = 'rounded-md bg-muted px-1.5 py-0.5 text-xs text-muted-foreground'
-            span.textContent = '#' + tag
-            return span
-          })
-        )
-      } else {
-        tags.remove()
-      }
+    if (!tags) return
+    if (team.tags && team.tags.length > 0) {
+      tags.replaceChildren(
+        ...team.tags.map((tag) => {
+          const span = document.createElement('span')
+          span.className = 'rounded-md bg-muted px-1.5 py-0.5 text-xs text-muted-foreground'
+          span.textContent = '#' + tag
+          return span
+        })
+      )
+    } else {
+      tags.remove() // 无标签就移除容器，避免空 flex 项撑出多余间距
     }
+  }
+
+  // 自定义赛道没有预渲染的卡：克隆一张静态卡当模板，重置后填入新赛道信息。
+  function buildCard(pristine: HTMLElement, team: Team): HTMLElement {
+    const card = pristine.cloneNode(true) as HTMLElement
+    card.dataset.teamId = team.id
+    delete card.dataset.full
+    delete card.dataset.detail
+
+    renderMeta(card, team)
 
     const detail = card.querySelector<HTMLElement>('[data-detail]')
     if (detail) {
@@ -610,6 +615,7 @@ import { activity, teams } from '@/data/agent-teams'
         cards.set(team.id, card)
         wireCard(card, board)
       }
+      renderMeta(card, team) // 标题/简介/标签以 DB 为准，覆盖预渲染值
       renderRoster(card, team)
       renderDetail(card, team.detail)
     }

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -31,7 +31,7 @@ import { activity, teams } from '@/data/agent-teams'
   >
   </p>
 
-  <div class='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+  <div class='grid grid-cols-1 gap-4 sm:grid-cols-2' data-team-grid>
     {
       teams.map((team) => (
         <article
@@ -40,7 +40,7 @@ import { activity, teams } from '@/data/agent-teams'
           data-capacity={team.capacity ?? ''}
         >
           <div class='flex items-start justify-between gap-3'>
-            <h2 class='m-0 text-lg font-medium text-foreground'>{team.title}</h2>
+            <h2 class='m-0 text-lg font-medium text-foreground' data-title>{team.title}</h2>
             <span
               class='shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground'
               data-count-label
@@ -49,10 +49,10 @@ import { activity, teams } from '@/data/agent-teams'
             </span>
           </div>
 
-          <p class='m-0 text-sm leading-snug text-muted-foreground'>{team.summary}</p>
+          <p class='m-0 text-sm leading-snug text-muted-foreground' data-summary>{team.summary}</p>
 
           {team.tags && team.tags.length > 0 && (
-            <div class='flex flex-wrap gap-1.5'>
+            <div class='flex flex-wrap gap-1.5' data-tags>
               {team.tags.map((tag) => (
                 <span class='rounded-md bg-muted px-1.5 py-0.5 text-xs text-muted-foreground'>
                   #{tag}
@@ -92,7 +92,7 @@ import { activity, teams } from '@/data/agent-teams'
 
           <form class='signup-form mt-1 flex-col gap-2' data-signup-form hidden>
             <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
-              昵称（会公开显示）
+              QQ 昵称（会公开显示，方便认人）
               <input
                 class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
                 name='name'
@@ -100,7 +100,7 @@ import { activity, teams } from '@/data/agent-teams'
                 maxlength='24'
                 required
                 autocomplete='off'
-                placeholder='你的昵称'
+                placeholder='你的 QQ 昵称'
               />
             </label>
             <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
@@ -158,14 +158,14 @@ import { activity, teams } from '@/data/agent-teams'
 
           <form class='detail-form mt-1 flex-col gap-2' data-detail-form hidden>
             <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
-              队长口令
+              口令（粉丝群的名字）
               <input
                 class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
                 name='passcode'
                 type='text'
                 maxlength='40'
                 autocomplete='off'
-                placeholder='你的队长口令'
+                placeholder='粉丝群的名字'
                 required
               />
             </label>
@@ -192,6 +192,83 @@ import { activity, teams } from '@/data/agent-teams'
       ))
     }
   </div>
+
+  {/* 自命题：自助创建一个新赛道卡片 */}
+  <div class='create-card mt-4 rounded-xl border border-dashed bg-background p-4 sm:p-5' data-create-card>
+    <div class='flex items-start justify-between gap-3'>
+      <div class='min-w-0'>
+        <h2 class='m-0 text-lg font-medium text-foreground'>没有合适的主题？</h2>
+        <p class='m-0 mt-1 text-sm leading-snug text-muted-foreground'>
+          自命题：创建一个属于你的赛道，别人也能来加入。
+        </p>
+      </div>
+      <button
+        type='button'
+        class='create-toggle inline-flex shrink-0 items-center gap-1 rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
+        data-create-toggle
+        aria-expanded='false'
+      >
+        ＋ 创建赛道
+      </button>
+    </div>
+
+    <form class='create-form mt-3 flex-col gap-2' data-create-form hidden>
+      <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+        赛道名称
+        <input
+          class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
+          name='title'
+          type='text'
+          maxlength='30'
+          required
+          autocomplete='off'
+          placeholder='例如：会写周报的 Agent'
+        />
+      </label>
+      <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+        一句话简介
+        <input
+          class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
+          name='summary'
+          type='text'
+          maxlength='80'
+          required
+          autocomplete='off'
+          placeholder='它能做什么，一句话说清'
+        />
+      </label>
+      <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+        口令（粉丝群的名字）
+        <input
+          class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
+          name='passcode'
+          type='text'
+          maxlength='40'
+          required
+          autocomplete='off'
+          placeholder='粉丝群的名字'
+        />
+      </label>
+
+      {/* 蜜罐 */}
+      <div class='hp-field' aria-hidden='true'>
+        <label>
+          Leave this empty
+          <input name='hp' type='text' tabindex='-1' autocomplete='off' />
+        </label>
+      </div>
+
+      <div class='flex items-center gap-3'>
+        <button
+          type='submit'
+          class='inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
+        >
+          创建
+        </button>
+        <p class='form-msg m-0 text-xs' data-create-msg role='status'></p>
+      </div>
+    </form>
+  </div>
 </section>
 
 <style>
@@ -208,6 +285,9 @@ import { activity, teams } from '@/data/agent-teams'
     display: flex;
   }
   .detail-form[data-open] {
+    display: flex;
+  }
+  .create-form[data-open] {
     display: flex;
   }
   .detail-edit-toggle[data-show] {
@@ -252,6 +332,9 @@ import { activity, teams } from '@/data/agent-teams'
   type Member = { name: string; note: string | null; ts: number }
   type Team = {
     id: string
+    title: string
+    summary: string
+    tags: string[]
     count: number
     capacity: number | null
     members: Member[]
@@ -330,6 +413,44 @@ import { activity, teams } from '@/data/agent-teams'
       if (member.note) li.title = member.note
       roster.appendChild(li)
     }
+  }
+
+  // 自定义赛道没有预渲染的卡：克隆一张静态卡当模板，重置后填入新赛道信息。
+  function buildCard(pristine: HTMLElement, team: Team): HTMLElement {
+    const card = pristine.cloneNode(true) as HTMLElement
+    card.dataset.teamId = team.id
+    card.dataset.capacity = team.capacity != null ? String(team.capacity) : ''
+    delete card.dataset.full
+    delete card.dataset.detail
+
+    const title = card.querySelector<HTMLElement>('[data-title]')
+    if (title) title.textContent = team.title
+    const summary = card.querySelector<HTMLElement>('[data-summary]')
+    if (summary) summary.textContent = team.summary
+
+    const tags = card.querySelector<HTMLElement>('[data-tags]')
+    if (tags) {
+      if (team.tags && team.tags.length > 0) {
+        tags.replaceChildren(
+          ...team.tags.map((tag) => {
+            const span = document.createElement('span')
+            span.className = 'rounded-md bg-muted px-1.5 py-0.5 text-xs text-muted-foreground'
+            span.textContent = '#' + tag
+            return span
+          })
+        )
+      } else {
+        tags.remove()
+      }
+    }
+
+    const detail = card.querySelector<HTMLElement>('[data-detail]')
+    if (detail) {
+      detail.textContent = ''
+      detail.hidden = true
+      detail.classList.add('hidden')
+    }
+    return card
   }
 
   function wireCard(card: HTMLElement, board: HTMLElement) {
@@ -453,7 +574,13 @@ import { activity, teams } from '@/data/agent-teams'
     }
   }
 
-  function applyState(board: HTMLElement, cards: Map<string, HTMLElement>, data: BoardData) {
+  function applyState(
+    board: HTMLElement,
+    grid: HTMLElement | null,
+    pristine: HTMLElement | null,
+    cards: Map<string, HTMLElement>,
+    data: BoardData
+  ) {
     board.dataset.configured = data.configured ? 'true' : 'false'
     board.dataset.passcodeRequired = data.passcodeRequired ? 'true' : 'false'
 
@@ -474,11 +601,22 @@ import { activity, teams } from '@/data/agent-teams'
     }
 
     for (const team of data.teams) {
-      const card = cards.get(team.id)
-      if (!card) continue
+      let card = cards.get(team.id)
+      if (!card) {
+        // 自定义赛道：动态建卡并接线
+        if (!pristine || !grid) continue
+        card = buildCard(pristine, team)
+        grid.appendChild(card)
+        cards.set(team.id, card)
+        wireCard(card, board)
+      }
       renderRoster(card, team)
       renderDetail(card, team.detail)
     }
+
+    // 未配置：禁用「创建赛道」入口
+    const createToggle = board.querySelector<HTMLButtonElement>('[data-create-toggle]')
+    if (createToggle) createToggle.disabled = !data.configured
 
     // 开放了队长编辑：显示每张卡的「队长编辑」入口
     if (data.detailEditable) {
@@ -513,7 +651,75 @@ import { activity, teams } from '@/data/agent-teams'
     }
   }
 
+  // 「创建赛道」表单：提交成功后 reload 重新拉一次名单，新卡就会出现。
+  function wireCreateCard(board: HTMLElement, reload: () => Promise<void>) {
+    const wrap = board.querySelector<HTMLElement>('[data-create-card]')
+    if (!wrap) return
+    const toggle = wrap.querySelector<HTMLButtonElement>('[data-create-toggle]')
+    const form = wrap.querySelector<HTMLFormElement>('[data-create-form]')
+    if (!toggle || !form) return
+
+    toggle.addEventListener('click', () => {
+      if (board.dataset.configured !== 'true') return
+      const open = form.hasAttribute('data-open')
+      if (open) {
+        form.removeAttribute('data-open')
+        form.hidden = true
+        toggle.setAttribute('aria-expanded', 'false')
+      } else {
+        form.setAttribute('data-open', '')
+        form.hidden = false
+        toggle.setAttribute('aria-expanded', 'true')
+        form.querySelector<HTMLInputElement>('input[name="title"]')?.focus()
+      }
+    })
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault()
+      const submitBtn = form.querySelector<HTMLButtonElement>('button[type="submit"]')
+      const data = new FormData(form)
+      const payload = {
+        action: 'create',
+        title: String(data.get('title') || ''),
+        summary: String(data.get('summary') || ''),
+        passcode: String(data.get('passcode') || ''),
+        hp: String(data.get('hp') || '')
+      }
+
+      if (submitBtn) submitBtn.disabled = true
+      setMsg(form, '创建中…', '', '[data-create-msg]')
+      try {
+        const res = await fetch('/api/agent-teams', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        })
+        const body = await res.json()
+        if (res.ok && body.ok) {
+          form.reset()
+          form.removeAttribute('data-open')
+          form.hidden = true
+          toggle.setAttribute('aria-expanded', 'false')
+          setMsg(form, '创建成功！已加到下面', 'success', '[data-create-msg]')
+          await reload()
+        } else {
+          setMsg(form, (body && body.message) || '创建失败，请稍后再试', 'error', '[data-create-msg]')
+        }
+      } catch {
+        setMsg(form, '网络错误，请稍后再试', 'error', '[data-create-msg]')
+      } finally {
+        if (submitBtn) submitBtn.disabled = false
+      }
+    })
+  }
+
   function initBoard(board: HTMLElement) {
+    const grid = board.querySelector<HTMLElement>('[data-team-grid]')
+    // 在任何改动前，克隆第一张静态卡当作自定义卡的模板。
+    const pristine = board.querySelector<HTMLElement>('[data-team-id]')?.cloneNode(true) as
+      | HTMLElement
+      | undefined
+
     const cards = new Map<string, HTMLElement>()
     board.querySelectorAll<HTMLElement>('[data-team-id]').forEach((card) => {
       const id = card.dataset.teamId
@@ -522,17 +728,23 @@ import { activity, teams } from '@/data/agent-teams'
       wireCard(card, board)
     })
 
-    fetch('/api/agent-teams', { cache: 'no-store' })
-      .then((res) => res.json())
-      .then((data: BoardData) => applyState(board, cards, data))
-      .catch(() => {
-        const banner = board.querySelector<HTMLElement>('[data-board-banner]')
-        if (banner) {
-          banner.textContent = '名单暂时加载不出来，请稍后刷新重试。'
-          banner.hidden = false
-          banner.classList.remove('hidden')
-        }
-      })
+    const showBannerError = () => {
+      const banner = board.querySelector<HTMLElement>('[data-board-banner]')
+      if (banner) {
+        banner.textContent = '名单暂时加载不出来，请稍后刷新重试。'
+        banner.hidden = false
+        banner.classList.remove('hidden')
+      }
+    }
+
+    const reload = () =>
+      fetch('/api/agent-teams', { cache: 'no-store' })
+        .then((res) => res.json())
+        .then((data: BoardData) => applyState(board, grid, pristine ?? null, cards, data))
+        .catch(showBannerError)
+
+    wireCreateCard(board, reload)
+    reload()
   }
 
   const board = document.querySelector<HTMLElement>('[data-agent-board]')

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -61,11 +61,17 @@ import { activity, teams } from '@/data/agent-teams'
             </div>
           )}
 
+          <div
+            class='team-detail hidden whitespace-pre-wrap rounded-lg border border-dashed px-3 py-2 text-sm leading-relaxed text-muted-foreground'
+            data-detail
+          >
+          </div>
+
           <ul class='roster m-0 flex list-none flex-wrap gap-1.5 p-0' data-roster>
             <li class='roster-empty text-xs text-muted-foreground'>加载中…</li>
           </ul>
 
-          <div class='mt-auto pt-1'>
+          <div class='mt-auto flex flex-wrap items-center gap-2 pt-1'>
             <button
               type='button'
               class='signup-toggle inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
@@ -73,6 +79,14 @@ import { activity, teams } from '@/data/agent-teams'
               aria-expanded='false'
             >
               报名 / 加入
+            </button>
+            <button
+              type='button'
+              class='detail-edit-toggle hidden items-center gap-1 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+              data-detail-edit-toggle
+              aria-expanded='false'
+            >
+              队长编辑
             </button>
           </div>
 
@@ -141,6 +155,39 @@ import { activity, teams } from '@/data/agent-teams'
               <p class='form-msg m-0 text-xs' data-form-msg role='status'></p>
             </div>
           </form>
+
+          <form class='detail-form mt-1 flex-col gap-2' data-detail-form hidden>
+            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+              队长口令
+              <input
+                class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
+                name='passcode'
+                type='text'
+                maxlength='40'
+                autocomplete='off'
+                placeholder='你的队长口令'
+                required
+              />
+            </label>
+            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+              详细介绍（会公开显示，最多 600 字，可分段）
+              <textarea
+                class='min-h-[7rem] rounded-lg border bg-background px-2.5 py-1.5 text-sm leading-relaxed text-foreground'
+                name='detail'
+                maxlength='600'
+                placeholder='多写点：这支队想做成什么样、技术路线、想找什么样的队友…'
+              ></textarea>
+            </label>
+            <div class='flex items-center gap-3'>
+              <button
+                type='submit'
+                class='inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
+              >
+                保存介绍
+              </button>
+              <p class='form-msg m-0 text-xs' data-detail-msg role='status'></p>
+            </div>
+          </form>
         </article>
       ))
     }
@@ -159,6 +206,12 @@ import { activity, teams } from '@/data/agent-teams'
 
   .signup-form[data-open] {
     display: flex;
+  }
+  .detail-form[data-open] {
+    display: flex;
+  }
+  .detail-edit-toggle[data-show] {
+    display: inline-flex;
   }
   .passcode-field[data-show] {
     display: flex;
@@ -197,11 +250,18 @@ import { activity, teams } from '@/data/agent-teams'
 
 <script>
   type Member = { name: string; note: string | null; ts: number }
-  type Team = { id: string; count: number; capacity: number | null; members: Member[] }
+  type Team = {
+    id: string
+    count: number
+    capacity: number | null
+    members: Member[]
+    detail: string | null
+  }
   type BoardData = {
     configured: boolean
     degraded?: boolean
     passcodeRequired: boolean
+    detailEditable: boolean
     teams: Team[]
   }
 
@@ -216,12 +276,28 @@ import { activity, teams } from '@/data/agent-teams'
     )
   }
 
-  function setMsg(form: HTMLElement, text: string, tone: 'error' | 'success' | '' = '') {
-    const el = form.querySelector<HTMLElement>('[data-form-msg]')
+  function setMsg(
+    form: HTMLElement,
+    text: string,
+    tone: 'error' | 'success' | '' = '',
+    selector = '[data-form-msg]'
+  ) {
+    const el = form.querySelector<HTMLElement>(selector)
     if (!el) return
     el.textContent = text
     if (tone) el.dataset.tone = tone
     else delete el.dataset.tone
+  }
+
+  function renderDetail(card: HTMLElement, value: string | null) {
+    const box = card.querySelector<HTMLElement>('[data-detail]')
+    if (!box) return
+    const detail = value ?? ''
+    box.textContent = detail // textContent + pre-wrap — 用户输入不当 HTML 解析
+    box.hidden = detail.length === 0
+    box.classList.toggle('hidden', detail.length === 0)
+    // 缓存当前值，供队长编辑表单预填
+    card.dataset.detail = detail
   }
 
   function renderRoster(card: HTMLElement, team: Team) {
@@ -317,6 +393,64 @@ import { activity, teams } from '@/data/agent-teams'
         if (submitBtn) submitBtn.disabled = false
       }
     })
+
+    // 队长编辑「详细介绍」
+    const detailToggle = card.querySelector<HTMLButtonElement>('[data-detail-edit-toggle]')
+    const detailForm = card.querySelector<HTMLFormElement>('[data-detail-form]')
+    if (detailToggle && detailForm) {
+      const textarea = detailForm.querySelector<HTMLTextAreaElement>('textarea[name="detail"]')
+
+      detailToggle.addEventListener('click', () => {
+        const open = detailForm.hasAttribute('data-open')
+        if (open) {
+          detailForm.removeAttribute('data-open')
+          detailForm.hidden = true
+          detailToggle.setAttribute('aria-expanded', 'false')
+        } else {
+          if (textarea) textarea.value = card.dataset.detail || ''
+          detailForm.setAttribute('data-open', '')
+          detailForm.hidden = false
+          detailToggle.setAttribute('aria-expanded', 'true')
+          detailForm.querySelector<HTMLInputElement>('input[name="passcode"]')?.focus()
+        }
+      })
+
+      detailForm.addEventListener('submit', async (event) => {
+        event.preventDefault()
+        const teamId = card.dataset.teamId || ''
+        const saveBtn = detailForm.querySelector<HTMLButtonElement>('button[type="submit"]')
+        const data = new FormData(detailForm)
+        const payload = {
+          teamId,
+          detail: String(data.get('detail') || ''),
+          passcode: String(data.get('passcode') || '')
+        }
+
+        if (saveBtn) saveBtn.disabled = true
+        setMsg(detailForm, '保存中…', '', '[data-detail-msg]')
+        try {
+          const res = await fetch('/api/agent-teams', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+          })
+          const body = await res.json()
+          if (res.ok && body.ok) {
+            renderDetail(card, typeof body.detail === 'string' ? body.detail : '')
+            detailForm.removeAttribute('data-open')
+            detailForm.hidden = true
+            detailToggle.setAttribute('aria-expanded', 'false')
+            setMsg(detailForm, '已更新！', 'success', '[data-detail-msg]')
+          } else {
+            setMsg(detailForm, (body && body.message) || '保存失败，请稍后再试', 'error', '[data-detail-msg]')
+          }
+        } catch {
+          setMsg(detailForm, '网络错误，请稍后再试', 'error', '[data-detail-msg]')
+        } finally {
+          if (saveBtn) saveBtn.disabled = false
+        }
+      })
+    }
   }
 
   function applyState(board: HTMLElement, cards: Map<string, HTMLElement>, data: BoardData) {
@@ -341,7 +475,20 @@ import { activity, teams } from '@/data/agent-teams'
 
     for (const team of data.teams) {
       const card = cards.get(team.id)
-      if (card) renderRoster(card, team)
+      if (!card) continue
+      renderRoster(card, team)
+      renderDetail(card, team.detail)
+    }
+
+    // 开放了队长编辑：显示每张卡的「队长编辑」入口
+    if (data.detailEditable) {
+      for (const card of cards.values()) {
+        const toggle = card.querySelector<HTMLElement>('[data-detail-edit-toggle]')
+        if (toggle) {
+          toggle.dataset.show = ''
+          toggle.classList.remove('hidden')
+        }
+      }
     }
 
     // 未配置：禁用所有报名按钮

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -90,14 +90,14 @@ import { activity, teams } from '@/data/agent-teams'
               />
             </label>
             <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
-              联系方式（可选，仅组织者可见）
+              QQ（可选，仅组织者可见，方便拉你进队）
               <input
                 class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
                 name='contact'
                 type='text'
                 maxlength='60'
                 autocomplete='off'
-                placeholder='微信 / 邮箱等'
+                placeholder='你的 QQ 号'
               />
             </label>
             <label class='flex flex-col gap-1 text-xs text-muted-foreground'>

--- a/src/data/agent-teams.test.ts
+++ b/src/data/agent-teams.test.ts
@@ -1,0 +1,75 @@
+// 静态赛道配置的完整性测试。
+//
+// 重点守护 `id`：它同时是 DB key（agent_team_signups.team_id）和埋点标识，
+// 一旦撞车或被改动，报名名单就会串。这些是纯数据断言，`bun test` 直接跑，无需 DB。
+
+import { describe, expect, test } from 'bun:test'
+import { activity, teams } from './agent-teams'
+
+describe('teams 配置', () => {
+  test('至少有一个赛道', () => {
+    expect(teams.length).toBeGreaterThan(0)
+  })
+
+  test('每个 id 唯一', () => {
+    const ids = teams.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  test('id 为稳定 slug（小写字母 / 数字 / 连字符）', () => {
+    for (const t of teams) {
+      expect(t.id).toMatch(/^[a-z0-9-]+$/)
+    }
+  })
+
+  test('id 不与自命题赛道的 custom- 前缀冲突', () => {
+    for (const t of teams) {
+      expect(t.id.startsWith('custom-')).toBe(false)
+    }
+  })
+
+  test('title / summary 非空且经过 trim', () => {
+    for (const t of teams) {
+      expect(t.title.length).toBeGreaterThan(0)
+      expect(t.title).toBe(t.title.trim())
+      expect(t.summary.length).toBeGreaterThan(0)
+      expect(t.summary).toBe(t.summary.trim())
+    }
+  })
+
+  test('capacity 省略或为正整数', () => {
+    for (const t of teams) {
+      if (t.capacity === undefined) continue
+      expect(Number.isInteger(t.capacity)).toBe(true)
+      expect(t.capacity).toBeGreaterThan(0)
+    }
+  })
+
+  test('tags 省略或为非空字符串数组', () => {
+    for (const t of teams) {
+      if (t.tags === undefined) continue
+      expect(Array.isArray(t.tags)).toBe(true)
+      for (const tag of t.tags) {
+        expect(typeof tag).toBe('string')
+        expect(tag.length).toBeGreaterThan(0)
+      }
+    }
+  })
+})
+
+describe('activity 配置', () => {
+  test('deadline 是合法的 YYYY-MM-DD', () => {
+    expect(activity.deadline).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(Number.isNaN(Date.parse(activity.deadline))).toBe(false)
+  })
+
+  test('title / subtitle / tagline 非空', () => {
+    expect(activity.title.length).toBeGreaterThan(0)
+    expect(activity.subtitle.length).toBeGreaterThan(0)
+    expect(activity.tagline.length).toBeGreaterThan(0)
+  })
+
+  test('docHref 是 http(s) 链接', () => {
+    expect(activity.docHref).toMatch(/^https?:\/\//)
+  })
+})

--- a/src/data/agent-teams.ts
+++ b/src/data/agent-teams.ts
@@ -128,6 +128,27 @@ export const teams: AgentTeam[] = [
     summary: '规划路线、出题讲解、追踪进度，陪你把一个领域啃下来。',
     tags: ['learning', 'tutor'],
     capacity: 6
+  },
+  {
+    id: 'live2d-agent',
+    title: 'Live2D Agent',
+    summary: '给 Agent 一副 Live2D 皮囊，会说话、有表情、随对话动起来的桌面伙伴。',
+    tags: ['live2d', 'avatar'],
+    capacity: 6
+  },
+  {
+    id: 'language-learning-agent',
+    title: '语言学习 Agent',
+    summary: '陪你练口语、纠发音、记单词，按你的水平定制每天的语言练习。',
+    tags: ['language', 'tutor'],
+    capacity: 6
+  },
+  {
+    id: 'newcomer-onboarding-agent',
+    title: '新人入门新领域 Agent',
+    summary: '面向零基础新人，把陌生领域拆成上手路径，边学边练地带你入门。',
+    tags: ['onboarding', 'learning'],
+    capacity: 6
   }
   // 「自命题赛道」不再是静态卡：由用户在页面上自助创建（见 store.ts 的 createTeam）。
 ]

--- a/src/data/agent-teams.ts
+++ b/src/data/agent-teams.ts
@@ -29,76 +29,103 @@ export const activity = {
   docHref: 'https://my.feishu.cn/wiki/LHJiw36mxietv4kKZjacOIbznhe?from=from_copylink'
 }
 
-/** 约 10 个占位主题 —— 之后替换成真实内容 */
+/** 第一届比赛的真实赛道 —— 简介 / tags 可随时改，id 上线后勿动 */
 export const teams: AgentTeam[] = [
   {
-    id: 'deep-research-agent',
-    title: '深度研究 Agent',
-    summary: '自动检索、交叉验证、产出带引用的研究报告。',
-    tags: ['research', 'web'],
+    id: 'game-agent',
+    title: '游戏 Agent（杀戮尖塔 2）',
+    summary: '让 Agent 自己读局面、做决策、打通关，以《杀戮尖塔 2》为例。',
+    tags: ['game', 'planning'],
     capacity: 6
   },
   {
-    id: 'coding-agent',
-    title: '编程 Agent',
-    summary: '从 issue 到 PR：自己写代码、跑测试、修 bug。',
-    tags: ['coding', 'tools'],
+    id: 'personal-agent',
+    title: '个人 Agent',
+    summary: '一个只属于你的私人助理，帮你打理日常里那些琐碎事。',
+    tags: ['personal', 'assistant'],
     capacity: 6
   },
   {
-    id: 'browser-agent',
-    title: '浏览器操作 Agent',
-    summary: '用视觉 + DOM 自主完成网页上的真实任务。',
-    tags: ['browser', 'vision'],
+    id: 'interview-transcript-agent',
+    title: '面试转录 Agent',
+    summary: '实时转录面试对话，结束后自动复盘、指出可以改进的地方。',
+    tags: ['transcription', 'review'],
+    capacity: 6
+  },
+  {
+    id: 'radio-agent',
+    title: '个人电台 Agent（han 神）',
+    summary: '像 han 神那样，用你的口味生成一档会聊天、会放歌的私人电台。',
+    tags: ['audio', 'voice'],
+    capacity: 6
+  },
+  {
+    id: 'galgame-agent',
+    title: 'Galgame Agent',
+    summary: '会写剧情、能分支选择的 Galgame，随玩随生成。',
+    tags: ['galgame', 'narrative'],
+    capacity: 6
+  },
+  {
+    id: 'mock-interview-agent',
+    title: '模拟面试 Agent',
+    summary: '扮演面试官出题、追问、打分，陪你练到手不抖。',
+    tags: ['interview', 'practice'],
     capacity: 6
   },
   {
     id: 'memory-agent',
-    title: '记忆与个性化 Agent',
-    summary: '长期记忆、用户画像、跨会话保持人格。',
-    tags: ['memory', 'personalization'],
-    capacity: 5
-  },
-  {
-    id: 'multi-agent-orchestra',
-    title: '多智能体协作',
-    summary: '编排一群 Agent 分工，合力完成复杂任务。',
-    tags: ['multi-agent', 'orchestration'],
+    title: '个人回忆 Agent',
+    summary: '收集、整理、随时回放你的人生片段。',
+    tags: ['memory', 'life'],
     capacity: 6
   },
   {
-    id: 'voice-agent',
-    title: '语音实时 Agent',
-    summary: '可打断、可转接，边听边想的实时语音对话。',
-    tags: ['voice', 'realtime'],
-    capacity: 5
+    id: 'qq-clone-bot',
+    title: 'QQ 群整理 Bot（数字分身）',
+    summary: '潜伏在群里学你说话，替你冒泡的数字分身。',
+    tags: ['qq', 'clone'],
+    capacity: 6
   },
   {
-    id: 'data-analyst-agent',
-    title: '数据分析 Agent',
-    summary: '连数据库、跑查询、出图表，直接给结论。',
-    tags: ['data', 'sql'],
-    capacity: 5
+    id: 'knowledge-archive-agent',
+    title: '个人知识存档 Agent',
+    summary: '自动归档、持续累积你的知识，越用越懂你。',
+    tags: ['knowledge', 'archive'],
+    capacity: 6
   },
   {
-    id: 'game-npc-agent',
-    title: '游戏 NPC Agent',
-    summary: '会记仇、会计划、可玩的智能 NPC。',
-    tags: ['game', 'simulation'],
-    capacity: 5
+    id: 'e2e-test-agent',
+    title: '前端 E2E 测试 Agent',
+    summary: '自动跑端到端测试，发现并复现前端的 UI bug。',
+    tags: ['testing', 'frontend'],
+    capacity: 6
   },
   {
-    id: 'life-automation-agent',
-    title: '生活自动化 Agent',
-    summary: '订票、排日程、跑报销，一条龙帮你搞定。',
-    tags: ['automation', 'daily'],
-    capacity: 5
+    id: 'roleplay-agent',
+    title: 'Roleplay Agent',
+    summary: '稳定人设、长程记忆，聊多久都不出戏的角色扮演。',
+    tags: ['roleplay', 'character'],
+    capacity: 6
   },
   {
-    id: 'rag-knowledge-agent',
-    title: '知识库问答 Agent',
-    summary: '私有资料检索问答，答案可溯源到出处。',
-    tags: ['rag', 'knowledge'],
-    capacity: 5
+    id: 'abstract-agent',
+    title: '抽象 Agent（虾神）',
+    summary: '主打一个抽象——像虾神一样不按常理出牌的整活 Agent。',
+    tags: ['fun', 'meme'],
+    capacity: 6
+  },
+  {
+    id: 'rss-agent',
+    title: 'RSS Agent',
+    summary: '帮你订阅、筛选、总结 RSS，只把你在意的推给你。',
+    tags: ['rss', 'feed'],
+    capacity: 6
+  },
+  {
+    id: 'open-track',
+    title: '自命题赛道',
+    summary: '没有命题，你来定义。任何脑洞都能在这里开一队。',
+    tags: ['open']
   }
 ]

--- a/src/data/agent-teams.ts
+++ b/src/data/agent-teams.ts
@@ -123,6 +123,13 @@ export const teams: AgentTeam[] = [
     capacity: 6
   },
   {
+    id: 'learning-agent',
+    title: '学习领域 Agent',
+    summary: '规划路线、出题讲解、追踪进度，陪你把一个领域啃下来。',
+    tags: ['learning', 'tutor'],
+    capacity: 6
+  },
+  {
     id: 'open-track',
     title: '自命题赛道',
     summary: '没有命题，你来定义。任何脑洞都能在这里开一队。',

--- a/src/data/agent-teams.ts
+++ b/src/data/agent-teams.ts
@@ -54,8 +54,8 @@ export const teams: AgentTeam[] = [
   },
   {
     id: 'radio-agent',
-    title: '个人电台 Agent（han 神）',
-    summary: '像 han 神那样，用你的口味生成一档会聊天、会放歌的私人电台。',
+    title: '个人电台 Agent（憨神）',
+    summary: '像憨神那样，用你的口味生成一档会聊天、会放歌的私人电台。',
     tags: ['audio', 'voice'],
     capacity: 6
   },

--- a/src/data/agent-teams.ts
+++ b/src/data/agent-teams.ts
@@ -128,11 +128,6 @@ export const teams: AgentTeam[] = [
     summary: '规划路线、出题讲解、追踪进度，陪你把一个领域啃下来。',
     tags: ['learning', 'tutor'],
     capacity: 6
-  },
-  {
-    id: 'open-track',
-    title: '自命题赛道',
-    summary: '没有命题，你来定义。任何脑洞都能在这里开一队。',
-    tags: ['open']
   }
+  // 「自命题赛道」不再是静态卡：由用户在页面上自助创建（见 store.ts 的 createTeam）。
 ]

--- a/src/lib/agent-teams/store.ts
+++ b/src/lib/agent-teams/store.ts
@@ -33,6 +33,15 @@ export type TeamRoster = {
   members: PublicMember[]
 }
 
+/** 队伍元信息（标题/简介/标签/名额）——静态赛道与自定义赛道统一成这个形状 */
+export type TeamMeta = {
+  id: string
+  title: string
+  summary: string
+  tags: string[]
+  capacity: number | null
+}
+
 /** 报名提交入参 */
 export type SignupInput = {
   teamId: string
@@ -63,9 +72,13 @@ const NAME_MAX = 24
 const NOTE_MAX = 60
 const CONTACT_MAX = 60
 const DETAIL_MAX = 600
+const TITLE_MAX = 30
+const SUMMARY_MAX = 80
 // 轻量限流：同一 IP 在窗口内最多成功报名这么多次。
 const RATE_LIMIT = 5
 const RATE_WINDOW_SEC = 600
+// 同一 IP 在窗口内最多创建这么多个自定义赛道。
+const CREATE_RATE_LIMIT = 3
 
 // --- 环境 / 配置 ---------------------------------------------------------
 
@@ -96,37 +109,19 @@ export function passcodeRequired(): boolean {
   return getPasscode() !== null
 }
 
-// 队长编辑鉴权：
-//   - AGENT_TEAMS_CAPTAIN_PASSCODES: JSON map，形如 {"game-agent":"xxx","rss-agent":"yyy"}，
-//     每个队长一个专属口令，只能改自己那支队。
-//   - AGENT_TEAMS_ADMIN_PASSCODE: 管理员口令，能改任意队伍（你自己兜底用）。
-function getCaptainPasscodes(): Record<string, string> {
-  const raw =
-    import.meta.env.AGENT_TEAMS_CAPTAIN_PASSCODES ?? process.env.AGENT_TEAMS_CAPTAIN_PASSCODES
-  if (!raw) return {}
-  try {
-    const obj = JSON.parse(String(raw)) as unknown
-    if (obj && typeof obj === 'object') {
-      const out: Record<string, string> = {}
-      for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
-        if (typeof v === 'string' && v.length > 0) out[k] = v
-      }
-      return out
-    }
-  } catch {
-    // 配错了就当没配，页面不显示编辑入口。
-  }
-  return {}
+// 编辑/建赛道口令：一个默认口令即可，默认值就是粉丝群的名字（群成员都知道）。
+// 想让它不出现在公开仓库里，可在 Vercel 配 AGENT_TEAMS_EDIT_PASSCODE 覆盖。
+// 注意：这只是「挡住路人」的轻门槛，不是强安全。报名本身不需要这个口令。
+const DEFAULT_EDIT_PASSCODE = '一群开心快乐的小奶龙'
+
+function getEditPasscode(): string {
+  const p = import.meta.env.AGENT_TEAMS_EDIT_PASSCODE ?? process.env.AGENT_TEAMS_EDIT_PASSCODE
+  return p && String(p).length > 0 ? String(p) : DEFAULT_EDIT_PASSCODE
 }
 
-function getAdminPasscode(): string | null {
-  const p = import.meta.env.AGENT_TEAMS_ADMIN_PASSCODE ?? process.env.AGENT_TEAMS_ADMIN_PASSCODE
-  return p && String(p).length > 0 ? String(p) : null
-}
-
-/** 是否开放了队长编辑（配了任一队长口令或管理员口令）——决定前端是否显示编辑入口 */
+/** 编辑简介 / 建赛道是否开放——总有默认口令，故恒为 true（保留给未来做锁定开关） */
 export function detailEditable(): boolean {
-  return getAdminPasscode() !== null || Object.keys(getCaptainPasscodes()).length > 0
+  return true
 }
 
 // --- 连接 / 表结构 -------------------------------------------------------
@@ -171,6 +166,16 @@ async function ensureSchema(sql: Sql): Promise<void> {
       team_id TEXT PRIMARY KEY,
       detail TEXT NOT NULL,
       updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `
+  // 用户自助创建的「自命题赛道」，一队一行。id 用 custom-<uuid8>，名单/介绍与静态赛道共表。
+  await sql`
+    CREATE TABLE IF NOT EXISTS agent_team_customs (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      ip TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     )
   `
   schemaReady = true
@@ -362,15 +367,8 @@ export async function updateDetail(input: DetailUpdateInput): Promise<DetailResu
   const sql = getSql()
   if (!sql) return { ok: false, code: 'not_configured', message: '系统尚未配置' }
 
-  const captain = getCaptainPasscodes()[input.teamId]
-  const admin = getAdminPasscode()
-  if (!captain && !admin) {
-    return { ok: false, code: 'passcode', message: '这支队伍还没有开放队长编辑' }
-  }
-  const pass = input.passcode ?? ''
-  const authed = (!!captain && pass === captain) || (!!admin && pass === admin)
-  if (!authed) {
-    return { ok: false, code: 'passcode', message: '队长口令不正确' }
+  if ((input.passcode ?? '') !== getEditPasscode()) {
+    return { ok: false, code: 'passcode', message: '口令不正确' }
   }
 
   const detail = cleanMultiline(input.detail ?? '').slice(0, DETAIL_MAX)
@@ -389,5 +387,92 @@ export async function updateDetail(input: DetailUpdateInput): Promise<DetailResu
     return { ok: true, teamId: input.teamId, detail }
   } catch {
     return { ok: false, code: 'store_error', message: '保存失败，请稍后再试' }
+  }
+}
+
+// --- 自命题：用户自助创建赛道 -------------------------------------------
+
+export type CreateTeamInput = {
+  title: string
+  summary: string
+  passcode?: string
+  /** 蜜罐字段：正常用户永远为空 */
+  hp?: string
+  ip?: string | null
+}
+
+export type CreateErrorCode =
+  | 'not_configured'
+  | 'invalid'
+  | 'passcode'
+  | 'rate_limited'
+  | 'store_error'
+
+export type CreateResult =
+  | { ok: true; team: TeamMeta }
+  | { ok: false; code: CreateErrorCode; message: string }
+
+/** 读取所有用户自定义赛道（按创建时间升序），统一成 TeamMeta 形状 */
+export async function getCustomTeams(): Promise<TeamMeta[]> {
+  const sql = getSql()
+  if (!sql) return []
+  await ensureSchema(sql)
+
+  const rows = (await sql`
+    SELECT id, title, summary
+    FROM agent_team_customs
+    ORDER BY created_at ASC
+  `) as { id: string; title: string; summary: string }[]
+
+  // 自定义赛道无标签、名额不限。
+  return rows.map((r) => ({ id: r.id, title: r.title, summary: r.summary, tags: [], capacity: null }))
+}
+
+/** 创建一个自定义赛道。口令匹配编辑口令才放行。 */
+export async function createTeam(input: CreateTeamInput): Promise<CreateResult> {
+  const sql = getSql()
+  if (!sql) return { ok: false, code: 'not_configured', message: '系统尚未配置' }
+
+  // 蜜罐。
+  if (input.hp && input.hp.trim().length > 0) {
+    return { ok: false, code: 'invalid', message: '提交无效' }
+  }
+  if ((input.passcode ?? '') !== getEditPasscode()) {
+    return { ok: false, code: 'passcode', message: '口令不正确' }
+  }
+
+  const title = cleanText(input.title ?? '')
+  if (title.length === 0 || title.length > TITLE_MAX) {
+    return { ok: false, code: 'invalid', message: `赛道名称需为 1–${TITLE_MAX} 个字符` }
+  }
+  const summary = cleanText(input.summary ?? '').slice(0, SUMMARY_MAX)
+  if (summary.length === 0) {
+    return { ok: false, code: 'invalid', message: '简介不能为空' }
+  }
+  const ip = input.ip ?? null
+  const id = `custom-${crypto.randomUUID().slice(0, 8)}`
+
+  try {
+    await ensureSchema(sql)
+
+    // 限流：同一 IP 短时间内创建太多赛道就挡一下。
+    if (ip) {
+      const limitRows = (await sql`
+        SELECT count(*)::int AS n
+        FROM agent_team_customs
+        WHERE ip = ${ip} AND created_at > now() - (${RATE_WINDOW_SEC} * interval '1 second')
+      `) as { n: number }[]
+      if ((limitRows[0]?.n ?? 0) >= CREATE_RATE_LIMIT) {
+        return { ok: false, code: 'rate_limited', message: '创建太频繁了，歇一会儿再来' }
+      }
+    }
+
+    await sql`
+      INSERT INTO agent_team_customs (id, title, summary, ip)
+      VALUES (${id}, ${title}, ${summary}, ${ip})
+    `
+    return { ok: true, team: { id, title, summary, tags: [], capacity: null } }
+  } catch {
+    return { ok: false, code: 'store_error', message: '创建失败，请稍后再试' }
   }
 }

--- a/src/lib/agent-teams/store.ts
+++ b/src/lib/agent-teams/store.ts
@@ -62,6 +62,7 @@ export type SignupResult =
 const NAME_MAX = 24
 const NOTE_MAX = 60
 const CONTACT_MAX = 60
+const DETAIL_MAX = 600
 // 轻量限流：同一 IP 在窗口内最多成功报名这么多次。
 const RATE_LIMIT = 5
 const RATE_WINDOW_SEC = 600
@@ -93,6 +94,39 @@ export function isConfigured(): boolean {
 /** 是否设置了报名口令 */
 export function passcodeRequired(): boolean {
   return getPasscode() !== null
+}
+
+// 队长编辑鉴权：
+//   - AGENT_TEAMS_CAPTAIN_PASSCODES: JSON map，形如 {"game-agent":"xxx","rss-agent":"yyy"}，
+//     每个队长一个专属口令，只能改自己那支队。
+//   - AGENT_TEAMS_ADMIN_PASSCODE: 管理员口令，能改任意队伍（你自己兜底用）。
+function getCaptainPasscodes(): Record<string, string> {
+  const raw =
+    import.meta.env.AGENT_TEAMS_CAPTAIN_PASSCODES ?? process.env.AGENT_TEAMS_CAPTAIN_PASSCODES
+  if (!raw) return {}
+  try {
+    const obj = JSON.parse(String(raw)) as unknown
+    if (obj && typeof obj === 'object') {
+      const out: Record<string, string> = {}
+      for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+        if (typeof v === 'string' && v.length > 0) out[k] = v
+      }
+      return out
+    }
+  } catch {
+    // 配错了就当没配，页面不显示编辑入口。
+  }
+  return {}
+}
+
+function getAdminPasscode(): string | null {
+  const p = import.meta.env.AGENT_TEAMS_ADMIN_PASSCODE ?? process.env.AGENT_TEAMS_ADMIN_PASSCODE
+  return p && String(p).length > 0 ? String(p) : null
+}
+
+/** 是否开放了队长编辑（配了任一队长口令或管理员口令）——决定前端是否显示编辑入口 */
+export function detailEditable(): boolean {
+  return getAdminPasscode() !== null || Object.keys(getCaptainPasscodes()).length > 0
 }
 
 // --- 连接 / 表结构 -------------------------------------------------------
@@ -131,6 +165,14 @@ async function ensureSchema(sql: Sql): Promise<void> {
     CREATE INDEX IF NOT EXISTS agent_team_signups_team_created
       ON agent_team_signups (team_id, created_at)
   `
+  // 队长维护的「详细介绍」，一队一行，队长编辑时 upsert。
+  await sql`
+    CREATE TABLE IF NOT EXISTS agent_team_details (
+      team_id TEXT PRIMARY KEY,
+      detail TEXT NOT NULL,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `
   schemaReady = true
 }
 
@@ -142,6 +184,19 @@ const CONTROL_CHARS = new RegExp('[\\u0000-\\u001F\\u007F]', 'g')
 
 function cleanText(input: string): string {
   return input.replace(CONTROL_CHARS, ' ').replace(/\s+/g, ' ').trim()
+}
+
+// 详细介绍要保留换行（队长要分段阐述），所以只去掉除换行外的控制字符，
+// 并折叠横向空白与多余空行。渲染端用 textContent + white-space: pre-wrap，无 XSS。
+const CONTROL_EXCEPT_NL = new RegExp('[\\u0000-\\u0009\\u000B-\\u001F\\u007F]', 'g')
+
+function cleanMultiline(input: string): string {
+  return input
+    .replace(CONTROL_EXCEPT_NL, ' ')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/[ \t]*\n[ \t]*/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
 }
 
 type RosterRow = { name: string; note: string | null; ts_sec: number }
@@ -173,6 +228,25 @@ export async function getRosters(teamIds: string[]): Promise<Record<string, Publ
     if (!out[row.team_id]) out[row.team_id] = []
     out[row.team_id].push(rowToMember(row))
   }
+  return out
+}
+
+/** 批量读取多支队伍的「详细介绍」，返回 { teamId: detail }（无则不含该键） */
+export async function getDetails(teamIds: string[]): Promise<Record<string, string>> {
+  const out: Record<string, string> = {}
+  if (teamIds.length === 0) return out
+
+  const sql = getSql()
+  if (!sql) return out
+  await ensureSchema(sql)
+
+  const rows = (await sql`
+    SELECT team_id, detail
+    FROM agent_team_details
+    WHERE team_id = ANY(${teamIds})
+  `) as { team_id: string; detail: string }[]
+
+  for (const row of rows) out[row.team_id] = row.detail
   return out
 }
 
@@ -263,5 +337,57 @@ export async function addSignup(
     }
   } catch {
     return { ok: false, code: 'store_error', message: '写入失败，请稍后再试' }
+  }
+}
+
+// --- 队长编辑详细介绍 ---------------------------------------------------
+
+export type DetailUpdateInput = {
+  teamId: string
+  detail: string
+  passcode?: string
+}
+
+export type DetailErrorCode = 'not_configured' | 'passcode' | 'store_error'
+
+export type DetailResult =
+  | { ok: true; teamId: string; detail: string }
+  | { ok: false; code: DetailErrorCode; message: string }
+
+/**
+ * 队长更新某队的详细介绍。口令匹配该队的队长口令、或匹配管理员口令才放行。
+ * detail 传空串表示清空（删除该行）。teamId 合法性由调用方校验。
+ */
+export async function updateDetail(input: DetailUpdateInput): Promise<DetailResult> {
+  const sql = getSql()
+  if (!sql) return { ok: false, code: 'not_configured', message: '系统尚未配置' }
+
+  const captain = getCaptainPasscodes()[input.teamId]
+  const admin = getAdminPasscode()
+  if (!captain && !admin) {
+    return { ok: false, code: 'passcode', message: '这支队伍还没有开放队长编辑' }
+  }
+  const pass = input.passcode ?? ''
+  const authed = (!!captain && pass === captain) || (!!admin && pass === admin)
+  if (!authed) {
+    return { ok: false, code: 'passcode', message: '队长口令不正确' }
+  }
+
+  const detail = cleanMultiline(input.detail ?? '').slice(0, DETAIL_MAX)
+
+  try {
+    await ensureSchema(sql)
+    if (detail.length === 0) {
+      await sql`DELETE FROM agent_team_details WHERE team_id = ${input.teamId}`
+      return { ok: true, teamId: input.teamId, detail: '' }
+    }
+    await sql`
+      INSERT INTO agent_team_details (team_id, detail, updated_at)
+      VALUES (${input.teamId}, ${detail}, now())
+      ON CONFLICT (team_id) DO UPDATE SET detail = EXCLUDED.detail, updated_at = now()
+    `
+    return { ok: true, teamId: input.teamId, detail }
+  } catch {
+    return { ok: false, code: 'store_error', message: '保存失败，请稍后再试' }
   }
 }

--- a/src/lib/agent-teams/store.ts
+++ b/src/lib/agent-teams/store.ts
@@ -22,6 +22,8 @@
 
 import { neon } from '@neondatabase/serverless'
 
+import { teams as seedTracks } from '@/data/agent-teams'
+
 /** 对外暴露的成员（不含联系方式 / IP） */
 export type PublicMember = { name: string; note: string | null; ts: number }
 
@@ -178,7 +180,42 @@ async function ensureSchema(sql: Sql): Promise<void> {
       created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     )
   `
+  // 内置赛道：标题/简介/标签/名额入库，以 DB 为准（可后台改而不必改代码 + 重新部署）。
+  // 代码里的 teams 只作「种子」：首次启动补齐缺失的赛道，已存在的行不动。
+  await sql`
+    CREATE TABLE IF NOT EXISTS agent_team_tracks (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      tags JSONB NOT NULL DEFAULT '[]'::jsonb,
+      capacity INTEGER,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `
+  await seedBuiltinTracks(sql)
   schemaReady = true
+}
+
+/**
+ * 把代码里的内置赛道种进 agent_team_tracks：只补「表里还没有」的 id，已存在的行原样保留
+ * （标题/简介以 DB 为准）。稳态下就一次 SELECT、零 INSERT。
+ */
+async function seedBuiltinTracks(sql: Sql): Promise<void> {
+  const rows = (await sql`SELECT id FROM agent_team_tracks`) as { id: string }[]
+  const have = new Set(rows.map((r) => r.id))
+  for (let i = 0; i < seedTracks.length; i++) {
+    const t = seedTracks[i]
+    if (have.has(t.id)) continue
+    await sql`
+      INSERT INTO agent_team_tracks (id, title, summary, tags, capacity, sort_order)
+      VALUES (
+        ${t.id}, ${t.title}, ${t.summary},
+        ${JSON.stringify(t.tags ?? [])}::jsonb, ${t.capacity ?? null}, ${i}
+      )
+      ON CONFLICT (id) DO NOTHING
+    `
+  }
 }
 
 // --- 校验帮助函数 -------------------------------------------------------
@@ -411,6 +448,28 @@ export type CreateErrorCode =
 export type CreateResult =
   | { ok: true; team: TeamMeta }
   | { ok: false; code: CreateErrorCode; message: string }
+
+/** 读取所有内置赛道（以 DB 为准，按 sort_order 升序），统一成 TeamMeta 形状 */
+export async function getBuiltinTracks(): Promise<TeamMeta[]> {
+  const sql = getSql()
+  if (!sql) return []
+  await ensureSchema(sql)
+
+  const rows = (await sql`
+    SELECT id, title, summary, tags, capacity
+    FROM agent_team_tracks
+    ORDER BY sort_order ASC, created_at ASC
+  `) as { id: string; title: string; summary: string; tags: unknown; capacity: number | null }[]
+
+  return rows.map((r) => ({
+    id: r.id,
+    title: r.title,
+    summary: r.summary,
+    // JSONB 经 neon 驱动已解析成 JS 值；兜底成字符串数组。
+    tags: Array.isArray(r.tags) ? r.tags.map((x) => String(x)) : [],
+    capacity: r.capacity
+  }))
+}
 
 /** 读取所有用户自定义赛道（按创建时间升序），统一成 TeamMeta 形状 */
 export async function getCustomTeams(): Promise<TeamMeta[]> {

--- a/src/pages/api/agent-teams.ts
+++ b/src/pages/api/agent-teams.ts
@@ -5,6 +5,7 @@ import {
   addSignup,
   createTeam,
   detailEditable,
+  getBuiltinTracks,
   getCustomTeams,
   getDetails,
   getRosters,
@@ -21,15 +22,14 @@ import {
 // SSR endpoint —— 名单要实时，且要读服务端 env / DB，不能预渲染。
 export const prerender = false
 
-// 静态赛道的元信息，统一成 TeamMeta 形状（与自定义赛道拼在一起）。
-const staticMetas: TeamMeta[] = teams.map((t) => ({
+// 赛道以 DB 为准（getBuiltinTracks）；这份代码里的元信息只在「未配置 / DB 降级」时兜底。
+const fallbackMetas: TeamMeta[] = teams.map((t) => ({
   id: t.id,
   title: t.title,
   summary: t.summary,
   tags: t.tags ?? [],
   capacity: t.capacity ?? null
 }))
-const staticCapacity = new Map(staticMetas.map((m) => [m.id, m.capacity]))
 
 type TeamPayload = TeamMeta & {
   count: number
@@ -67,13 +67,13 @@ export const GET: APIRoute = async () => {
       configured: false,
       passcodeRequired: false,
       detailEditable: editable,
-      teams: buildTeams(staticMetas)
+      teams: buildTeams(fallbackMetas)
     })
   }
 
   try {
-    const customs = await getCustomTeams()
-    const metas = [...staticMetas, ...customs]
+    const [builtins, customs] = await Promise.all([getBuiltinTracks(), getCustomTeams()])
+    const metas = [...builtins, ...customs]
     const ids = metas.map((m) => m.id)
     const [rosters, details] = await Promise.all([getRosters(ids), getDetails(ids)])
     return json({
@@ -83,13 +83,13 @@ export const GET: APIRoute = async () => {
       teams: buildTeams(metas, rosters, details)
     })
   } catch {
-    // 数据库抖动——仍让页面渲染出静态赛道卡，只是名单/介绍/自定义赛道暂时为空。
+    // 数据库抖动——仍让页面渲染出赛道卡（用代码兜底），只是名单/介绍/自定义赛道暂时为空。
     return json({
       configured: true,
       degraded: true,
       passcodeRequired: passcodeRequired(),
       detailEditable: editable,
-      teams: buildTeams(staticMetas)
+      teams: buildTeams(fallbackMetas)
     })
   }
 }
@@ -113,11 +113,13 @@ function resolveIp(request: Request, clientAddress: string | undefined): string 
   }
 }
 
-/** 某队的名额：静态赛道用配置；自定义赛道名额不限（null）；都不是则 undefined = 未知 */
+/** 某队的名额：从 DB 的内置 + 自定义赛道里查；查不到则 undefined = 未知队伍 */
 async function resolveCapacity(teamId: string): Promise<number | null | undefined> {
-  if (staticCapacity.has(teamId)) return staticCapacity.get(teamId) ?? null
-  const customs = await getCustomTeams().catch(() => [] as TeamMeta[])
-  const found = customs.find((t) => t.id === teamId)
+  const [builtins, customs] = await Promise.all([
+    getBuiltinTracks().catch(() => [] as TeamMeta[]),
+    getCustomTeams().catch(() => [] as TeamMeta[])
+  ])
+  const found = [...builtins, ...customs].find((t) => t.id === teamId)
   return found ? found.capacity : undefined
 }
 

--- a/src/pages/api/agent-teams.ts
+++ b/src/pages/api/agent-teams.ts
@@ -3,9 +3,13 @@ import type { APIRoute } from 'astro'
 import { teams } from '@/data/agent-teams'
 import {
   addSignup,
+  detailEditable,
+  getDetails,
   getRosters,
   isConfigured,
   passcodeRequired,
+  updateDetail,
+  type DetailErrorCode,
   type PublicMember,
   type SignupErrorCode
 } from '@/lib/agent-teams/store'
@@ -21,12 +25,22 @@ type TeamPayload = {
   count: number
   capacity: number | null
   members: PublicMember[]
+  detail: string | null
 }
 
-function buildTeams(rosters: Record<string, PublicMember[]>): TeamPayload[] {
+function buildTeams(
+  rosters: Record<string, PublicMember[]>,
+  details: Record<string, string> = {}
+): TeamPayload[] {
   return teams.map((t) => {
     const members = rosters[t.id] ?? []
-    return { id: t.id, count: members.length, capacity: t.capacity ?? null, members }
+    return {
+      id: t.id,
+      count: members.length,
+      capacity: t.capacity ?? null,
+      members,
+      detail: details[t.id] ?? null
+    }
   })
 }
 
@@ -43,19 +57,31 @@ function json(body: unknown, status = 200) {
 
 export const GET: APIRoute = async () => {
   const configured = isConfigured()
+  const editable = detailEditable()
   if (!configured) {
-    return json({ configured: false, passcodeRequired: false, teams: buildTeams({}) })
+    return json({
+      configured: false,
+      passcodeRequired: false,
+      detailEditable: editable,
+      teams: buildTeams({})
+    })
   }
 
   try {
-    const rosters = await getRosters(teamIds)
-    return json({ configured: true, passcodeRequired: passcodeRequired(), teams: buildTeams(rosters) })
+    const [rosters, details] = await Promise.all([getRosters(teamIds), getDetails(teamIds)])
+    return json({
+      configured: true,
+      passcodeRequired: passcodeRequired(),
+      detailEditable: editable,
+      teams: buildTeams(rosters, details)
+    })
   } catch {
-    // Redis 抖动——仍让页面渲染出队伍卡，只是名单暂时为空。
+    // 数据库抖动——仍让页面渲染出队伍卡，只是名单/介绍暂时为空。
     return json({
       configured: true,
       degraded: true,
       passcodeRequired: passcodeRequired(),
+      detailEditable: editable,
       teams: buildTeams({})
     })
   }
@@ -120,4 +146,40 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
     return json({ ok: true, roster: result.roster })
   }
   return json({ ok: false, code: result.code, message: result.message }, STATUS_BY_CODE[result.code])
+}
+
+const DETAIL_STATUS_BY_CODE: Record<DetailErrorCode, number> = {
+  not_configured: 503,
+  passcode: 403,
+  store_error: 500
+}
+
+// 队长编辑详细介绍。
+export const PUT: APIRoute = async ({ request }) => {
+  let body: Record<string, unknown>
+  try {
+    body = (await request.json()) as Record<string, unknown>
+  } catch {
+    return json({ ok: false, code: 'passcode', message: '请求格式不正确' }, 400)
+  }
+
+  const teamId = typeof body.teamId === 'string' ? body.teamId : ''
+  if (!capacityOf.has(teamId)) {
+    return json({ ok: false, code: 'passcode', message: '未知的队伍' }, 400)
+  }
+
+  const str = (v: unknown) => (typeof v === 'string' ? v : undefined)
+  const result = await updateDetail({
+    teamId,
+    detail: str(body.detail) ?? '',
+    passcode: str(body.passcode)
+  })
+
+  if (result.ok) {
+    return json({ ok: true, teamId: result.teamId, detail: result.detail })
+  }
+  return json(
+    { ok: false, code: result.code, message: result.message },
+    DETAIL_STATUS_BY_CODE[result.code]
+  )
 }

--- a/src/pages/api/agent-teams.ts
+++ b/src/pages/api/agent-teams.ts
@@ -3,44 +3,48 @@ import type { APIRoute } from 'astro'
 import { teams } from '@/data/agent-teams'
 import {
   addSignup,
+  createTeam,
   detailEditable,
+  getCustomTeams,
   getDetails,
   getRosters,
   isConfigured,
   passcodeRequired,
   updateDetail,
+  type CreateErrorCode,
   type DetailErrorCode,
   type PublicMember,
-  type SignupErrorCode
+  type SignupErrorCode,
+  type TeamMeta
 } from '@/lib/agent-teams/store'
 
-// SSR endpoint —— 名单要实时，且要读服务端 env / Redis，不能预渲染。
+// SSR endpoint —— 名单要实时，且要读服务端 env / DB，不能预渲染。
 export const prerender = false
 
-const teamIds = teams.map((t) => t.id)
-const capacityOf = new Map(teams.map((t) => [t.id, t.capacity ?? null]))
+// 静态赛道的元信息，统一成 TeamMeta 形状（与自定义赛道拼在一起）。
+const staticMetas: TeamMeta[] = teams.map((t) => ({
+  id: t.id,
+  title: t.title,
+  summary: t.summary,
+  tags: t.tags ?? [],
+  capacity: t.capacity ?? null
+}))
+const staticCapacity = new Map(staticMetas.map((m) => [m.id, m.capacity]))
 
-type TeamPayload = {
-  id: string
+type TeamPayload = TeamMeta & {
   count: number
-  capacity: number | null
   members: PublicMember[]
   detail: string | null
 }
 
 function buildTeams(
-  rosters: Record<string, PublicMember[]>,
+  metas: TeamMeta[],
+  rosters: Record<string, PublicMember[]> = {},
   details: Record<string, string> = {}
 ): TeamPayload[] {
-  return teams.map((t) => {
-    const members = rosters[t.id] ?? []
-    return {
-      id: t.id,
-      count: members.length,
-      capacity: t.capacity ?? null,
-      members,
-      detail: details[t.id] ?? null
-    }
+  return metas.map((m) => {
+    const members = rosters[m.id] ?? []
+    return { ...m, count: members.length, members, detail: details[m.id] ?? null }
   })
 }
 
@@ -63,28 +67,58 @@ export const GET: APIRoute = async () => {
       configured: false,
       passcodeRequired: false,
       detailEditable: editable,
-      teams: buildTeams({})
+      teams: buildTeams(staticMetas)
     })
   }
 
   try {
-    const [rosters, details] = await Promise.all([getRosters(teamIds), getDetails(teamIds)])
+    const customs = await getCustomTeams()
+    const metas = [...staticMetas, ...customs]
+    const ids = metas.map((m) => m.id)
+    const [rosters, details] = await Promise.all([getRosters(ids), getDetails(ids)])
     return json({
       configured: true,
       passcodeRequired: passcodeRequired(),
       detailEditable: editable,
-      teams: buildTeams(rosters, details)
+      teams: buildTeams(metas, rosters, details)
     })
   } catch {
-    // 数据库抖动——仍让页面渲染出队伍卡，只是名单/介绍暂时为空。
+    // 数据库抖动——仍让页面渲染出静态赛道卡，只是名单/介绍/自定义赛道暂时为空。
     return json({
       configured: true,
       degraded: true,
       passcodeRequired: passcodeRequired(),
       detailEditable: editable,
-      teams: buildTeams({})
+      teams: buildTeams(staticMetas)
     })
   }
+}
+
+const str = (v: unknown) => (typeof v === 'string' ? v : undefined)
+
+function clientIp(request: Request, clientAddress: string | undefined): string | null {
+  const forwarded = request.headers.get('x-forwarded-for')
+  if (forwarded) return forwarded.split(',')[0]?.trim() || null
+  const real = request.headers.get('x-real-ip')
+  if (real) return real.trim() || null
+  return clientAddress ?? null
+}
+
+function resolveIp(request: Request, clientAddress: string | undefined): string | null {
+  // clientAddress 在个别适配器下会抛错，包一层防御。
+  try {
+    return clientIp(request, clientAddress)
+  } catch {
+    return clientIp(request, undefined)
+  }
+}
+
+/** 某队的名额：静态赛道用配置；自定义赛道名额不限（null）；都不是则 undefined = 未知 */
+async function resolveCapacity(teamId: string): Promise<number | null | undefined> {
+  if (staticCapacity.has(teamId)) return staticCapacity.get(teamId) ?? null
+  const customs = await getCustomTeams().catch(() => [] as TeamMeta[])
+  const found = customs.find((t) => t.id === teamId)
+  return found ? found.capacity : undefined
 }
 
 const STATUS_BY_CODE: Record<SignupErrorCode, number> = {
@@ -97,12 +131,12 @@ const STATUS_BY_CODE: Record<SignupErrorCode, number> = {
   store_error: 500
 }
 
-function clientIp(request: Request, clientAddress: string | undefined): string | null {
-  const forwarded = request.headers.get('x-forwarded-for')
-  if (forwarded) return forwarded.split(',')[0]?.trim() || null
-  const real = request.headers.get('x-real-ip')
-  if (real) return real.trim() || null
-  return clientAddress ?? null
+const CREATE_STATUS_BY_CODE: Record<CreateErrorCode, number> = {
+  not_configured: 503,
+  invalid: 400,
+  passcode: 403,
+  rate_limited: 429,
+  store_error: 500
 }
 
 export const POST: APIRoute = async ({ request, clientAddress }) => {
@@ -113,20 +147,29 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
     return json({ ok: false, code: 'invalid', message: '请求格式不正确' }, 400)
   }
 
-  const teamId = typeof body.teamId === 'string' ? body.teamId : ''
-  const capacity = capacityOf.get(teamId)
-  if (capacity === undefined) {
-    return json({ ok: false, code: 'invalid', message: '未知的队伍' }, 400)
+  const ip = resolveIp(request, clientAddress)
+
+  // action=create：自助创建自定义赛道。
+  if (body.action === 'create') {
+    const result = await createTeam({
+      title: str(body.title) ?? '',
+      summary: str(body.summary) ?? '',
+      passcode: str(body.passcode),
+      hp: str(body.hp),
+      ip
+    })
+    if (result.ok) return json({ ok: true, team: result.team })
+    return json(
+      { ok: false, code: result.code, message: result.message },
+      CREATE_STATUS_BY_CODE[result.code]
+    )
   }
 
-  const str = (v: unknown) => (typeof v === 'string' ? v : undefined)
-
-  // clientAddress 在个别适配器下会抛错，包一层防御。
-  let ip: string | null = null
-  try {
-    ip = clientIp(request, clientAddress)
-  } catch {
-    ip = clientIp(request, undefined)
+  // 默认：报名加入某队。
+  const teamId = str(body.teamId) ?? ''
+  const capacity = await resolveCapacity(teamId)
+  if (capacity === undefined) {
+    return json({ ok: false, code: 'invalid', message: '未知的队伍' }, 400)
   }
 
   const result = await addSignup(
@@ -163,12 +206,12 @@ export const PUT: APIRoute = async ({ request }) => {
     return json({ ok: false, code: 'passcode', message: '请求格式不正确' }, 400)
   }
 
-  const teamId = typeof body.teamId === 'string' ? body.teamId : ''
-  if (!capacityOf.has(teamId)) {
+  const teamId = str(body.teamId) ?? ''
+  const known = (await resolveCapacity(teamId)) !== undefined
+  if (!known) {
     return json({ ok: false, code: 'passcode', message: '未知的队伍' }, 400)
   }
 
-  const str = (v: unknown) => (typeof v === 'string' ? v : undefined)
   const result = await updateDetail({
     teamId,
     detail: str(body.detail) ?? '',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -505,16 +505,6 @@ const agentHackathonLink =
                 <path d='m12 5 7 7-7 7'></path>
               </svg>
             </a>
-            <button
-              type='button'
-              data-agent-popout-minimize
-              class='rounded-full border bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
-              data-analytics-event='agent_competition_click'
-              data-analytics-surface='agent_popout'
-              data-analytics-action='minimize'
-            >
-              收进角落
-            </button>
             <a
               href={agentHackathonLink}
               target='_blank'
@@ -530,24 +520,6 @@ const agentHackathonLink =
         </div>
       </div>
     </div>
-
-    <button
-      type='button'
-      data-agent-popout-pill
-      class='agent-popout-pill hidden items-center gap-2 rounded-full border bg-background/95 px-3 py-2 text-sm font-medium shadow-lg backdrop-blur transition-all hover:-translate-y-0.5 hover:border-foreground/25 hover:shadow-xl'
-      aria-label='展开第一届 Joye 粉丝 Agent 比赛弹窗'
-      data-analytics-event='agent_competition_click'
-      data-analytics-surface='agent_pill'
-      data-analytics-action='pill_open'
-    >
-      <span class='relative flex size-2'>
-        <span
-          class='absolute inline-flex size-full animate-ping rounded-full bg-muted-foreground opacity-30'
-        ></span>
-        <span class='relative inline-flex size-2 rounded-full bg-muted-foreground'></span>
-      </span>
-      第一届 Agent 活动
-    </button>
   </aside>
 
   <script is:inline>
@@ -556,9 +528,7 @@ const agentHackathonLink =
       if (!root) return
 
       const panel = root.querySelector('[data-agent-popout-panel]')
-      const pill = root.querySelector('[data-agent-popout-pill]')
       const closeButton = root.querySelector('[data-agent-popout-close]')
-      const minimizeButton = root.querySelector('[data-agent-popout-minimize]')
       const copy = root.querySelector('[data-agent-popout-copy]')
       const output = root.querySelector('[data-agent-popout-output]')
       const storageKey = 'joye-agent-popout-state'
@@ -590,12 +560,11 @@ const agentHackathonLink =
       }
 
       const nudge = () => {
-        if (reduceMotion || root.dataset.state === 'closed') return
-        const target = root.dataset.state === 'minimized' ? pill : panel
-        target.classList.remove('agent-popout-nudge')
-        void target.offsetWidth
-        target.classList.add('agent-popout-nudge')
-        window.setTimeout(() => target.classList.remove('agent-popout-nudge'), 1600)
+        if (reduceMotion || root.dataset.state === 'closed' || !panel) return
+        panel.classList.remove('agent-popout-nudge')
+        void panel.offsetWidth
+        panel.classList.add('agent-popout-nudge')
+        window.setTimeout(() => panel.classList.remove('agent-popout-nudge'), 1600)
       }
 
       const scheduleNudge = () => {
@@ -609,23 +578,20 @@ const agentHackathonLink =
       }
 
       const setState = (state) => {
-        if (!panel || !pill) return
+        if (!panel) return
         root.dataset.state = state
         panel.classList.toggle('hidden', state !== 'open')
-        pill.classList.toggle('hidden', state !== 'minimized')
-        pill.classList.toggle('inline-flex', state === 'minimized')
         root.classList.toggle('hidden', state === 'closed')
         window.localStorage.setItem(storageKey, state)
         if (state === 'open') typeText()
         scheduleNudge()
       }
 
+      // 只剩 open / closed 两态；历史上被「收进角落」存成 minimized 的当作 open。
       const savedState = window.localStorage.getItem(storageKey)
-      setState(savedState === 'closed' || savedState === 'minimized' ? savedState : 'open')
+      setState(savedState === 'closed' ? 'closed' : 'open')
 
       closeButton?.addEventListener('click', () => setState('closed'))
-      minimizeButton?.addEventListener('click', () => setState('minimized'))
-      pill?.addEventListener('click', () => setState('open'))
     })()
   </script>
 </PageLayout>
@@ -635,10 +601,6 @@ const agentHackathonLink =
     position: relative;
     transform-origin: bottom left;
     animation: agent-pop-up 980ms cubic-bezier(0.18, 0.9, 0.18, 1.12);
-  }
-
-  .agent-popout-pill {
-    animation: agent-pill 460ms cubic-bezier(0.2, 0.9, 0.25, 1.15);
   }
 
   .agent-popout-nudge {
@@ -695,17 +657,6 @@ const agentHackathonLink =
     }
   }
 
-  @keyframes agent-pill {
-    0% {
-      opacity: 0;
-      transform: translateY(10px) scale(0.94);
-    }
-    100% {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-    }
-  }
-
   @keyframes agent-caret {
     50% {
       opacity: 0;
@@ -714,7 +665,6 @@ const agentHackathonLink =
 
   @media (prefers-reduced-motion: reduce) {
     .agent-popout-panel,
-    .agent-popout-pill,
     .agent-popout-nudge,
     .agent-type-caret {
       animation: none;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -484,15 +484,10 @@ const agentHackathonLink =
           </p>
           <div class='mt-3 flex flex-wrap items-center gap-2'>
             <a
-              href={agentHackathonLink}
-              target='_blank'
-              rel='noopener noreferrer'
+              href='/agent-teams'
               class='group inline-flex items-center gap-1.5 rounded-full bg-foreground px-3 py-1.5 text-sm font-medium text-background no-underline transition-transform hover:-translate-y-0.5'
-              data-analytics-event='agent_competition_click'
-              data-analytics-surface='agent_popout'
-              data-analytics-action='external_link'
             >
-              去看群比赛
+              去组队
               <svg
                 xmlns='http://www.w3.org/2000/svg'
                 width='16'
@@ -520,6 +515,17 @@ const agentHackathonLink =
             >
               收进角落
             </button>
+            <a
+              href={agentHackathonLink}
+              target='_blank'
+              rel='noopener noreferrer'
+              class='inline-flex items-center gap-1 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline'
+              data-analytics-event='agent_competition_click'
+              data-analytics-surface='agent_popout'
+              data-analytics-action='external_link'
+            >
+              活动详情 ↗
+            </a>
           </div>
         </div>
       </div>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -60,7 +60,7 @@ const headings = [
         id: 'agent_competition',
         analyticsEvent: 'agent_competition_click',
         name: '第一届 Joye 粉丝 Agent 比赛',
-        description: '暑假一起做点东西。10 个主题任你选，点进来组队报名，围观、找队友都欢迎。',
+        description: '暑假一起做点东西。十几个主题任你选，点进来组队报名，围观、找队友都欢迎。',
         links: [
           { type: 'site', href: '/agent-teams' },
           { type: 'doc', href: agentHackathonLink }

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -50,7 +50,6 @@ export const theme: ThemeUserConfig = {
       { title: 'Blog', link: '/blog' },
       { title: 'Notes', link: '/notes' },
       { title: 'Talks', link: '/talks' },
-      { title: 'Agent 赛', link: '/agent-teams' },
       { title: 'Projects', link: '/projects' },
       { title: 'Links', link: '/links' },
       { title: 'About', link: '/about' },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,5 +27,13 @@
       "@/data/*": ["src/data/*"]
     }
   },
-  "exclude": ["node_modules", "**/node_modules/*", ".vscode", "dist", "public/scripts/*", "test/*"]
+  "exclude": [
+    "node_modules",
+    "**/node_modules/*",
+    ".vscode",
+    "dist",
+    "public/scripts/*",
+    "test/*",
+    "**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
@
## What & why

充实「第一届 Joye 粉丝 Agent 比赛」组队报名功能：把占位赛道换成真实主题，让入口从顶部导航移到首页 popout，并支持用户自助创建自命题赛道与队长编辑详情。

## Changes

**赛道内容**
- 填入真实赛道，并新增 learning-domain、Live2D、语言学习、新人入门新领域四个赛道
- 修正电台赛道文案：`han 神` → `憨神`

**功能**
- 入口从顶部导航移到首页 popout（`index.astro` / `site.config.ts`）
- 队长可用共享口令编辑一段可展开的「详细介绍」
- 用户可用同一口令自助创建自命题赛道（`custom-<uuid8>`，与静态赛道共用名单表）
- 精简 popout 交互，去掉冗余的最小化/pill

**数据层**
- `store.ts`：Neon/Postgres HTTP 驱动，幂等自建表；报名去重、名额校验、按 IP 轻量限流；contact/IP 仅落库不外泄
- `api/agent-teams.ts`：报名 / 编辑详情 / 建赛道的接口，含蜜罐字段

**测试**
- 新增 `src/data/agent-teams.test.ts`（`bun test`，10 个用例）守护静态赛道配置完整性：id 唯一、为合法 slug、不与 `custom-` 前缀冲突、title/summary 非空、capacity/tags 合法、activity 字段合法
- `package.json` 加 `test` 脚本；`tsconfig.json` 把 `*.test.ts` 排除出 astro check（tsc 不认 `bun:test` 类型）

## Verification

- `bun run check`：0 errors
- `bun test src/`：10 pass
- 用浏览器 preview 跑通全部前端流程：展开表单、空名校验、报名成功、重复去重、口令错误拒绝、建自定义赛道。测试写入真实库的数据已用脚本清理干净（残留 0）。

## Reviewer notes

- 赛道 `id` 是 DB key 兼埋点标识，上线有人报名后不可再改（数据完整性测试对此兜底）。
- 编辑/建赛道用单一共享口令，默认值为粉丝群名，可用 `AGENT_TEAMS_EDIT_PASSCODE` 覆盖；这是「挡路人」的轻门槛，非强安全。
- 需在 Vercel 配 Neon 的 `DATABASE_URL`；未配置时页面走「配置中」降级路径。
- 改动了 `ANALYTICS.md`，涉及埋点事件 `agent_team_signup`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@