### PR TITLE
feat(agent-teams): overhaul the Summer of Agents board UI

### DIFF
--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -400,6 +400,9 @@ import { activity, teams } from '@/data/agent-teams'
     );
   }
   .board-title {
+    /* text-5xl 默认 line-height:1，行框正好等于字号，会让 g/y 这类降部字母露到框外
+       盖住下面的段落。加回一点行高留出降部空间。 */
+    line-height: 1.15 !important;
     background-image: linear-gradient(to right, #fbbf24, #f59e0b, #f97316);
     -webkit-background-clip: text;
     background-clip: text;

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -59,7 +59,7 @@ import { activity, teams } from '@/data/agent-teams'
     {
       teams.map((team) => (
         <article
-          class='team-card relative flex flex-col gap-3 rounded-xl border bg-background p-4 sm:p-5 sm:min-h-[23rem]'
+          class='team-card relative flex flex-col gap-3 rounded-xl border bg-background p-4 sm:p-5 sm:min-h-[15rem]'
           data-team-id={team.id}
           data-capacity={team.capacity ?? ''}
           data-loaded='false'
@@ -86,20 +86,13 @@ import { activity, teams } from '@/data/agent-teams'
             </div>
           )}
 
-          <div class='flex flex-col items-start gap-1.5' data-detail-wrap>
-            <div
-              class='team-detail hidden w-full whitespace-pre-wrap rounded-lg border border-dashed px-3 py-2 text-sm leading-relaxed text-muted-foreground'
-              data-detail
-            >
-            </div>
-            <button
-              type='button'
-              class='detail-toggle hidden text-xs font-medium text-foreground underline-offset-4 hover:underline'
-              data-detail-toggle
-            >
-              展开
-            </button>
-          </div>
+          <button
+            type='button'
+            class='detail-toggle hidden items-center gap-1 self-start text-xs font-medium text-foreground underline-offset-4 hover:underline'
+            data-detail-toggle
+          >
+            📄 查看详细介绍
+          </button>
 
           <ul class='roster m-0 flex list-none flex-wrap gap-1.5 p-0' data-roster>
             <li class='roster-empty flex gap-1.5'>
@@ -406,6 +399,17 @@ import { activity, teams } from '@/data/agent-teams'
       </div>
     </form>
   </div>
+
+  {/* 「详细介绍」弹窗：全站共用一个，点开哪张卡就把内容填进来再 showModal。 */}
+  <dialog class='detail-dialog' data-detail-dialog>
+    <form method='dialog' class='detail-dialog-inner'>
+      <div class='detail-dialog-head'>
+        <h3 class='m-0 text-base font-medium text-foreground' data-detail-dialog-title></h3>
+        <button type='submit' class='detail-dialog-close' aria-label='关闭'>✕</button>
+      </div>
+      <div class='detail-dialog-body' data-detail-dialog-body></div>
+    </form>
+  </dialog>
 </section>
 
 <style>
@@ -513,21 +517,55 @@ import { activity, teams } from '@/data/agent-teams'
     }
   }
 
-  /* 详细介绍：默认只显示 4 行，超出的靠「展开」按钮撑开，让卡片高度不会被长文本拉得参差不齐。
-     :not([hidden]) 很重要——没有它，这条规则的优先级会盖过 .hidden / [hidden]，
-     让空的介绍框也变成一个可见的虚线方块。 */
-  .team-detail:not([data-expanded]):not([hidden]) {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 4;
-    overflow: hidden;
+  /* 详细介绍不再撑在卡片里——点「查看详细介绍」弹一个共用的 <dialog>，
+     卡片高度就不会因为有没有写详细介绍而参差不齐。 */
+  .detail-toggle:not(.hidden) {
+    display: inline-flex;
   }
-  .team-detail[data-expanded] {
-    display: block;
+
+  .detail-dialog {
+    width: min(92vw, 34rem);
+    max-height: 80vh;
+    padding: 0;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius, 0.75rem);
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
-  .detail-toggle[data-show] {
-    display: inline-block;
-    align-self: flex-start;
+  .detail-dialog::backdrop {
+    background: rgb(0 0 0 / 0.5);
+  }
+  .detail-dialog-inner {
+    display: flex;
+    flex-direction: column;
+    max-height: 80vh;
+  }
+  .detail-dialog-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid hsl(var(--border));
+  }
+  .detail-dialog-close {
+    border: none;
+    background: transparent;
+    padding: 0.25rem;
+    line-height: 1;
+    cursor: pointer;
+    color: hsl(var(--muted-foreground));
+  }
+  .detail-dialog-close:hover {
+    color: hsl(var(--foreground));
+  }
+  .detail-dialog-body {
+    overflow-y: auto;
+    padding: 1rem 1.25rem;
+    white-space: pre-wrap;
+    font-size: 0.875rem;
+    line-height: 1.7;
+    color: hsl(var(--muted-foreground));
   }
 
   .signup-form[data-open] {
@@ -640,34 +678,15 @@ import { activity, teams } from '@/data/agent-teams'
   }
 
   function renderDetail(card: HTMLElement, value: string | null) {
-    const box = card.querySelector<HTMLElement>('[data-detail]')
-    const toggle = card.querySelector<HTMLButtonElement>('[data-detail-toggle]')
-    if (!box) return
     const detail = value ?? ''
-    box.textContent = detail // textContent + pre-wrap — 用户输入不当 HTML 解析
-    box.removeAttribute('data-expanded') // 每次拿到新数据都先收起，避免旧的展开状态错位
-    const empty = detail.length === 0
-    box.hidden = empty
-    box.classList.toggle('hidden', empty)
-    // 缓存当前值，供队长编辑表单预填
+    // 缓存当前值：卡片本身不再铺开显示，只在弹窗和队长编辑表单预填时用它。
     card.dataset.detail = detail
 
+    const toggle = card.querySelector<HTMLButtonElement>('[data-detail-toggle]')
     if (!toggle) return
-    if (empty) {
-      delete toggle.dataset.show
-      toggle.hidden = true
-      toggle.classList.add('hidden')
-      return
-    }
-    toggle.textContent = '展开'
-    // 等一帧让 line-clamp 布局完成，再判断文本是否真的被裁掉——没超出就不显示按钮。
-    requestAnimationFrame(() => {
-      const overflowing = box.scrollHeight - box.clientHeight > 1
-      toggle.hidden = !overflowing
-      toggle.classList.toggle('hidden', !overflowing)
-      if (overflowing) toggle.dataset.show = ''
-      else delete toggle.dataset.show
-    })
+    const empty = detail.length === 0
+    toggle.hidden = empty
+    toggle.classList.toggle('hidden', empty)
   }
 
   function renderRoster(card: HTMLElement, team: Team) {
@@ -789,36 +808,29 @@ import { activity, teams } from '@/data/agent-teams'
 
     renderMeta(card, team)
 
-    const detail = card.querySelector<HTMLElement>('[data-detail]')
-    if (detail) {
-      detail.textContent = ''
-      detail.removeAttribute('data-expanded')
-      detail.hidden = true
-      detail.classList.add('hidden')
-    }
     const detailToggle = card.querySelector<HTMLButtonElement>('[data-detail-toggle]')
     if (detailToggle) {
-      delete detailToggle.dataset.show
       detailToggle.hidden = true
       detailToggle.classList.add('hidden')
     }
     return card
   }
 
+  // 「查看详细介绍」弹窗：全站共用一个 <dialog>，点开哪张卡就把标题/正文填进去再弹出。
+  function openDetailDialog(board: HTMLElement, card: HTMLElement) {
+    const dialog = board.querySelector<HTMLDialogElement>('[data-detail-dialog]')
+    if (!dialog) return
+    const titleEl = dialog.querySelector<HTMLElement>('[data-detail-dialog-title]')
+    const bodyEl = dialog.querySelector<HTMLElement>('[data-detail-dialog-body]')
+    if (titleEl) titleEl.textContent = card.querySelector('[data-title]')?.textContent ?? ''
+    if (bodyEl) bodyEl.textContent = card.dataset.detail ?? ''
+    dialog.showModal()
+  }
+
   function wireCard(card: HTMLElement, board: HTMLElement) {
-    // 「详细介绍」展开/收起：内容默认裁到 4 行，卡片高度才不会被长文本撑得参差不齐。
-    const detailBox = card.querySelector<HTMLElement>('[data-detail]')
-    const detailExpandToggle = card.querySelector<HTMLButtonElement>('[data-detail-toggle]')
-    detailExpandToggle?.addEventListener('click', () => {
-      const expanded = detailBox?.hasAttribute('data-expanded')
-      if (expanded) {
-        detailBox?.removeAttribute('data-expanded')
-        detailExpandToggle.textContent = '展开'
-      } else {
-        detailBox?.setAttribute('data-expanded', '')
-        detailExpandToggle.textContent = '收起'
-      }
-    })
+    card
+      .querySelector<HTMLButtonElement>('[data-detail-toggle]')
+      ?.addEventListener('click', () => openDetailDialog(board, card))
 
     const toggle = card.querySelector<HTMLButtonElement>('[data-signup-toggle]')
     const form = card.querySelector<HTMLFormElement>('[data-signup-form]')

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -41,6 +41,11 @@ import { activity, teams } from '@/data/agent-teams'
     </p>
   </header>
 
+  {/* 首次拉取名单 / 自定义赛道期间的进度条，加载完成后由脚本隐藏 */}
+  <div class='board-loading-bar mb-5' data-board-loading role='status' aria-label='正在加载赛道数据…'>
+    <span class='board-loading-fill'></span>
+  </div>
+
   {/* 未配置 / 加载失败时的横幅，默认隐藏，由脚本控制 */}
   <p
     class='board-banner mb-5 hidden rounded-lg border border-dashed px-4 py-3 text-sm text-muted-foreground'
@@ -54,17 +59,18 @@ import { activity, teams } from '@/data/agent-teams'
     {
       teams.map((team) => (
         <article
-          class='team-card relative flex flex-col gap-3 rounded-xl border bg-background p-4 sm:p-5'
+          class='team-card relative flex flex-col gap-3 rounded-xl border bg-background p-4 sm:p-5 sm:min-h-[23rem]'
           data-team-id={team.id}
           data-capacity={team.capacity ?? ''}
+          data-loaded='false'
         >
           <div class='flex items-start justify-between gap-3'>
             <h2 class='m-0 text-lg font-medium text-foreground' data-title>{team.title}</h2>
             <span
-              class='shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground'
+              class='skeleton inline-block h-5 w-14 shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground'
               data-count-label
             >
-              …
+              <span class='sr-only'>人数加载中…</span>
             </span>
           </div>
 
@@ -80,14 +86,27 @@ import { activity, teams } from '@/data/agent-teams'
             </div>
           )}
 
-          <div
-            class='team-detail hidden whitespace-pre-wrap rounded-lg border border-dashed px-3 py-2 text-sm leading-relaxed text-muted-foreground'
-            data-detail
-          >
+          <div class='flex flex-col items-start gap-1.5' data-detail-wrap>
+            <div
+              class='team-detail hidden w-full whitespace-pre-wrap rounded-lg border border-dashed px-3 py-2 text-sm leading-relaxed text-muted-foreground'
+              data-detail
+            >
+            </div>
+            <button
+              type='button'
+              class='detail-toggle hidden text-xs font-medium text-foreground underline-offset-4 hover:underline'
+              data-detail-toggle
+            >
+              展开
+            </button>
           </div>
 
           <ul class='roster m-0 flex list-none flex-wrap gap-1.5 p-0' data-roster>
-            <li class='roster-empty text-xs text-muted-foreground'>加载中…</li>
+            <li class='roster-empty flex gap-1.5'>
+              <span class='sr-only'>名单加载中…</span>
+              <span class='skeleton h-5 w-16 rounded-full' aria-hidden='true'></span>
+              <span class='skeleton h-5 w-12 rounded-full' aria-hidden='true'></span>
+            </li>
           </ul>
 
           <div class='mt-auto flex flex-wrap items-center gap-2 pt-1'>
@@ -420,6 +439,91 @@ import { activity, teams } from '@/data/agent-teams'
     overflow: hidden;
   }
 
+  /* 骨架屏：名单 / 人数还没从接口拉回来之前的占位动画。 */
+  .skeleton {
+    position: relative;
+    overflow: hidden;
+    color: transparent !important;
+    background: hsl(var(--muted));
+  }
+  .skeleton::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, hsl(var(--foreground) / 0.12), transparent);
+    animation: skeleton-shimmer 1.4s ease-in-out infinite;
+  }
+  @keyframes skeleton-shimmer {
+    from {
+      transform: translateX(-100%);
+    }
+    to {
+      transform: translateX(100%);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton::after {
+      animation: none;
+    }
+  }
+  /* 数据到手后脚本会把这些元素换成真实内容并摘掉 .skeleton，这里只是兜底防止残留动画。 */
+  [data-loaded='true'] .skeleton {
+    animation: none;
+  }
+
+  /* 顶部细进度条：首次拉取赛道数据期间显示，拉完（无论成功与否）就淡出。 */
+  .board-loading-bar {
+    height: 3px;
+    border-radius: 999px;
+    background: hsl(var(--muted));
+    overflow: hidden;
+    opacity: 1;
+    transition: opacity 0.3s ease;
+  }
+  .board-loading-bar[data-done] {
+    opacity: 0;
+    pointer-events: none;
+  }
+  .board-loading-fill {
+    display: block;
+    height: 100%;
+    width: 40%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #fbbf24, #f97316);
+    animation: board-loading-slide 1.1s ease-in-out infinite;
+  }
+  @keyframes board-loading-slide {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(250%);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .board-loading-fill {
+      animation: none;
+      width: 100%;
+    }
+  }
+
+  /* 详细介绍：默认只显示 4 行，超出的靠「展开」按钮撑开，让卡片高度不会被长文本拉得参差不齐。
+     :not([hidden]) 很重要——没有它，这条规则的优先级会盖过 .hidden / [hidden]，
+     让空的介绍框也变成一个可见的虚线方块。 */
+  .team-detail:not([data-expanded]):not([hidden]) {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+    overflow: hidden;
+  }
+  .team-detail[data-expanded] {
+    display: block;
+  }
+  .detail-toggle[data-show] {
+    display: inline-block;
+    align-self: flex-start;
+  }
+
   .signup-form[data-open] {
     display: flex;
   }
@@ -531,19 +635,42 @@ import { activity, teams } from '@/data/agent-teams'
 
   function renderDetail(card: HTMLElement, value: string | null) {
     const box = card.querySelector<HTMLElement>('[data-detail]')
+    const toggle = card.querySelector<HTMLButtonElement>('[data-detail-toggle]')
     if (!box) return
     const detail = value ?? ''
     box.textContent = detail // textContent + pre-wrap — 用户输入不当 HTML 解析
-    box.hidden = detail.length === 0
-    box.classList.toggle('hidden', detail.length === 0)
+    box.removeAttribute('data-expanded') // 每次拿到新数据都先收起，避免旧的展开状态错位
+    const empty = detail.length === 0
+    box.hidden = empty
+    box.classList.toggle('hidden', empty)
     // 缓存当前值，供队长编辑表单预填
     card.dataset.detail = detail
+
+    if (!toggle) return
+    if (empty) {
+      delete toggle.dataset.show
+      toggle.hidden = true
+      toggle.classList.add('hidden')
+      return
+    }
+    toggle.textContent = '展开'
+    // 等一帧让 line-clamp 布局完成，再判断文本是否真的被裁掉——没超出就不显示按钮。
+    requestAnimationFrame(() => {
+      const overflowing = box.scrollHeight - box.clientHeight > 1
+      toggle.hidden = !overflowing
+      toggle.classList.toggle('hidden', !overflowing)
+      if (overflowing) toggle.dataset.show = ''
+      else delete toggle.dataset.show
+    })
   }
 
   function renderRoster(card: HTMLElement, team: Team) {
     const capacity = team.capacity
     const label = card.querySelector<HTMLElement>('[data-count-label]')
-    if (label) label.textContent = capacity != null ? `${team.count} / ${capacity} 人` : `${team.count} 人`
+    if (label) {
+      label.classList.remove('skeleton')
+      label.textContent = capacity != null ? `${team.count} / ${capacity} 人` : `${team.count} 人`
+    }
 
     const full = capacity != null && team.count >= capacity
     card.dataset.full = full ? 'true' : 'false'
@@ -564,15 +691,13 @@ import { activity, teams } from '@/data/agent-teams'
       return
     }
     // 队长：以 team.captain（后台转让后的 name_key）为准；没设 / 已退队则默认第一个报名的人。
-    // 只有 2 人及以上才标队长——一个人的卡片没必要区分。
+    // 唯一的队员也算队长——个人赛道就是靠这个拿到编辑主题的权限。
     let captainIndex = -1
-    if (team.members.length > 1) {
-      const captainKey = team.captain ? team.captain.toLowerCase() : null
-      if (captainKey) {
-        captainIndex = team.members.findIndex((m) => m.name.toLowerCase() === captainKey)
-      }
-      if (captainIndex < 0) captainIndex = 0
+    const captainKey = team.captain ? team.captain.toLowerCase() : null
+    if (captainKey) {
+      captainIndex = team.members.findIndex((m) => m.name.toLowerCase() === captainKey)
     }
+    if (captainIndex < 0) captainIndex = 0
     team.members.forEach((member, index) => {
       const li = document.createElement('li')
       li.className = 'roster-chip'
@@ -655,13 +780,34 @@ import { activity, teams } from '@/data/agent-teams'
     const detail = card.querySelector<HTMLElement>('[data-detail]')
     if (detail) {
       detail.textContent = ''
+      detail.removeAttribute('data-expanded')
       detail.hidden = true
       detail.classList.add('hidden')
+    }
+    const detailToggle = card.querySelector<HTMLButtonElement>('[data-detail-toggle]')
+    if (detailToggle) {
+      delete detailToggle.dataset.show
+      detailToggle.hidden = true
+      detailToggle.classList.add('hidden')
     }
     return card
   }
 
   function wireCard(card: HTMLElement, board: HTMLElement) {
+    // 「详细介绍」展开/收起：内容默认裁到 4 行，卡片高度才不会被长文本撑得参差不齐。
+    const detailBox = card.querySelector<HTMLElement>('[data-detail]')
+    const detailExpandToggle = card.querySelector<HTMLButtonElement>('[data-detail-toggle]')
+    detailExpandToggle?.addEventListener('click', () => {
+      const expanded = detailBox?.hasAttribute('data-expanded')
+      if (expanded) {
+        detailBox?.removeAttribute('data-expanded')
+        detailExpandToggle.textContent = '展开'
+      } else {
+        detailBox?.setAttribute('data-expanded', '')
+        detailExpandToggle.textContent = '收起'
+      }
+    })
+
     const toggle = card.querySelector<HTMLButtonElement>('[data-signup-toggle]')
     const form = card.querySelector<HTMLFormElement>('[data-signup-form]')
     if (!toggle || !form) return
@@ -915,6 +1061,7 @@ import { activity, teams } from '@/data/agent-teams'
       renderMeta(card, team) // 标题/简介/标签以 DB 为准，覆盖预渲染值
       renderRoster(card, team)
       renderDetail(card, team.detail)
+      card.dataset.loaded = 'true'
     }
 
     // 未配置：禁用「创建赛道」入口
@@ -1065,11 +1212,17 @@ import { activity, teams } from '@/data/agent-teams'
       }
     }
 
+    const hideLoadingBar = () => {
+      const bar = board.querySelector<HTMLElement>('[data-board-loading]')
+      if (bar) bar.dataset.done = ''
+    }
+
     const reload = () =>
       fetch('/api/agent-teams', { cache: 'no-store' })
         .then((res) => res.json())
         .then((data: BoardData) => applyState(board, grid, pristine ?? null, cards, data))
         .catch(showBannerError)
+        .finally(hideLoadingBar)
 
     wireCreateCard(board, reload)
     reload()

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -295,6 +295,14 @@ import { activity, teams } from '@/data/agent-teams'
     }
   </div>
 
+  {/* 分页控件：order-last 保证它排在赛道网格下面（而不是排到「创建赛道」下面）。 */}
+  <div
+    class='board-pagination order-last mb-4 flex items-center justify-center gap-3 text-sm text-muted-foreground'
+    data-board-pagination
+    hidden
+  >
+  </div>
+
   {/* 自命题：自助创建一个新赛道卡片（排在队伍列表上方） */}
   <div class='create-card mb-4 rounded-xl border border-dashed bg-background p-4 sm:p-5' data-create-card>
     <div class='flex items-start justify-between gap-3'>
@@ -314,59 +322,82 @@ import { activity, teams } from '@/data/agent-teams'
       </button>
     </div>
 
-    <form class='create-form mt-3 flex-col gap-2' data-create-form hidden>
-      <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
-        赛道名称
-        <input
-          class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
-          name='title'
-          type='text'
-          maxlength='30'
-          required
-          autocomplete='off'
-          placeholder='例如：会写周报的 Agent'
-        />
-      </label>
-      <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
-        一句话简介
-        <input
-          class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
-          name='summary'
-          type='text'
-          maxlength='80'
-          required
-          autocomplete='off'
-          placeholder='它能做什么，一句话说清'
-        />
-      </label>
+    <form class='create-form mt-4 flex-col gap-4' data-create-form hidden>
+      <div class='grid gap-3 sm:grid-cols-2'>
+        <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+          赛道名称
+          <input
+            class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
+            name='title'
+            type='text'
+            maxlength='30'
+            required
+            autocomplete='off'
+            placeholder='例如：会写周报的 Agent'
+          />
+        </label>
+        <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+          一句话简介
+          <input
+            class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
+            name='summary'
+            type='text'
+            maxlength='80'
+            required
+            autocomplete='off'
+            placeholder='它能做什么，一句话说清'
+          />
+        </label>
+      </div>
+
       <div class='flex flex-col gap-1.5 text-xs text-muted-foreground'>
         类型
-        <div class='flex flex-wrap gap-x-4 gap-y-1.5' data-create-kind>
-          <label class='inline-flex items-center gap-1.5'>
-            <input type='radio' name='kind' value='team' checked />
-            组队（多人一起做）
+        <div class='kind-picker grid grid-cols-2 gap-2' data-create-kind>
+          <label class='kind-option flex cursor-pointer flex-col gap-0.5 rounded-lg border px-3 py-2 transition-colors'>
+            <input class='sr-only' type='radio' name='kind' value='team' checked />
+            <span class='text-sm font-medium text-foreground'>👥 组队</span>
+            <span class='text-xs text-muted-foreground'>多人一起做，你自动当队长</span>
           </label>
-          <label class='inline-flex items-center gap-1.5'>
-            <input type='radio' name='kind' value='solo' />
-            个人（就我一个，别人不能加入）
+          <label class='kind-option flex cursor-pointer flex-col gap-0.5 rounded-lg border px-3 py-2 transition-colors'>
+            <input class='sr-only' type='radio' name='kind' value='solo' />
+            <span class='text-sm font-medium text-foreground'>🧍 个人</span>
+            <span class='text-xs text-muted-foreground'>就我一个，别人不能加入</span>
           </label>
         </div>
       </div>
-      <label
-        class='solo-name-field flex-col gap-1 text-xs text-muted-foreground'
-        data-solo-name-field
-        hidden
-      >
-        你的昵称（会公开显示，就是这张卡的人）
-        <input
-          class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
-          name='name'
-          type='text'
-          maxlength='24'
-          autocomplete='off'
-          placeholder='你的 QQ 昵称'
-        />
-      </label>
+
+      <div class='grid gap-3 sm:grid-cols-2'>
+        <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+          你的昵称（会公开显示，创建后自动加入并成为队长）
+          <input
+            class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
+            name='name'
+            type='text'
+            maxlength='24'
+            required
+            autocomplete='off'
+            placeholder='你的 QQ 昵称'
+          />
+        </label>
+        <label
+          class='team-capacity-field flex-col gap-1 text-xs text-muted-foreground'
+          data-team-capacity-field
+          data-show
+        >
+          名额上限（组队才需要，个人固定 1 人）
+          <input
+            class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
+            name='capacity'
+            type='number'
+            min='2'
+            max='999'
+            step='1'
+            value='10'
+            autocomplete='off'
+          />
+        </label>
+      </div>
+
       <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
         口令（粉丝群的名字）
         <input
@@ -593,8 +624,39 @@ import { activity, teams } from '@/data/agent-teams'
   .passcode-field[data-show] {
     display: flex;
   }
-  .solo-name-field[data-show] {
+  .team-capacity-field[data-show] {
     display: flex;
+  }
+  /* 类型选择做成两张可点的卡片而不是裸单选框：原生 radio 视觉隐藏，
+     用 :has() 给选中的那张卡描边高亮，比灰突突的圆点好认多了。 */
+  .kind-option {
+    border-color: hsl(var(--border));
+  }
+  .kind-option:hover {
+    background: hsl(var(--muted) / 0.5);
+  }
+  .kind-option:has(input:checked) {
+    border-color: rgb(245 158 11 / 0.6);
+    background: rgb(245 158 11 / 0.1);
+  }
+  .kind-option:has(input:focus-visible) {
+    outline: 2px solid rgb(245 158 11 / 0.5);
+    outline-offset: 1px;
+  }
+
+  /* 名单区域固定一个高度区间：人少不至于看起来很空，人多超出就滚动，
+     卡片高度才不会因为队伍人数差异忽高忽低。 */
+  .roster {
+    min-height: 1.75rem;
+    max-height: 3.75rem;
+    overflow-y: auto;
+  }
+  /* flex-wrap 容器里，中文/emoji 文本的 flex item 默认允许缩到 min-content
+     （几乎能在任意字符间断行），加了 max-height/overflow 后这个收缩会被放大成
+     一整列竖排字——用 flex-shrink:0 让它们按自然宽度换行，不要被压扁。 */
+  :global(.roster-chip),
+  :global(.roster-empty) {
+    flex-shrink: 0;
   }
 
   /* 名单是脚本动态渲染的，拿不到 Astro 的 scope 属性，故这几条都用 :global 才生效。 */
@@ -1073,6 +1135,63 @@ import { activity, teams } from '@/data/agent-teams'
     }
   }
 
+  // 赛道太多堆一页不好翻，按固定页大小分页；新建的自定义赛道加进来后也要重新计算页数。
+  const PAGE_SIZE = 8
+
+  function renderPagination(board: HTMLElement, cards: Map<string, HTMLElement>) {
+    const pager = board.querySelector<HTMLElement>('[data-board-pagination]')
+    if (!pager) return
+
+    const cardEls = [...cards.values()]
+    const pageCount = Math.max(1, Math.ceil(cardEls.length / PAGE_SIZE))
+    let page = Number.parseInt(board.dataset.page ?? '0', 10)
+    if (!Number.isFinite(page) || page < 0) page = 0
+    if (page > pageCount - 1) page = pageCount - 1
+    board.dataset.page = String(page)
+
+    cardEls.forEach((card, i) => {
+      const onPage = Math.floor(i / PAGE_SIZE) === page
+      card.hidden = !onPage
+      card.classList.toggle('hidden', !onPage)
+    })
+
+    pager.replaceChildren()
+    if (pageCount <= 1) {
+      pager.hidden = true
+      pager.classList.add('hidden')
+      return
+    }
+    pager.hidden = false
+    pager.classList.remove('hidden')
+
+    const pagerBtnClass =
+      'inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40'
+
+    const goTo = (next: number) => {
+      board.dataset.page = String(next)
+      renderPagination(board, cards)
+    }
+
+    const prev = document.createElement('button')
+    prev.type = 'button'
+    prev.className = pagerBtnClass
+    prev.textContent = '← 上一页'
+    prev.disabled = page === 0
+    prev.addEventListener('click', () => goTo(page - 1))
+
+    const label = document.createElement('span')
+    label.textContent = `第 ${page + 1} / ${pageCount} 页`
+
+    const next = document.createElement('button')
+    next.type = 'button'
+    next.className = pagerBtnClass
+    next.textContent = '下一页 →'
+    next.disabled = page === pageCount - 1
+    next.addEventListener('click', () => goTo(page + 1))
+
+    pager.append(prev, label, next)
+  }
+
   function applyState(
     board: HTMLElement,
     grid: HTMLElement | null,
@@ -1150,6 +1269,8 @@ import { activity, teams } from '@/data/agent-teams'
         })
       }
     }
