### PR TITLE
perf(terminal): lazy-fetch pseudo-fs instead of embedding it per page

### DIFF
--- a/src/components/terminal/DevModeHost.tsx
+++ b/src/components/terminal/DevModeHost.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { trackSiteEvent } from '@/lib/analytics'
 
 import DevMode from './DevMode'
+import { fetchSiteFs } from './fs/client'
 import type { FsNode } from './fs/types'
 
 /**
@@ -13,6 +14,10 @@ import type { FsNode } from './fs/types'
  *   - `joye:toggle-dev` / `joye:enter-dev` / `joye:exit-dev` custom events
  *     (dispatched by the Header toggle button — keeps the Astro side
  *     decoupled from React).
+ *
+ * The pseudo-FS is fetched on demand when dev mode is entered, rather than
+ * shipped as a server-rendered prop — this component mounts on every page,
+ * but the manifest is only ever needed by the ~backtick minority of visits.
  */
 
 type Mode = 'human' | 'dev'
@@ -25,8 +30,39 @@ function isEditable(target: EventTarget | null): boolean {
   return false
 }
 
-export default function DevModeHost({ fs }: { fs: FsNode }) {
+function DevModeLoading({ failed }: { failed: boolean }) {
+  return (
+    <div className='dev-root' role='dialog' aria-label='dev mode terminal'>
+      <div className='dev-chrome'>
+        <div className='dev-chrome-left'>
+          <div className='dev-chrome-dots' aria-hidden>
+            <span />
+            <span />
+            <span />
+          </div>
+          <span className='dev-chrome-title'>dev mode</span>
+        </div>
+        <div className='dev-chrome-hint'>
+          press <span className='wt-kbd'>Esc</span> to leave
+        </div>
+      </div>
+      <div className='dev-body'>
+        <div className='dev-boot' aria-live='polite'>
+          <span className='dev-boot-line wt-tone-muted'>
+            <span className='wt-tone-fg'>
+              {failed ? 'failed to load manifest — press Esc to leave' : 'loading manifest…'}
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function DevModeHost() {
   const [mode, setMode] = useState<Mode>('human')
+  const [fs, setFs] = useState<FsNode | null>(null)
+  const [loadFailed, setLoadFailed] = useState(false)
 
   const enter = useCallback((method: string) => {
     trackSiteEvent('terminal_open', {
@@ -37,6 +73,35 @@ export default function DevModeHost({ fs }: { fs: FsNode }) {
     setMode('dev')
   }, [])
   const exit = useCallback(() => setMode('human'), [])
+
+  // fetch the pseudo-FS the first time dev mode is entered (shared cache in
+  // fs/client — reuses the home-page Terminal's in-flight request if any)
+  useEffect(() => {
+    if (mode !== 'dev' || fs) return
+    let cancelled = false
+    setLoadFailed(false)
+    fetchSiteFs()
+      .then((tree) => {
+        if (!cancelled) setFs(tree)
+      })
+      .catch(() => {
+        if (!cancelled) setLoadFailed(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [mode, fs])
+
+  // Esc to back out while the manifest is still loading/failed — once `fs`
+  // resolves, DevMode mounts and its own input owns Esc-to-exit instead.
+  useEffect(() => {
+    if (mode !== 'dev' || fs) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') exit()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [mode, fs, exit])
 
   // global `\`` hotkey — only fires when nothing editable is focused
   useEffect(() => {
@@ -76,5 +141,6 @@ export default function DevModeHost({ fs }: { fs: FsNode }) {
   }, [mode])
 
   if (mode !== 'dev') return null
+  if (!fs) return <DevModeLoading failed={loadFailed} />
   return <DevMode fs={fs} onExit={exit} />
 }

--- a/src/components/terminal/Terminal.astro
+++ b/src/components/terminal/Terminal.astro
@@ -1,8 +1,5 @@
 ---
 import TerminalShell from './TerminalShell'
-import { buildSiteFs } from './fs/server'
-
-const fs = await buildSiteFs()
 ---
 
 <div class='wt-intro' aria-hidden='true'>
@@ -11,4 +8,4 @@ const fs = await buildSiteFs()
     Skip the scroll — try the interactive CLI. Type <code>help</code>, <code>design</code>, or <code>ls /blog</code>.
   </span>
 </div>
-<TerminalShell client:load fs={fs} />
+<TerminalShell client:load />

--- a/src/components/terminal/TerminalShell.tsx
+++ b/src/components/terminal/TerminalShell.tsx
@@ -152,21 +152,25 @@ export default function Terminal({ user = 'joye', host = ROOT_LABEL }: Props) {
   const idRef = useRef(0)
   const newId = () => `e${++idRef.current}`
 
-  // fetch the pseudo-FS once on mount instead of embedding it server-side
-  // (shared cache in fs/client — DevMode reuses the same in-flight request)
-  useEffect(() => {
+  // fetch the pseudo-FS instead of embedding it server-side (shared cache in
+  // fs/client — DevMode reuses the same in-flight request). A failed fetch
+  // resets that cache, so calling this again (from the `!fs` guard in
+  // runInput below) genuinely retries instead of replaying a stale failure.
+  const loadFs = useCallback(() => {
     let cancelled = false
     fetchSiteFs()
       .then((tree) => {
         if (!cancelled) setFs(tree)
       })
       .catch(() => {
-        /* command handlers below no-op while fs stays null */
+        /* stays null; next command attempt retries via runInput */
       })
     return () => {
       cancelled = true
     }
   }, [])
+
+  useEffect(() => loadFs(), [loadFs])
 
   // hydrate collapsed state from localStorage
   useEffect(() => {
@@ -282,6 +286,7 @@ export default function Terminal({ user = 'joye', host = ROOT_LABEL }: Props) {
           kind: 'output',
           lines: [{ kind: 'text', tone: 'muted', text: 'still booting… try again in a moment' }]
         })
+        loadFs() // retries — a no-op if the initial fetch is still in flight
         return
       }
       setHistory((h) => [...h, trimmed])
@@ -340,7 +345,7 @@ export default function Terminal({ user = 'joye', host = ROOT_LABEL }: Props) {
         })
       }
     },
-    [appendEntry, updateStream, fs, cwd, ctxSetTheme, ctxNavigate]
+    [appendEntry, updateStream, fs, cwd, ctxSetTheme, ctxNavigate, loadFs]
   )
 
   // first-load hint, only client side

--- a/src/components/terminal/TerminalShell.tsx
+++ b/src/components/terminal/TerminalShell.tsx
@@ -5,6 +5,7 @@ import { trackSiteEvent } from '@/lib/analytics'
 
 import { classifyTerminalCommand } from './analytics'
 import { commands, completeInput } from './commands'
+import { fetchSiteFs } from './fs/client'
 import { ROOT_LABEL } from './fs/content'
 import { displayPath } from './fs/path'
 import type { FsNode } from './fs/types'
@@ -14,7 +15,6 @@ import './terminal.css'
 import type { HistoryEntry, OutputLine, Tone } from './types'
 
 type Props = {
-  fs: FsNode
   user?: string
   host?: string
 }
@@ -136,7 +136,8 @@ function MatrixRain() {
 const COLLAPSE_KEY = 'wt-collapsed'
 const PEEK_DEMOS = ['whoami', 'help', 'ls blog', 'chat hire-me', 'design', 'theme dark', 'matrix']
 
-export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props) {
+export default function Terminal({ user = 'joye', host = ROOT_LABEL }: Props) {
+  const [fs, setFs] = useState<FsNode | null>(null)
   const [entries, setEntries] = useState<RenderEntry[]>([])
   const [input, setInput] = useState('')
   const [history, setHistory] = useState<string[]>([])
@@ -150,6 +151,22 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
   const bodyRef = useRef<HTMLDivElement | null>(null)
   const idRef = useRef(0)
   const newId = () => `e${++idRef.current}`
+
+  // fetch the pseudo-FS once on mount instead of embedding it server-side
+  // (shared cache in fs/client — DevMode reuses the same in-flight request)
+  useEffect(() => {
+    let cancelled = false
+    fetchSiteFs()
+      .then((tree) => {
+        if (!cancelled) setFs(tree)
+      })
+      .catch(() => {
+        /* command handlers below no-op while fs stays null */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   // hydrate collapsed state from localStorage
   useEffect(() => {
@@ -260,6 +277,13 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
       const trimmed = raw.trim()
       appendEntry({ kind: 'input', raw: trimmed, cwd })
       if (!trimmed) return
+      if (!fs) {
+        appendEntry({
+          kind: 'output',
+          lines: [{ kind: 'text', tone: 'muted', text: 'still booting… try again in a moment' }]
+        })
+        return
+      }
       setHistory((h) => [...h, trimmed])
       setHistIdx(-1)
 
@@ -399,6 +423,7 @@ export default function Terminal({ fs, user = 'joye', host = ROOT_LABEL }: Props
     }
     if (e.key === 'Tab') {
       e.preventDefault()
+      if (!fs) return
       const completion = completeInput(input, { fs, cwd })
       if (!completion) return
       if (typeof completion === 'string') {

--- a/src/components/terminal/fs/client.ts
+++ b/src/components/terminal/fs/client.ts
@@ -1,0 +1,27 @@
+import type { FsNode } from './types'
+
+/**
+ * Client-side counterpart to `buildSiteFs` (server.ts). Fetches the same
+ * tree from the public /api/knowledge/index.json endpoint instead of
+ * having each island embed its own server-rendered copy in the page HTML.
+ * The in-flight/resolved promise is cached so multiple callers on the same
+ * page (Terminal + DevMode) share one network request instead of each
+ * shipping (or re-fetching) a duplicate multi-hundred-KB manifest.
+ */
+let pending: Promise<FsNode> | null = null
+
+export function fetchSiteFs(): Promise<FsNode> {
+  if (!pending) {
+    pending = fetch('/api/knowledge/index.json')
+      .then((res) => {
+        if (!res.ok) throw new Error(`fs fetch failed: ${res.status}`)
+        return res.json() as Promise<{ tree: FsNode }>
+      })
+      .then((payload) => payload.tree)
+      .catch((err) => {
+        pending = null
+        throw err
+      })
+  }
+  return pending
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,7 +10,6 @@ import BaseHead from '@/components/BaseHead.astro'
 import ViewCounter from '@/components/comment/ViewCounter.astro'
 import Header from '@/components/Header.astro'
 import DevModeHost from '@/components/terminal/DevModeHost'
-import { buildSiteFs } from '@/components/terminal/fs/server'
 import ThemeProvider from '@/components/ThemeProvider.astro'
 import config from '@/site-config'
 
@@ -31,9 +30,6 @@ const {
 
 const lang = getLangFromUrl(Astro.url)
 const htmlLang = lang === 'en' ? 'en' : config.locale.lang
-
-// Pseudo-FS shipped to the DevMode React island. Built once per page render.
-const fs = await buildSiteFs()
 ---
 
 <html lang={htmlLang}>
@@ -57,7 +53,7 @@ const fs = await buildSiteFs()
       <slot />
       <Footer />
     </div>
-    <DevModeHost client:only='react' fs={fs} />
+    <DevModeHost client:only='react' />
     <Analytics />
     <AnalyticsEvents />
     <SpeedInsights />


### PR DESCRIPTION
Terminal and DevMode each embedded a ~237KB server-rendered `fs` prop in every page's HTML — DevMode's copy shipped site-wide even though it's only used behind the backtick hotkey. The homepage carried both copies at once (~474KB extra), likely why page-fetch tools choked on it specifically. Both now fetch the existing `/api/knowledge/index.json` endpoint on demand instead, sharing one in-flight request via `fs/client.ts`.

Notes: DevMode shows a small loading placeholder (reusing its own chrome styling) for the rare case the fetch hasn't resolved yet when dev mode is entered; Esc still works to back out if it fails.