### PR TITLE
feat: add design command to download DESIGN.md

### DIFF
--- a/src/components/terminal/Terminal.astro
+++ b/src/components/terminal/Terminal.astro
@@ -8,7 +8,7 @@ const fs = await buildSiteFs()
 <div class='wt-intro' aria-hidden='true'>
   <span class='wt-intro-tag'>// power user?</span>
   <span class='wt-intro-text'>
-    Skip the scroll — try the interactive CLI. Type <code>help</code>, <code>chat</code>, or <code>ls /blog</code>.
+    Skip the scroll — try the interactive CLI. Type <code>help</code>, <code>design</code>, or <code>ls /blog</code>.
   </span>
 </div>
 <TerminalShell client:load fs={fs} />

--- a/src/components/terminal/TerminalShell.tsx
+++ b/src/components/terminal/TerminalShell.tsx
@@ -134,7 +134,7 @@ function MatrixRain() {
 }
 
 const COLLAPSE_KEY = 'wt-collapsed'
-const PEEK_DEMOS = ['whoami', 'help', 'ls blog', 'chat hire-me', 'theme dark', 'matrix']
+const PEEK_DEMOS = ['whoami', 'help', 'ls blog', 'chat hire-me', 'design', 'theme dark', 'matrix']
 
 export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props) {
   const [entries, setEntries] = useState<RenderEntry[]>([])

--- a/src/components/terminal/commands.tsx
+++ b/src/components/terminal/commands.tsx
@@ -428,6 +428,33 @@ export const commands: CommandRegistry = {
     }
   },
 
+  design: {
+    name: 'design',
+    summary: 'download DESIGN.md',
+    run: ({ push }) => {
+      const href = '/api/design.md'
+      push([
+        { kind: 'text', tone: 'muted', text: 'downloading design.md…' },
+        {
+          kind: 'node',
+          node: (
+            <a className='wt-link' href={href} download='design.md'>
+              {href}
+            </a>
+          )
+        }
+      ])
+      if (typeof document !== 'undefined') {
+        const a = document.createElement('a')
+        a.href = href
+        a.download = 'design.md'
+        document.body.appendChild(a)
+        a.click()
+        a.remove()
+      }
+    }
+  },
+
   chat: {
     name: 'chat',
     summary: 'talk to my agent (mock)',

--- a/src/pages/api/design.md.ts
+++ b/src/pages/api/design.md.ts
@@ -1,0 +1,14 @@
+import type { APIRoute } from 'astro'
+
+// Vite root == repo root, so this resolves at build time — no runtime
+// filesystem read, which keeps it safe on Vercel's serverless functions.
+import designMd from '../../../DESIGN.md?raw'
+
+export const GET: APIRoute = () =>
+  new Response(designMd, {
+    headers: {
+      'content-type': 'text/markdown; charset=utf-8',
+      'content-disposition': 'attachment; filename="design.md"',
+      'cache-control': 'public, max-age=300, s-maxage=86400'
+    }
+  })


### PR DESCRIPTION
Adds a `design` terminal command on the homepage that one-click downloads `DESIGN.md`.

- `/api/design.md` serves the file's raw content (bundled at build time) with `Content-Disposition: attachment` so hitting it triggers a real download.
- New `design` command in the shared terminal command registry — shows up in `help` automatically, works in both the homepage terminal and dev mode.
- Swapped `chat` for `design` in the "Skip the scroll" intro hint (chat is still a mock agent) and added `design` to the collapsed-terminal typing demo.

Notes: `bun run check` passes; verified locally that `design` fetches `/api/design.md` (200, attachment header) and triggers the browser download.