+
+    renderPagination(board, cards)
   }
 
   // 「创建赛道」表单：提交成功后 reload 重新拉一次名单，新卡就会出现。
@@ -1160,16 +1281,19 @@ import { activity, teams } from '@/data/agent-teams'
     const form = wrap.querySelector<HTMLFormElement>('[data-create-form]')
     if (!toggle || !form) return
 
-    // 组队 / 个人切换：选「个人」才显示并要求填昵称。
-    const soloField = form.querySelector<HTMLElement>('[data-solo-name-field]')
-    const soloInput = soloField?.querySelector<HTMLInputElement>('input[name="name"]')
+    // 昵称现在两种类型都要填（创建者自动加入并当队长）；名额上限只有「组队」才需要。
+    const capacityField = form.querySelector<HTMLElement>('[data-team-capacity-field]')
     const syncKind = () => {
       const solo = form.querySelector<HTMLInputElement>('input[name="kind"]:checked')?.value === 'solo'
-      if (!soloField) return
-      if (solo) soloField.dataset.show = ''
-      else delete soloField.dataset.show
-      soloField.hidden = !solo
-      if (soloInput) soloInput.required = solo
+      if (capacityField) {
+        if (solo) {
+          delete capacityField.dataset.show
+          capacityField.hidden = true
+        } else {
+          capacityField.dataset.show = ''
+          capacityField.hidden = false
+        }
+      }
     }
     form
       .querySelectorAll<HTMLInputElement>('input[name="kind"]')
