### PR TITLE
feat: add blurred icon transition to theme and language toggles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Project references
 
 - Analytics tracking contract: `ANALYTICS.md`. Check this before adding, renaming, or changing Vercel Analytics events.
+- UI/motion conventions: `DESIGN.md`. Check this before adding new interactive UI or transitions, so components reuse existing patterns (e.g. the Blurred Icon Transition) instead of inventing new ones.
 
 ## Git workflow
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,51 @@
+# Design Conventions
+
+This file collects small UI/motion philosophies for this site. Check it before
+adding or reviewing interactive UI so new components stay consistent with
+existing ones instead of reinventing a pattern.
+
+## Motion
+
+### No instant state swaps
+
+When a control has more than one visual state (an icon, a label, an
+expanded/collapsed panel), do not swap between states with `display:none` /
+`display:block` or a hard content replace. An instant swap reads as a glitch,
+not a change. Prefer a short transition that make the change feel intentional.
+
+### Blurred Icon Transition
+
+The default crossfade for a control that swaps between a small set of icons
+or labels (theme toggle, language switch, any future "cycle through options"
+button):
+
+- Stack every state in the same position (`position: absolute; inset: 0;
+margin: auto;` inside a `position: relative` container), instead of only
+  rendering the active one.
+- The outgoing state animates to `opacity: 0`, `filter: blur(4px)`,
+  `transform: scale(0.6)`.
+- The incoming state animates to `opacity: 1`, `filter: blur(0)`,
+  `transform: scale(1)`.
+- Both transition over `0.25s ease` on `opacity`, `filter`, and `transform`.
+- Always add a `prefers-reduced-motion: reduce` override that removes the
+  transition (state still changes, just without the animation).
+
+Reference implementations:
+
+- [`Header.astro`](src/components/Header.astro) — theme toggle button
+  (system/light/dark icons), swap is in-place via a `data-theme` attribute.
+- [`LanguageSwitcher.astro`](src/components/LanguageSwitcher.astro) — the
+  language switch navigates to a different page (no in-place state), so the
+  same blur+scale motion is played as a ~250ms exit animation before the
+  navigation fires, instead of navigating instantly on click.
+
+Use this same recipe for any new control that has this shape, rather than
+inventing a different transition style per component.
+
+## Motion always respects reduced motion
+
+Every animation/transition added to the site must have a
+`@media (prefers-reduced-motion: reduce)` override. Look at existing
+components (`Header.astro`, `LanguageSwitcher.astro`, `IntroOverlay.astro`,
+`BackToTop.astro`, `TableOfContents.astro`) for the pattern before adding a
+new one.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -84,12 +84,12 @@ const searchHref = localizedPath('/search', lang)
       </button>
       <button
         id='toggleDarkMode'
-        class='group/dark box-content size-5 rounded-md border p-1.5 transition-colors hover:bg-border sm:group-[.not-top]:rounded-xl'
+        class='group/dark relative box-content size-5 rounded-md border p-1.5 transition-colors hover:bg-border sm:group-[.not-top]:rounded-xl'
       >
         <span class='sr-only'>{t('nav.toggleDarkMode')}</span>
-        <Icon class='system size-5 group-hover/dark:text-primary' name='computer' />
-        <Icon class='light hidden size-5 group-hover/dark:text-primary' name='sun' />
-        <Icon class='dark hidden size-5 group-hover/dark:text-primary' name='moon' />
+        <Icon class='theme-icon system size-5 group-hover/dark:text-primary' name='computer' />
+        <Icon class='theme-icon light size-5 group-hover/dark:text-primary' name='sun' />
+        <Icon class='theme-icon dark size-5 group-hover/dark:text-primary' name='moon' />
       </button>
       <button
         id='toggleMenu'
@@ -268,21 +268,52 @@ const searchHref = localizedPath('/search', lang)
 
   /* dark light mode toggle */
   #toggleDarkMode {
+    & .theme-icon {
+      position: absolute;
+      inset: 0;
+      margin: auto;
+      opacity: 0;
+      filter: blur(4px);
+      transform: scale(0.6);
+      transition:
+        opacity 0.25s ease,
+        filter 0.25s ease,
+        transform 0.25s ease;
+      pointer-events: none;
+    }
+    & .system {
+      opacity: 1;
+      filter: blur(0);
+      transform: scale(1);
+    }
     &[data-theme='dark'] {
       & .system {
-        display: none;
+        opacity: 0;
+        filter: blur(4px);
+        transform: scale(0.6);
       }
       & .dark {
-        display: block;
+        opacity: 1;
+        filter: blur(0);
+        transform: scale(1);
       }
     }
     &[data-theme='light'] {
       & .system {
-        display: none;
+        opacity: 0;
+        filter: blur(4px);
+        transform: scale(0.6);
       }
-      .light {
-        display: block;
+      & .light {
+        opacity: 1;
+        filter: blur(0);
+        transform: scale(1);
       }
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    #toggleDarkMode .theme-icon {
+      transition: none;
     }
   }
 </style>

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -17,11 +17,13 @@ const label = lang === 'en' ? '中' : 'EN'
   class='box-content flex size-5 items-center justify-center rounded-md border p-1.5 text-xs font-semibold leading-none transition-colors hover:bg-border hover:text-primary sm:group-[.not-top]:rounded-xl'
 >
   <span class='sr-only'>{t('nav.toggleLang')}</span>
-  <span aria-hidden='true'>{label}</span>
+  <span class='lang-label' aria-hidden='true'>{label}</span>
 </button>
 
 <script>
   import { trackSiteEvent } from '@/lib/analytics'
+
+  const LEAVE_DURATION = 250
 
   function targetPathname(pathname: string, current: 'zh' | 'en'): string {
     if (current === 'en') {
@@ -45,6 +47,40 @@ const label = lang === 'en' ? '中' : 'EN'
       to_locale: current === 'en' ? 'zh' : 'en',
       target_path: next
     })
-    window.location.href = next + window.location.search + window.location.hash
+
+    const destination = next + window.location.search + window.location.hash
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduceMotion) {
+      window.location.href = destination
+      return
+    }
+
+    btn.classList.add('leaving')
+    window.setTimeout(() => {
+      window.location.href = destination
+    }, LEAVE_DURATION)
   })
 </script>
+
+<style>
+  .lang-label {
+    display: inline-block;
+    opacity: 1;
+    filter: blur(0);
+    transform: scale(1);
+    transition:
+      opacity 0.25s ease,
+      filter 0.25s ease,
+      transform 0.25s ease;
+  }
+  #toggleLang.leaving .lang-label {
+    opacity: 0;
+    filter: blur(4px);
+    transform: scale(0.6);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .lang-label {
+      transition: none;
+    }
+  }
+</style>


### PR DESCRIPTION
Theme toggle icons (system/light/dark) and the language switch label now crossfade with a blur+scale motion instead of an instant swap. The language switch plays the exit half of the animation before navigating, since it's a full page change rather than an in-place toggle.

- Stack icon states absolutely and crossfade opacity/filter/transform instead of `display:none`/`block`.
- Added `DESIGN.md` documenting the "Blurred Icon Transition" recipe and reduced-motion requirement, referenced from `CLAUDE.md`.

Notes: both transitions respect `prefers-reduced-motion`.