### PR TITLE
docs(home): rework about-section intro copy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -154,9 +154,10 @@ const agentHackathonLink =
       <Section title='About'>
         <p class='text-muted-foreground'>AI Agent & Full-Stack Developer</p>
         <p class='text-muted-foreground'>
-          墨尔本大学在读，目前在 Adastra Labs（石墨文档海外）参与 Playyy.ai， 同时在特赞 Tezign 做
-          atypica（商业研究 Multi-Agent），并在 fAIshion.ai 与 Goshu Tech 做 AI 全栈与剪辑 Agent。
-          在意 LLM 的底层机制，也在意产品能不能真正跑起来。 Build fast, learn faster —
+          墨尔本大学在读，专注 AI Agent 产品开发 —— 从 Adastra Labs（石墨文档海外）的
+          Playyy.ai、特赞 Tezign 的 atypica（商业研究 Multi-Agent），到 fAIshion.ai 与
+          Goshu Tech 的全栈与剪辑 Agent，都是这条线上的实践。 在意 LLM
+          的底层机制，也在意产品能不能真正跑起来。 Build fast, learn faster —
           平时弹琴、拉大提琴、玩摄影。
         </p>
         <Button


### PR DESCRIPTION
Rewrites the homepage About-section bio so it reads as one AI Agent product-focus thread instead of a "同时...并在..." list of parallel jobs.

Closes none — copy-only tweak requested by Joye.