@@ -1195,12 +1319,15 @@ import { activity, teams } from '@/data/agent-teams'
       const submitBtn = form.querySelector<HTMLButtonElement>('button[type="submit"]')
       const data = new FormData(form)
       const kind = data.get('kind') === 'solo' ? 'solo' : 'team'
+      const capacityRaw = String(data.get('capacity') || '').trim()
       const payload = {
         action: 'create',
         kind,
         title: String(data.get('title') || ''),
         summary: String(data.get('summary') || ''),
         name: String(data.get('name') || ''),
+        // 只有「组队」才带名额上限；留空就交给后端按不限处理。
+        capacity: kind === 'team' && capacityRaw ? Number(capacityRaw) : undefined,
         passcode: String(data.get('passcode') || ''),
         hp: String(data.get('hp') || '')
       }
@@ -1216,7 +1343,7 @@ import { activity, teams } from '@/data/agent-teams'
         const body = await res.json()
         if (res.ok && body.ok) {
           form.reset()
-          syncKind() // 复位到「组队」并收起昵称框
+          syncKind() // 复位到「组队」并把名额字段收回默认值
           form.removeAttribute('data-open')
           form.hidden = true
           toggle.setAttribute('aria-expanded', 'false')
@@ -1253,6 +1380,8 @@ import { activity, teams } from '@/data/agent-teams'
       cards.set(id, card)
       wireCard(card, board)
     })
