### PR TITLE
Agent competition UI: throttle intro, persist popout per-session, add About entry

### DIFF
--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -47,9 +47,9 @@ import avatar from 'src/assets/avatar.png'
 <script is:inline>
   ;(function () {
     try {
-      // 冷却期：看过后 7 天内不再自动播（避免每个会话都弹）。重播按钮不受限。
+      // 冷却期：看过后 24 小时内不再自动播（避免每个会话都弹）。重播按钮不受限。
       var seenAt = parseInt(localStorage.getItem('intro-seen-at') || '0', 10)
-      var recentlySeen = seenAt > 0 && Date.now() - seenAt < 7 * 24 * 60 * 60 * 1000
+      var recentlySeen = seenAt > 0 && Date.now() - seenAt < 24 * 60 * 60 * 1000
       var skip =
         recentlySeen || (window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches)
       if (skip) {
@@ -505,10 +505,10 @@ import avatar from 'src/assets/avatar.png'
     if (replayBtn) replayBtn.addEventListener('click', function () { playSource = 'replay'; trackIntro('intro_replay', 'replay'); play('replay') })
 
     var seen = false
-    // 与预渲染门一致：7 天内看过就算 seen，不自动重播。
+    // 与预渲染门一致：24 小时内看过就算 seen，不自动重播。
     try {
       var seenAtMain = parseInt(localStorage.getItem('intro-seen-at') || '0', 10)
-      seen = seenAtMain > 0 && Date.now() - seenAtMain < 7 * 24 * 60 * 60 * 1000
+      seen = seenAtMain > 0 && Date.now() - seenAtMain < 24 * 60 * 60 * 1000
     } catch (e) {}
     if (!seen && !reduce) {
       var fontReady = document.fonts && document.fonts.load ? document.fonts.load('700 120px "Satoshi"') : null

--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -47,9 +47,11 @@ import avatar from 'src/assets/avatar.png'
 <script is:inline>
   ;(function () {
     try {
+      // 冷却期：看过后 7 天内不再自动播（避免每个会话都弹）。重播按钮不受限。
+      var seenAt = parseInt(localStorage.getItem('intro-seen-at') || '0', 10)
+      var recentlySeen = seenAt > 0 && Date.now() - seenAt < 7 * 24 * 60 * 60 * 1000
       var skip =
-        sessionStorage.getItem('intro-seen') === '1' ||
-        (window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches)
+        recentlySeen || (window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches)
       if (skip) {
         var el = document.getElementById('intro-overlay')
         if (el) el.classList.add('intro-idle')
@@ -482,7 +484,7 @@ import avatar from 'src/assets/avatar.png'
       if (card) card.classList.remove('show')
       hud.style.opacity = ''; hud.classList.remove('show')
       overlay.classList.remove('intro-idle'); overlay.classList.remove('intro-done')
-      try { sessionStorage.setItem('intro-seen', '1') } catch (e) {}
+      try { localStorage.setItem('intro-seen-at', String(Date.now())) } catch (e) {}
       trackIntro('intro_start', 'animation')
       start()
     }
@@ -503,7 +505,11 @@ import avatar from 'src/assets/avatar.png'
     if (replayBtn) replayBtn.addEventListener('click', function () { playSource = 'replay'; trackIntro('intro_replay', 'replay'); play('replay') })
 
     var seen = false
-    try { seen = sessionStorage.getItem('intro-seen') === '1' } catch (e) {}
+    // 与预渲染门一致：7 天内看过就算 seen，不自动重播。
+    try {
+      var seenAtMain = parseInt(localStorage.getItem('intro-seen-at') || '0', 10)
+      seen = seenAtMain > 0 && Date.now() - seenAtMain < 7 * 24 * 60 * 60 * 1000
+    } catch (e) {}
     if (!seen && !reduce) {
       var fontReady = document.fonts && document.fonts.load ? document.fonts.load('700 120px "Satoshi"') : null
       Promise.race([Promise.resolve(fontReady).catch(function () {}), new Promise(function (r) { setTimeout(r, 700) })]).then(function () { play('first_visit') })

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -7,6 +7,7 @@ import pencilIcon from '@/assets/tools/pencil.png'
 import hermesIcon from '@/assets/tools/hermes.png'
 
 const headings = [
+  { depth: 2, slug: 'summer-of-agents', text: 'Summer of Agents' },
   { depth: 2, slug: 'hobbies', text: 'Hobbies' },
   { depth: 2, slug: 'social-networks', text: 'Social Networks' },
   { depth: 2, slug: 'tools', text: 'Tools' },
@@ -25,6 +26,37 @@ const headings = [
     My motto: Build fast, learn faster. <Spoiler></Spoiler>
   </p>
   <Button title='Sponsor Me' class='w-fit' href='/projects#sponsorship' style='ahead' />
+
+  {/* summer-of-agents */}
+  <h2 id='summer-of-agents'>Summer of Agents</h2>
+  <p>
+    今年夏天我在粉丝群里发起了「第一届 Joye 粉丝 Agent 比赛」——十几个赛道任你选，也可以自命题开一队。
+    公开报名已经截止，现在是组队阶段，参赛、围观、找队友都欢迎，说不定还会有第二届 😄
+  </p>
+  <a
+    href='/agent-teams'
+    class='not-prose group my-2 flex flex-col gap-3 rounded-2xl border p-5 no-underline transition-all hover:-translate-y-0.5 hover:shadow-sm sm:flex-row sm:items-center sm:justify-between sm:gap-6'
+  >
+    <span class='min-w-0'>
+      <span class='flex flex-wrap items-center gap-2 text-xs font-medium'>
+        <span
+          class='rounded-full border border-amber-500/40 bg-amber-500/15 px-2 py-0.5 text-amber-700 dark:text-amber-300'
+        >
+          第一届
+        </span>
+        <span class='text-muted-foreground'>Joye 粉丝 Agent 比赛 · 组队报名</span>
+      </span>
+      <span class='mt-1.5 block text-xl font-bold text-foreground sm:text-2xl'>Summer of Agents</span>
+      <span class='mt-1 block text-sm leading-relaxed text-muted-foreground'>
+        选一个感兴趣的赛道组队，或者自命题开一队。
+      </span>
+    </span>
+    <span
+      class='inline-flex shrink-0 items-center gap-1 self-start rounded-full border px-4 py-2 text-sm font-medium text-foreground transition-transform group-hover:translate-x-0.5 sm:self-center'
+    >
+      去组队 →
+    </span>
+  </a>
 
   {/* general-talk */}
   <h2 id='hobbies'>Hobbies</h2>

--- a/src/pages/en/about/index.astro
+++ b/src/pages/en/about/index.astro
@@ -7,6 +7,7 @@ import pencilIcon from '@/assets/tools/pencil.png'
 import hermesIcon from '@/assets/tools/hermes.png'
 
 const headings = [
+  { depth: 2, slug: 'summer-of-agents', text: 'Summer of Agents' },
   { depth: 2, slug: 'hobbies', text: 'Hobbies' },
   { depth: 2, slug: 'social-networks', text: 'Social Networks' },
   { depth: 2, slug: 'tools', text: 'Tools' },
@@ -27,6 +28,38 @@ const headings = [
     My motto: Build fast, learn faster. <Spoiler></Spoiler>
   </p>
   <Button title='Sponsor Me' class='w-fit' href='/en/projects#sponsorship' style='ahead' />
+
+  {/* summer-of-agents */}
+  <h2 id='summer-of-agents'>Summer of Agents</h2>
+  <p>
+    This summer I kicked off the first Joye fan-group Agent competition — a dozen-plus tracks to pick
+    from, or propose your own. Public sign-ups have closed and it's now the team-up phase; the board
+    is in Chinese, but you're welcome to browse, join a team, or just spectate.
+  </p>
+  <a
+    href='/agent-teams'
+    class='not-prose group my-2 flex flex-col gap-3 rounded-2xl border p-5 no-underline transition-all hover:-translate-y-0.5 hover:shadow-sm sm:flex-row sm:items-center sm:justify-between sm:gap-6'
+  >
+    <span class='min-w-0'>
+      <span class='flex flex-wrap items-center gap-2 text-xs font-medium'>
+        <span
+          class='rounded-full border border-amber-500/40 bg-amber-500/15 px-2 py-0.5 text-amber-700 dark:text-amber-300'
+        >
+          1st edition
+        </span>
+        <span class='text-muted-foreground'>Joye fan-group Agent competition</span>
+      </span>
+      <span class='mt-1.5 block text-xl font-bold text-foreground sm:text-2xl'>Summer of Agents</span>
+      <span class='mt-1 block text-sm leading-relaxed text-muted-foreground'>
+        Pick a track and team up, or start your own.
+      </span>
+    </span>
+    <span
+      class='inline-flex shrink-0 items-center gap-1 self-start rounded-full border px-4 py-2 text-sm font-medium text-foreground transition-transform group-hover:translate-x-0.5 sm:self-center'
+    >
+      Team up →
+    </span>
+  </a>
 
   {/* hobbies */}
   <h2 id='hobbies'>Hobbies</h2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -606,13 +606,15 @@ const agentHackathonLink =
         root.dataset.state = state
         panel.classList.toggle('hidden', state !== 'open')
         root.classList.toggle('hidden', state === 'closed')
-        window.localStorage.setItem(storageKey, state)
+        // 关闭只在本次会话记住（sessionStorage）——下次访问弹窗会重新出现，
+        // 不像以前 localStorage 那样关一次就永久消失。
+        window.sessionStorage.setItem(storageKey, state)
         if (state === 'open') typeText()
         scheduleNudge()
       }
 
-      // 只剩 open / closed 两态；历史上被「收进角落」存成 minimized 的当作 open。
-      const savedState = window.localStorage.getItem(storageKey)
+      // 只剩 open / closed 两态；只认本次会话的关闭状态。
+      const savedState = window.sessionStorage.getItem(storageKey)
       setState(savedState === 'closed' ? 'closed' : 'open')
 
       closeButton?.addEventListener('click', () => setState('closed'))


### PR DESCRIPTION
## What

Three frontend tweaks around the Agent competition ("Summer of Agents") entry points and the homepage intro:

1. **Entrance animation — throttle to once per 24h.** It was gated by `sessionStorage` (`intro-seen`), so it replayed on every new tab / browser session and felt too frequent. Now gated by a `localStorage` timestamp (`intro-seen-at`) with a 24-hour cooldown. The 重播 (replay) button still forces a replay regardless.
2. **Bottom-left competition popout — dismissal is per-session, not permanent.** Closing wrote `closed` to `localStorage`, so once dismissed the popout never came back. Switched to `sessionStorage`: a close hides it for the current visit, but it returns next session. This also un-banishes users who had previously dismissed it (the stale `localStorage` key is now ignored).
3. **About page — new "Summer of Agents" section (zh + en).** Surfaces the competition beyond the homepage: a short intro plus an entry card linking to `/agent-teams`, registered in the page's table of contents. The EN About links to the same board (the board itself is Chinese-only).

## Why

- The intro animation was reappearing too often for repeat visitors.
- The popout disappearing forever after a single accidental close was bad UX for what is now a flagship activity.
- The competition only lived on the homepage; it needed a discoverable home elsewhere.

## Reviewer notes

- Both storage-gate changes are client-side only; no server/API changes.
- Cooldown is a single inlined constant (`24 * 60 * 60 * 1000`) in two spots of `IntroOverlay.astro` (the pre-paint gate + the main script) — easy to tune.
- `bun run check` passes (0 errors). Verified in preview: popout close writes `sessionStorage` (not `localStorage`), intro cooldown logic behaves (fresh→play, just-saw→skip, >24h→play), and the About section renders + appears in the TOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)