+    // 数据到手前先按 SSR 渲染出的静态赛道分页，首屏就不会把几十张卡全堆出来。
+    renderPagination(board, cards)
 
     const showBannerError = () => {
       const banner = board.querySelector<HTMLElement>('[data-board-banner]')

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -698,10 +698,16 @@ import { activity, teams } from '@/data/agent-teams'
       captainIndex = team.members.findIndex((m) => m.name.toLowerCase() === captainKey)
     }
     if (captainIndex < 0) captainIndex = 0
-    team.members.forEach((member, index) => {
+
+    // 队长排在名单最前面，其余人保持原来的报名顺序。
+    const ordered = [
+      team.members[captainIndex],
+      ...team.members.filter((_, index) => index !== captainIndex)
+    ]
+    ordered.forEach((member, index) => {
       const li = document.createElement('li')
       li.className = 'roster-chip'
-      if (index === captainIndex) {
+      if (index === 0) {
         li.classList.add('is-captain')
         li.appendChild(captainIcon())
       }

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -95,10 +95,17 @@ import { activity, teams } from '@/data/agent-teams'
           </button>
 
           <ul class='roster m-0 flex list-none flex-wrap gap-1.5 p-0' data-roster>
-            <li class='roster-empty flex gap-1.5'>
+            <li class='roster-empty flex flex-wrap gap-1.5'>
               <span class='sr-only'>名单加载中…</span>
-              <span class='skeleton h-5 w-16 rounded-full' aria-hidden='true'></span>
-              <span class='skeleton h-5 w-12 rounded-full' aria-hidden='true'></span>
+              {/* 骨架屏的人数跟着名额走（名额越大占位越多），加载完切成真名单时不会跳得太突兀。 */}
+              {Array.from({
+                length: Math.min(5, Math.max(2, team.capacity ? Math.round(team.capacity / 2.5) : 3))
+              }).map((_, i) => (
+                <span
+                  class={`skeleton h-5 rounded-full ${['w-16', 'w-12', 'w-14', 'w-10', 'w-16'][i % 5]}`}
+                  aria-hidden='true'
+                />
+              ))}
             </li>
           </ul>
 

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -602,6 +602,24 @@ import { activity, teams } from '@/data/agent-teams'
     line-height: 1.2;
     color: hsl(var(--foreground));
     background: hsl(var(--muted) / 0.4);
+    /* 名单一到手就按顺序从下往上弹出来，像一个个上台一样；--i 由脚本按序号写入。 */
+    animation: roster-pop-in 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+    animation-delay: calc(var(--i, 0) * 80ms);
+  }
+  @keyframes roster-pop-in {
+    from {
+      opacity: 0;
+      transform: translateY(0.6rem) scale(0.85);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    :global(.roster-chip) {
+      animation: none;
+    }
   }
   /* 队长：琥珀色描边 + 淡底，配一个小皇冠 */
   :global(.roster-chip.is-captain) {
@@ -732,6 +750,8 @@ import { activity, teams } from '@/data/agent-teams'
     ordered.forEach((member, index) => {
       const li = document.createElement('li')
       li.className = 'roster-chip'
+      // 一个个从下往上弹出来，像依次上台一样——用 --i 错开每个人的入场时机。
+      li.style.setProperty('--i', String(index))
       if (index === 0) {
         li.classList.add('is-captain')
         li.appendChild(captainIcon())

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -719,9 +719,10 @@ import { activity, teams } from '@/data/agent-teams'
 
   /* 名单区域固定一个高度区间：人少不至于看起来很空，人多超出就滚动，
      卡片高度才不会因为队伍人数差异忽高忽低。 */
+  /* 固定高度而不是 min/max 区间——1 个人的卡和 6 个人的卡，名单区域也要占同样高度，
+     后面的「查看详细介绍」/操作按钮才能在同一行的两张卡里对齐，不会一高一矮。 */
   .roster {
-    min-height: 1.75rem;
-    max-height: 3.75rem;
+    height: 3.75rem;
     overflow-y: auto;
   }
   /* flex-wrap 容器里，中文/emoji 文本的 flex item 默认允许缩到 min-content

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -297,17 +297,25 @@ import { activity, teams } from '@/data/agent-teams'
 
   {/* 分页控件：order-last 保证它排在赛道网格下面（而不是排到「创建赛道」下面）。 */}
   <div
-    class='board-pagination order-last mb-4 items-center justify-center gap-3 text-sm text-muted-foreground'
+    class='board-pagination order-last mt-5 mb-4 items-center justify-center gap-3 text-sm text-muted-foreground'
     data-board-pagination
     hidden
   >
   </div>
 
-  {/* 自命题：自助创建一个新赛道卡片（排在队伍列表上方） */}
-  <div class='create-card mb-4 rounded-xl border border-dashed bg-background p-4 sm:p-5' data-create-card>
+  {/* 自命题：自助创建一个新赛道卡片（排在队伍列表上方），加个光环效果突出它是入口 */}
+  <div class='create-card mb-4 rounded-xl border bg-background p-4 sm:p-5' data-create-card>
     <div class='flex items-start justify-between gap-3'>
       <div class='min-w-0'>
-        <h2 class='m-0 text-lg font-medium text-foreground'>没有合适的主题？</h2>
+        <div class='flex flex-wrap items-center gap-2'>
+          <h2 class='m-0 text-lg font-medium text-foreground'>没有合适的主题？</h2>
+          <span
+            class='team-count-badge shrink-0 rounded-full border px-2 py-0.5 text-xs text-muted-foreground'
+            data-team-count-label
+          >
+            共 {teams.length} 个主题
+          </span>
+        </div>
         <p class='m-0 mt-1 text-sm leading-snug text-muted-foreground'>
           自命题：创建一个属于你的赛道。组队（多人）或个人（就你一个）都行。
         </p>
@@ -470,6 +478,45 @@ import { activity, teams } from '@/data/agent-teams'
     -webkit-text-fill-color: transparent;
     color: transparent;
     width: fit-content;
+  }
+
+  /* 创建赛道卡：暖色描边 + 呼吸光环，让它在一堆队伍卡里跳出来，别人一眼就知道这是入口。 */
+  .create-card {
+    position: relative;
+    border-color: rgb(245 158 11 / 0.45);
+    background-image: linear-gradient(
+      to bottom right,
+      rgb(250 204 21 / 0.07),
+      rgb(245 158 11 / 0.03),
+      rgb(249 115 22 / 0.05)
+    );
+    animation: create-card-glow 3s ease-in-out infinite;
+  }
+  @keyframes create-card-glow {
+    0%,
+    100% {
+      box-shadow:
+        0 0 0 1px rgb(245 158 11 / 0.12),
+        0 0 22px 2px rgb(245 158 11 / 0.1);
+    }
+    50% {
+      box-shadow:
+        0 0 0 1px rgb(245 158 11 / 0.28),
+        0 0 34px 6px rgb(245 158 11 / 0.2);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .create-card {
+      animation: none;
+      box-shadow:
+        0 0 0 1px rgb(245 158 11 / 0.18),
+        0 0 22px 2px rgb(245 158 11 / 0.12);
+    }
+  }
+  .team-count-badge {
+    border-color: rgb(245 158 11 / 0.35);
+    background: rgb(245 158 11 / 0.1);
+    color: hsl(var(--foreground));
   }
 
   /* 蜜罐字段：对真人完全不可见，但对填表机器人仍存在 */
@@ -1240,6 +1287,10 @@ import { activity, teams } from '@/data/agent-teams'
       renderDetail(card, team.detail)
       card.dataset.loaded = 'true'
     }
+
+    // 主题总数：以接口拿到的完整列表为准（含自定义赛道），覆盖 SSR 时只数得到内置赛道的数字。
+    const countLabel = board.querySelector<HTMLElement>('[data-team-count-label]')
+    if (countLabel) countLabel.textContent = `共 ${data.teams.length} 个主题`
 
     // 未配置：禁用「创建赛道」入口
     const createToggle = board.querySelector<HTMLButtonElement>('[data-create-toggle]')

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -43,12 +43,25 @@ import { activity, teams } from '@/data/agent-teams'
         </p>
       </div>
 
-      {/* 主题总数：独立成一块，摆右边（原本这里一大片空白），数字够大才叫突出。 */}
+      {/* 主题总数：独立成一块，摆右边（原本这里一大片空白），数字够大才叫突出。
+          先只知道内置赛道数，自定义赛道还没拉到——与其先秀一个错的数字再跳成对的，
+          不如先用骨架屏占位，数据到手后再数字滚动到位。 */}
       <div class='team-count-card shrink-0 self-start rounded-xl border px-6 py-5 text-center sm:self-center'>
-        <div class='team-count-number text-5xl font-bold leading-none sm:text-6xl' data-team-count-number>
-          {teams.length}
+        <div
+          class='team-count-skeleton skeleton mx-auto h-12 w-20 rounded-lg sm:h-[3.75rem] sm:w-24'
+          data-team-count-skeleton
+          aria-hidden='true'
+        >
         </div>
-        <div class='mt-1.5 text-xs font-medium text-muted-foreground'>个可选主题</div>
+        <div
+          class='team-count-number hidden text-5xl font-bold leading-none sm:text-6xl'
+          data-team-count-number
+        >
+          0
+        </div>
+        <div class='mt-1.5 text-xs font-medium text-muted-foreground'>
+          <span class='sr-only' data-team-count-loading-label>主题数量加载中，</span>个可选主题
+        </div>
       </div>
     </div>
   </header>
@@ -838,6 +851,40 @@ import { activity, teams } from '@/data/agent-teams'
     else delete el.dataset.tone
   }
 
+  // 主题总数「数字滚动」：从当前显示的值滚到目标值，而不是直接跳字——
+  // 首次加载是 0 滚到真实总数，之后（比如建了新赛道）是旧总数滚到新总数。
+  function animateCount(el: HTMLElement, to: number, duration = 700) {
+    const from = Number.parseInt(el.textContent ?? '0', 10) || 0
+    if (from === to) {
+      el.textContent = String(to)
+      return
+    }
+    const start = performance.now()
+    const step = (now: number) => {
+      const t = Math.min(1, (now - start) / duration)
+      const eased = 1 - (1 - t) ** 3 // ease-out，滚到最后再放慢
+      el.textContent = String(Math.round(from + (to - from) * eased))
+      if (t < 1) requestAnimationFrame(step)
+    }
+    requestAnimationFrame(step)
+  }
+
+  // 骨架屏 → 数字滚动：第一次拿到真实总数时切掉骨架屏、露出数字并开始滚动。
+  function revealTeamCount(board: HTMLElement, total: number) {
+    const skeleton = board.querySelector<HTMLElement>('[data-team-count-skeleton]')
+    const number = board.querySelector<HTMLElement>('[data-team-count-number]')
+    if (!number) return
+    if (skeleton && !skeleton.hidden) {
+      skeleton.hidden = true
+      skeleton.classList.add('hidden')
+      number.hidden = false
+      number.classList.remove('hidden')
+      const loadingLabel = board.querySelector<HTMLElement>('[data-team-count-loading-label]')
+      if (loadingLabel) loadingLabel.remove()
+    }
+    animateCount(number, total)
+  }
+
   function renderDetail(card: HTMLElement, value: string | null) {
     const detail = value ?? ''
     // 缓存当前值：卡片本身不再铺开显示，只在弹窗和队长编辑表单预填时用它。
@@ -1315,9 +1362,8 @@ import { activity, teams } from '@/data/agent-teams'
       card.dataset.loaded = 'true'
     }
 
-    // 主题总数：以接口拿到的完整列表为准（含自定义赛道），覆盖 SSR 时只数得到内置赛道的数字。
-    const countNumber = board.querySelector<HTMLElement>('[data-team-count-number]')
-    if (countNumber) countNumber.textContent = String(data.teams.length)
+    // 主题总数：以接口拿到的完整列表为准（含自定义赛道），数字滚动到位。
+    revealTeamCount(board, data.teams.length)
 
     // 未配置：禁用「创建赛道」入口
     const createToggle = board.querySelector<HTMLButtonElement>('[data-create-toggle]')

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -99,7 +99,9 @@ import { activity, teams } from '@/data/agent-teams'
             </span>
           </div>
 
-          <p class='m-0 text-sm leading-snug text-muted-foreground' data-summary>{team.summary}</p>
+          <p class='team-summary m-0 text-sm leading-snug text-muted-foreground' data-summary>
+            {team.summary}
+          </p>
 
           {team.tags && team.tags.length > 0 && (
             <div class='flex flex-wrap gap-1.5' data-tags>
@@ -678,10 +680,21 @@ import { activity, teams } from '@/data/agent-teams'
   .detail-dialog-body {
     overflow-y: auto;
     padding: 1rem 1.25rem;
-    white-space: pre-wrap;
     font-size: 0.875rem;
     line-height: 1.7;
     color: hsl(var(--muted-foreground));
+  }
+  /* 弹窗里：一句话简介（完整版）当引言放最上面，下面才是队长写的详细介绍。 */
+  .detail-dialog-summary {
+    margin: 0;
+    color: hsl(var(--foreground));
+    white-space: pre-wrap;
+  }
+  .detail-dialog-detail {
+    margin-top: 0.85rem;
+    padding-top: 0.85rem;
+    border-top: 1px solid hsl(var(--border));
+    white-space: pre-wrap;
   }
 
   .signup-form[data-open] {
@@ -730,12 +743,19 @@ import { activity, teams } from '@/data/agent-teams'
     outline-offset: 1px;
   }
 
-  /* 名单区域固定一个高度区间：人少不至于看起来很空，人多超出就滚动，
-     卡片高度才不会因为队伍人数差异忽高忽低。 */
-  /* 固定高度而不是 min/max 区间——1 个人的卡和 6 个人的卡，名单区域也要占同样高度，
-     后面的「查看详细介绍」/操作按钮才能在同一行的两张卡里对齐，不会一高一矮。 */
+  /* 一句话简介裁到 2 行——各卡的简介长短不一，裁齐了这一段的高度才稳定，
+     卡片就不会因为简介一长一短而参差。完整简介 + 详细介绍都进「查看详细介绍」弹窗。 */
+  .team-summary {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+
+  /* 名单不再强行等高——人多就多占一点、人少就少占一点，自然排布。人特别多时给个
+     上限滚动，别把卡撑爆；卡片整体等高交给 grid 的 stretch + 底部按钮的 mt-auto。 */
   .roster {
-    height: 3.75rem;
+    max-height: 5.5rem;
     overflow-y: auto;
   }
   /* flex-wrap 容器里，中文/emoji 文本的 flex item 默认允许缩到 min-content
@@ -886,15 +906,23 @@ import { activity, teams } from '@/data/agent-teams'
   }
 
   function renderDetail(card: HTMLElement, value: string | null) {
-    const detail = value ?? ''
     // 缓存当前值：卡片本身不再铺开显示，只在弹窗和队长编辑表单预填时用它。
-    card.dataset.detail = detail
+    card.dataset.detail = value ?? ''
+    refreshDetailToggle(card)
+  }
 
+  // 「查看详细介绍」按钮的显隐：有详细介绍，或者一句话简介被裁到看不全，就显示。
+  // 注意要在卡片可见时量 scrollHeight——display:none 的卡（翻页隐藏）量出来是 0，
+  // 所以翻页把某张卡显示出来时会再调一次这个函数重新判断。
+  function refreshDetailToggle(card: HTMLElement) {
     const toggle = card.querySelector<HTMLButtonElement>('[data-detail-toggle]')
     if (!toggle) return
-    const empty = detail.length === 0
-    toggle.hidden = empty
-    toggle.classList.toggle('hidden', empty)
+    const hasDetail = (card.dataset.detail ?? '').length > 0
+    const summaryEl = card.querySelector<HTMLElement>('[data-summary]')
+    const summaryClamped = !!summaryEl && summaryEl.scrollHeight - summaryEl.clientHeight > 1
+    const show = hasDetail || summaryClamped
+    toggle.hidden = !show
+    toggle.classList.toggle('hidden', !show)
   }
 
   function renderRoster(card: HTMLElement, team: Team) {
@@ -992,6 +1020,8 @@ import { activity, teams } from '@/data/agent-teams'
     if (title) title.textContent = team.title
     const summary = card.querySelector<HTMLElement>('[data-summary]')
     if (summary) summary.textContent = team.summary
+    // 缓存完整简介，供「查看详细介绍」弹窗展示（卡面上的那份被裁成 2 行）。
+    card.dataset.summary = team.summary
 
     const tags = card.querySelector<HTMLElement>('[data-tags]')
     if (!tags) return
@@ -1033,7 +1063,23 @@ import { activity, teams } from '@/data/agent-teams'
     const titleEl = dialog.querySelector<HTMLElement>('[data-detail-dialog-title]')
     const bodyEl = dialog.querySelector<HTMLElement>('[data-detail-dialog-body]')
     if (titleEl) titleEl.textContent = card.querySelector('[data-title]')?.textContent ?? ''
-    if (bodyEl) bodyEl.textContent = card.dataset.detail ?? ''
+    if (bodyEl) {
+      bodyEl.replaceChildren()
+      const summary = card.dataset.summary ?? ''
+      const detail = card.dataset.detail ?? ''
+      if (summary) {
+        const p = document.createElement('p')
+        p.className = 'detail-dialog-summary'
+        p.textContent = summary // textContent — 用户输入不当 HTML 解析
+        bodyEl.appendChild(p)
+      }
+      if (detail) {
+        const d = document.createElement('div')
+        d.className = 'detail-dialog-detail'
+        d.textContent = detail
+        bodyEl.appendChild(d)
+      }
+    }
     dialog.showModal()
   }
 
@@ -1273,8 +1319,13 @@ import { activity, teams } from '@/data/agent-teams'
     cardEls.forEach((card, i) => {
       const onPage = Math.floor(i / PAGE_SIZE) === page
       // 不用 .hidden/[hidden]：team-card 自带 .flex，二者优先级打不过，切换了也白切换。
-      if (onPage) delete card.dataset.pageHidden
-      else card.dataset.pageHidden = ''
+      if (onPage) {
+        delete card.dataset.pageHidden
+        // 卡片刚从隐藏切到显示，简介的 scrollHeight 这时才量得准——重判一次「查看详细介绍」的显隐。
+        refreshDetailToggle(card)
+      } else {
+        card.dataset.pageHidden = ''
+      }
     })
 
     pager.replaceChildren()

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -7,45 +7,50 @@ import { activity, teams } from '@/data/agent-teams'
 
 <section class='agent-board not-prose mt-6 flex flex-col' data-agent-board>
   <header class='board-hero mb-8 overflow-hidden rounded-2xl border p-6 sm:p-8'>
-    <div class='flex flex-wrap items-center gap-2 text-xs font-medium'>
-      <span
-        class='rounded-full border border-amber-500/40 bg-amber-500/15 px-2.5 py-0.5 text-amber-700 dark:text-amber-300'
-      >
-        {activity.title}
-      </span>
-      <span class='text-muted-foreground'>{activity.subtitle}</span>
-    </div>
-    <h1 class='board-title mt-3 text-3xl font-bold tracking-tight sm:text-5xl'>
-      {activity.name}
-    </h1>
-    <p class='mt-3 max-w-2xl leading-relaxed text-muted-foreground'>{activity.tagline}</p>
-    <div class='mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground'>
-      <span class='inline-flex items-center gap-1.5'>
-        <span class='inline-block size-1.5 animate-pulse rounded-full bg-amber-500'></span>
-        组队进行中 · {activity.deadlineText}截止
-      </span>
-      <span class='team-count inline-flex items-baseline gap-1.5'>
-        共
-        <span class='team-count-number text-2xl font-bold leading-none sm:text-3xl' data-team-count-number>
+    <div class='flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between'>
+      <div class='min-w-0 sm:flex-1'>
+        <div class='flex flex-wrap items-center gap-2 text-xs font-medium'>
+          <span
+            class='rounded-full border border-amber-500/40 bg-amber-500/15 px-2.5 py-0.5 text-amber-700 dark:text-amber-300'
+          >
+            {activity.title}
+          </span>
+          <span class='text-muted-foreground'>{activity.subtitle}</span>
+        </div>
+        <h1 class='board-title mt-3 text-3xl font-bold tracking-tight sm:text-5xl'>
+          {activity.name}
+        </h1>
+        <p class='mt-3 max-w-2xl leading-relaxed text-muted-foreground'>{activity.tagline}</p>
+        <div class='mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground'>
+          <span class='inline-flex items-center gap-1.5'>
+            <span class='inline-block size-1.5 animate-pulse rounded-full bg-amber-500'></span>
+            组队进行中 · {activity.deadlineText}截止
+          </span>
+          <a
+            class='inline-flex items-center gap-1 text-foreground underline-offset-4 hover:underline'
+            href={activity.docHref}
+            target='_blank'
+            rel='noopener noreferrer'
+          >
+            活动详情 ↗
+          </a>
+        </div>
+        <p
+          class='mt-5 max-w-2xl rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm leading-relaxed text-foreground'
+          role='note'
+        >
+          {activity.notice}
+        </p>
+      </div>
+
+      {/* 主题总数：独立成一块，摆右边（原本这里一大片空白），数字够大才叫突出。 */}
+      <div class='team-count-card shrink-0 self-start rounded-xl border px-6 py-5 text-center sm:self-center'>
+        <div class='team-count-number text-5xl font-bold leading-none sm:text-6xl' data-team-count-number>
           {teams.length}
-        </span>
-        个主题
-      </span>
-      <a
-        class='inline-flex items-center gap-1 text-foreground underline-offset-4 hover:underline'
-        href={activity.docHref}
-        target='_blank'
-        rel='noopener noreferrer'
-      >
-        活动详情 ↗
-      </a>
+        </div>
+        <div class='mt-1.5 text-xs font-medium text-muted-foreground'>个可选主题</div>
+      </div>
     </div>
-    <p
-      class='mt-5 max-w-2xl rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm leading-relaxed text-foreground'
-      role='note'
-    >
-      {activity.notice}
-    </p>
   </header>
 
   {/* 首次拉取名单 / 自定义赛道期间的进度条，加载完成后由脚本隐藏 */}
@@ -479,7 +484,17 @@ import { activity, teams } from '@/data/agent-teams'
     width: fit-content;
   }
 
-  /* 主题总数：数字要比周围的小字大一截、颜色也跳出来，一眼能看到量级。 */
+  /* 主题总数：单独一块摆在 hero 右侧的空白处，暖色描边 + 底色，跟正文明显区隔开。 */
+  .team-count-card {
+    border-color: rgb(245 158 11 / 0.4);
+    background-image: linear-gradient(
+      to bottom right,
+      rgb(250 204 21 / 0.14),
+      rgb(245 158 11 / 0.07),
+      rgb(249 115 22 / 0.12)
+    );
+  }
+  /* 数字要比「个可选主题」这行小字大出一大截、颜色也跳出来，一眼能看到量级。 */
   .team-count-number {
     background-image: linear-gradient(to right, #fbbf24, #f59e0b, #f97316);
     -webkit-background-clip: text;

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -24,6 +24,7 @@ import { activity, teams } from '@/data/agent-teams'
         <span class='inline-block size-1.5 animate-pulse rounded-full bg-amber-500'></span>
         组队进行中 · {activity.deadlineText}截止
       </span>
+      <span data-team-count-label>共 {teams.length} 个主题</span>
       <a
         class='inline-flex items-center gap-1 text-foreground underline-offset-4 hover:underline'
         href={activity.docHref}
@@ -307,15 +308,7 @@ import { activity, teams } from '@/data/agent-teams'
   <div class='create-card mb-4 rounded-xl border bg-background p-4 sm:p-5' data-create-card>
     <div class='flex items-start justify-between gap-3'>
       <div class='min-w-0'>
-        <div class='flex flex-wrap items-center gap-2'>
-          <h2 class='m-0 text-lg font-medium text-foreground'>没有合适的主题？</h2>
-          <span
-            class='team-count-badge shrink-0 rounded-full border px-2 py-0.5 text-xs text-muted-foreground'
-            data-team-count-label
-          >
-            共 {teams.length} 个主题
-          </span>
-        </div>
+        <h2 class='m-0 text-lg font-medium text-foreground'>没有合适的主题？</h2>
         <p class='m-0 mt-1 text-sm leading-snug text-muted-foreground'>
           自命题：创建一个属于你的赛道。组队（多人）或个人（就你一个）都行。
         </p>
@@ -512,11 +505,6 @@ import { activity, teams } from '@/data/agent-teams'
         0 0 0 1px rgb(245 158 11 / 0.18),
         0 0 22px 2px rgb(245 158 11 / 0.12);
     }
-  }
-  .team-count-badge {
-    border-color: rgb(245 158 11 / 0.35);
-    background: rgb(245 158 11 / 0.1);
-    color: hsl(var(--foreground));
   }
 
   /* 蜜罐字段：对真人完全不可见，但对填表机器人仍存在 */
@@ -1224,6 +1212,8 @@ import { activity, teams } from '@/data/agent-teams'
     const goTo = (next: number) => {
       board.dataset.page = String(next)
       renderPagination(board, cards)
+      // 翻页后卷回赛道网格顶部——不然人还停在页面底部的翻页按钮旁边，看不到新一页的卡片。
+      board.querySelector('[data-team-grid]')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     }
 
     const prev = document.createElement('button')

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -24,7 +24,13 @@ import { activity, teams } from '@/data/agent-teams'
         <span class='inline-block size-1.5 animate-pulse rounded-full bg-amber-500'></span>
         组队进行中 · {activity.deadlineText}截止
       </span>
-      <span data-team-count-label>共 {teams.length} 个主题</span>
+      <span class='team-count inline-flex items-baseline gap-1.5'>
+        共
+        <span class='team-count-number text-2xl font-bold leading-none sm:text-3xl' data-team-count-number>
+          {teams.length}
+        </span>
+        个主题
+      </span>
       <a
         class='inline-flex items-center gap-1 text-foreground underline-offset-4 hover:underline'
         href={activity.docHref}
@@ -471,6 +477,15 @@ import { activity, teams } from '@/data/agent-teams'
     -webkit-text-fill-color: transparent;
     color: transparent;
     width: fit-content;
+  }
+
+  /* 主题总数：数字要比周围的小字大一截、颜色也跳出来，一眼能看到量级。 */
+  .team-count-number {
+    background-image: linear-gradient(to right, #fbbf24, #f59e0b, #f97316);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
   }
 
   /* 创建赛道卡：暖色描边 + 呼吸光环，让它在一堆队伍卡里跳出来，别人一眼就知道这是入口。 */
@@ -1213,7 +1228,13 @@ import { activity, teams } from '@/data/agent-teams'
       board.dataset.page = String(next)
       renderPagination(board, cards)
       // 翻页后卷回赛道网格顶部——不然人还停在页面底部的翻页按钮旁边，看不到新一页的卡片。
-      board.querySelector('[data-team-grid]')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      // 页面顶部有个 sticky header（top:1rem、约 44px 高），scrollIntoView 的默认对齐
+      // 会把网格顶端顶到 viewport 最上面，正好被这个 header 挡住，所以手动减一个偏移量。
+      const gridEl = board.querySelector<HTMLElement>('[data-team-grid]')
+      if (gridEl) {
+        const top = gridEl.getBoundingClientRect().top + window.scrollY - 76
+        window.scrollTo({ top, behavior: 'smooth' })
+      }
     }
 
     const prev = document.createElement('button')
@@ -1279,8 +1300,8 @@ import { activity, teams } from '@/data/agent-teams'
     }
 
     // 主题总数：以接口拿到的完整列表为准（含自定义赛道），覆盖 SSR 时只数得到内置赛道的数字。
-    const countLabel = board.querySelector<HTMLElement>('[data-team-count-label]')
-    if (countLabel) countLabel.textContent = `共 ${data.teams.length} 个主题`
+    const countNumber = board.querySelector<HTMLElement>('[data-team-count-number]')
+    if (countNumber) countNumber.textContent = String(data.teams.length)
 
     // 未配置：禁用「创建赛道」入口
     const createToggle = board.querySelector<HTMLButtonElement>('[data-create-toggle]')

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -67,7 +67,7 @@ import { activity, teams } from '@/data/agent-teams'
           <div class='flex items-start justify-between gap-3'>
             <h2 class='m-0 text-lg font-medium text-foreground' data-title>{team.title}</h2>
             <span
-              class='skeleton inline-block h-5 w-14 shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground'
+              class='skeleton count-label inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground'
               data-count-label
             >
               <span class='sr-only'>人数加载中…</span>
@@ -460,6 +460,12 @@ import { activity, teams } from '@/data/agent-teams'
     to {
       transform: translateX(100%);
     }
+  }
+  /* 人数徽章：骨架屏阶段给个占位尺寸；真实文案（如「6 / 10 人」）到手后
+     去掉 .skeleton 就该按内容自适应宽度，靠 white-space:nowrap 防止折成两行。 */
+  .count-label.skeleton {
+    min-width: 3.5rem;
+    min-height: 1.25rem;
   }
   @media (prefers-reduced-motion: reduce) {
     .skeleton::after {

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -86,14 +86,6 @@ import { activity, teams } from '@/data/agent-teams'
             </div>
           )}
 
-          <button
-            type='button'
-            class='detail-toggle hidden items-center gap-1 self-start text-xs font-medium text-foreground underline-offset-4 hover:underline'
-            data-detail-toggle
-          >
-            📄 查看详细介绍
-          </button>
-
           <ul class='roster m-0 flex list-none flex-wrap gap-1.5 p-0' data-roster>
             <li class='roster-empty flex flex-wrap gap-1.5'>
               <span class='sr-only'>名单加载中…</span>
@@ -108,6 +100,14 @@ import { activity, teams } from '@/data/agent-teams'
               ))}
             </li>
           </ul>
+
+          <button
+            type='button'
+            class='detail-toggle hidden items-center gap-1 self-start text-xs font-medium text-foreground underline-offset-4 hover:underline'
+            data-detail-toggle
+          >
+            📄 查看详细介绍
+          </button>
 
           <div class='mt-auto flex flex-wrap items-center gap-2 pt-1'>
             <button
@@ -297,7 +297,7 @@ import { activity, teams } from '@/data/agent-teams'
 
   {/* 分页控件：order-last 保证它排在赛道网格下面（而不是排到「创建赛道」下面）。 */}
   <div
-    class='board-pagination order-last mb-4 flex items-center justify-center gap-3 text-sm text-muted-foreground'
+    class='board-pagination order-last mb-4 items-center justify-center gap-3 text-sm text-muted-foreground'
     data-board-pagination
     hidden
   >
@@ -626,6 +626,14 @@ import { activity, teams } from '@/data/agent-teams'
   }
   .team-capacity-field[data-show] {
     display: flex;
+  }
+  .board-pagination:not([hidden]) {
+    display: flex;
+  }
+  /* team-card 自带 .flex（内部要用 flex-col 排版），普通的 [hidden]/.hidden 优先级
+     干不过它——分页隐藏另开一个更高优先级的属性选择器，而不是复用 .hidden。 */
+  .team-card[data-page-hidden] {
+    display: none;
   }
   /* 类型选择做成两张可点的卡片而不是裸单选框：原生 radio 视觉隐藏，
      用 :has() 给选中的那张卡描边高亮，比灰突突的圆点好认多了。 */
@@ -1151,18 +1159,17 @@ import { activity, teams } from '@/data/agent-teams'
 
     cardEls.forEach((card, i) => {
       const onPage = Math.floor(i / PAGE_SIZE) === page
-      card.hidden = !onPage
-      card.classList.toggle('hidden', !onPage)
+      // 不用 .hidden/[hidden]：team-card 自带 .flex，二者优先级打不过，切换了也白切换。
+      if (onPage) delete card.dataset.pageHidden
+      else card.dataset.pageHidden = ''
     })
 
     pager.replaceChildren()
     if (pageCount <= 1) {
       pager.hidden = true
-      pager.classList.add('hidden')
       return
     }
     pager.hidden = false
-    pager.classList.remove('hidden')
 
     const pagerBtnClass =
       'inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40'

--- a/src/lib/agent-teams/store.ts
+++ b/src/lib/agent-teams/store.ts
@@ -381,6 +381,16 @@ export async function addSignup(
       return { ok: false, code: 'duplicate', message: '这个昵称已经在这支队伍里了' }
     }
 
+    // 这支队伍的第一个人：自动记为队长（个人赛道创建时已在 createTeam 里处理过，
+    // 这里补的是「组队」赛道第一个报名者的情形）。ON CONFLICT DO NOTHING 避免覆盖已有队长。
+    if (existing.length === 0) {
+      await sql`
+        INSERT INTO agent_team_captains (team_id, captain_key)
+        VALUES (${input.teamId}, ${nameKey})
+        ON CONFLICT (team_id) DO NOTHING
+      `
+    }
+
     const members = [
       ...existing.map(rowToMember),
       { name, note, ts: Math.round(inserted[0].ts_sec * 1000) }

--- a/src/lib/agent-teams/store.ts
+++ b/src/lib/agent-teams/store.ts
@@ -76,6 +76,9 @@ const CONTACT_MAX = 60
 const DETAIL_MAX = 600
 const TITLE_MAX = 30
 const SUMMARY_MAX = 80
+// 组队赛道的名额上限范围；不在这个区间就当没填，按不限处理。
+const TEAM_CAPACITY_MIN = 2
+const TEAM_CAPACITY_MAX = 999
 // 轻量限流：同一 IP 在窗口内最多成功报名这么多次。
 const RATE_LIMIT = 5
 const RATE_WINDOW_SEC = 600
@@ -184,6 +187,9 @@ async function ensureSchema(sql: Sql): Promise<void> {
   `
   // 赛道类型：team=可多人组队，solo=个人（名额 1，别人不能加入）。旧行默认 team。
   await sql`ALTER TABLE agent_team_customs ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'team'`
+  // 名额上限：组队赛道创建时可选填（默认 10，参照内置赛道的惯例），留空则不限；
+  // 个人赛道恒为 1，不走这一列。旧行（建功能前创建的）没有名额，NULL 就是「不限」。
+  await sql`ALTER TABLE agent_team_customs ADD COLUMN IF NOT EXISTS capacity INTEGER`
   // 队长：一队一行，记录队长的 name_key。没有行时默认「第一个报名的人」当队长。
   await sql`
     CREATE TABLE IF NOT EXISTS agent_team_captains (
@@ -513,8 +519,10 @@ export type CreateTeamInput = {
   summary: string
   /** team=可多人组队；solo=个人（名额 1，别人不能加入） */
   kind?: 'team' | 'solo'
-  /** 个人赛道必填：创建者昵称，创建时自动占用唯一名额并成为队长 */
+  /** 必填：创建者昵称，创建时自动占一个名额并成为队长（不论组队还是个人） */
   name?: string
+  /** 仅「组队」有效：名额上限；省略/非法值则不限。个人赛道恒为 1，忽略这个字段。 */
+  capacity?: number
   passcode?: string
   /** 蜜罐字段：正常用户永远为空 */
   hp?: string
@@ -562,18 +570,19 @@ export async function getCustomTeams(): Promise<TeamMeta[]> {
   await ensureSchema(sql)
 
   const rows = (await sql`
-    SELECT id, title, summary, kind
+    SELECT id, title, summary, kind, capacity
     FROM agent_team_customs
     ORDER BY created_at ASC
-  `) as { id: string; title: string; summary: string; kind: string }[]
+  `) as { id: string; title: string; summary: string; kind: string; capacity: number | null }[]
 
-  // 自定义赛道无标签；个人赛道名额固定 1（别人加不进来），组队赛道名额不限。
+  // 自定义赛道无标签；个人赛道名额恒为 1（别人加不进来，capacity 列对它不作数），
+  // 组队赛道按创建时填的名额来，没填 / 建功能前创建的老行就是不限。
   return rows.map((r) => ({
     id: r.id,
     title: r.title,
     summary: r.summary,
     tags: [],
-    capacity: r.kind === 'solo' ? 1 : null
+    capacity: r.kind === 'solo' ? 1 : r.capacity
   }))
 }
 
@@ -600,16 +609,19 @@ export async function createTeam(input: CreateTeamInput): Promise<CreateResult> 
   }
 
   const kind = input.kind === 'solo' ? 'solo' : 'team'
-  // 个人赛道要在创建时就把创建者占进唯一名额，所以必须带昵称。
-  let creatorName: string | null = null
-  if (kind === 'solo') {
-    creatorName = cleanText(input.name ?? '')
-    if (creatorName.length === 0 || creatorName.length > NAME_MAX) {
-      return { ok: false, code: 'invalid', message: `个人参赛要填你的昵称（1–${NAME_MAX} 个字符）` }
-    }
+  // 不管组队还是个人，创建时都要带昵称——创建者会自动占一个名额并当队长。
+  const creatorName = cleanText(input.name ?? '')
+  if (creatorName.length === 0 || creatorName.length > NAME_MAX) {
+    return { ok: false, code: 'invalid', message: `请填你的昵称（1–${NAME_MAX} 个字符），创建后会自动加入并当队长` }
   }
 
-  const capacity = kind === 'solo' ? 1 : null
+  let capacity: number | null = kind === 'solo' ? 1 : null
+  if (kind === 'team' && input.capacity != null) {
+    const n = Math.trunc(input.capacity)
+    if (Number.isFinite(n) && n >= TEAM_CAPACITY_MIN && n <= TEAM_CAPACITY_MAX) {
+      capacity = n
+    }
+  }
   const ip = input.ip ?? null
   const id = `custom-${crypto.randomUUID().slice(0, 8)}`
 
@@ -629,12 +641,13 @@ export async function createTeam(input: CreateTeamInput): Promise<CreateResult> 
     }
 
     await sql`
-      INSERT INTO agent_team_customs (id, title, summary, ip, kind)
-      VALUES (${id}, ${title}, ${summary}, ${ip}, ${kind})
+      INSERT INTO agent_team_customs (id, title, summary, ip, kind, capacity)
+      VALUES (${id}, ${title}, ${summary}, ${ip}, ${kind}, ${capacity})
     `
 
-    // 个人赛道：创建者自动报名占位 + 当队长，卡片一建好就是「1/1，他本人」。
-    if (kind === 'solo' && creatorName) {
+    // 创建者自动报名占位 + 当队长——个人赛道卡片一建好就是「1/1，他本人」，
+    // 组队赛道也一样，不用创建完还得再手动报名一次才当上队长。
+    {
       const nameKey = creatorName.toLowerCase()
       await sql`
         INSERT INTO agent_team_signups (team_id, name, name_key, ip)

--- a/src/pages/api/agent-teams.ts
+++ b/src/pages/api/agent-teams.ts
@@ -171,11 +171,13 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
 
   // action=create：自助创建自定义赛道。
   if (body.action === 'create') {
+    const capacityRaw = body.capacity
     const result = await createTeam({
       title: str(body.title) ?? '',
       summary: str(body.summary) ?? '',
       kind: str(body.kind) === 'solo' ? 'solo' : 'team',
       name: str(body.name),
+      capacity: typeof capacityRaw === 'number' && Number.isFinite(capacityRaw) ? capacityRaw : undefined,
       passcode: str(body.passcode),
       hp: str(body.hp),
       ip


### PR DESCRIPTION
Front-end polish pass on the agent-teams board, plus a couple of data-layer follow-ups it needed.

- Loading: per-card count/roster skeletons, a top progress bar, and a skeleton→count-up animation for the topic total (was flashing a wrong SSR number).
- Cards: summary clamped to 2 lines with the full text (plus captain detail) in a shared popup dialog; rosters flow naturally again; captain sorts to the front of the list and pops in staggered.
- Hero: topic count moved into its own stat card in the previously-empty right column.
- Pagination: 8 tracks per page with prev/next, scrolls back to the grid top (offset for the sticky header) on page change.
- Create form: restyled kind picker as selectable cards, creators now pick a capacity and are auto-registered as the first member + captain.

Notes: `store.ts` adds a `capacity` column to `agent_team_customs` via an idempotent `ALTER … IF NOT EXISTS` (auto-run on first access, no manual migration) and now records the creator/first signup as captain for team tracks too. Signups/creates write to the live Neon DB.