### PR TITLE
fix(i18n): stop language switcher and EN nav from linking to 404s

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,5 @@
 ---
-import { getLangFromUrl, localizedPath, useTranslations, type Lang } from '@/i18n/ui'
+import { getLangFromUrl, hasEnAlternate, localizedPath, useTranslations, type Lang } from '@/i18n/ui'
 
 import { Icon } from 'astro-pure/user'
 import LanguageSwitcher from '@/components/LanguageSwitcher.astro'
@@ -22,13 +22,16 @@ const menuKeyMap: Record<string, Parameters<typeof t>[0]> = {
   '/contact': 'nav.contact'
 }
 
-const menu = (config.header?.menu ?? []).map((item) => {
-  const key = menuKeyMap[item.link]
-  return {
-    title: key ? t(key) : item.title,
-    link: localizedPath(item.link, lang)
-  }
-})
+// 英文站只展示有英文镜像的菜单项，避免生成 /en/talks 这类 404 链接
+const menu = (config.header?.menu ?? [])
+  .filter((item) => lang !== 'en' || hasEnAlternate(item.link))
+  .map((item) => {
+    const key = menuKeyMap[item.link]
+    return {
+      title: key ? t(key) : item.title,
+      link: localizedPath(item.link, lang)
+    }
+  })
 
 const homeHref = localizedPath('/', lang)
 const searchHref = localizedPath('/search', lang)

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -1,5 +1,6 @@
 ---
-import { useTranslations, type Lang } from '@/i18n/ui'
+import { hasEnVersion } from '@/i18n/translations'
+import { stripLangPrefix, useTranslations, withLangPrefix, type Lang } from '@/i18n/ui'
 
 interface Props {
   lang: Lang
@@ -8,12 +9,18 @@ interface Props {
 const { lang } = Astro.props
 const t = useTranslations(lang)
 const label = lang === 'en' ? '中' : 'EN'
+
+const barePath = stripLangPrefix(Astro.url.pathname)
+// en -> zh：中文原文一定存在；zh -> en：只有真实英文镜像才跳，否则落回英文首页
+const target =
+  lang === 'en' ? barePath : (await hasEnVersion(barePath)) ? withLangPrefix(barePath, 'en') : '/en'
 ---
 
 <button
   id='toggleLang'
   type='button'
   data-lang={lang}
+  data-target={target}
   class='box-content flex size-5 items-center justify-center rounded-md border p-1.5 text-xs font-semibold leading-none transition-colors hover:bg-border hover:text-primary sm:group-[.not-top]:rounded-xl'
 >
   <span class='sr-only'>{t('nav.toggleLang')}</span>
@@ -25,22 +32,12 @@ const label = lang === 'en' ? '中' : 'EN'
 
   const LEAVE_DURATION = 250
 
-  function targetPathname(pathname: string, current: 'zh' | 'en'): string {
-    if (current === 'en') {
-      if (pathname === '/en' || pathname === '/en/') return '/'
-      if (pathname.startsWith('/en/')) return pathname.slice(3)
-      return '/'
-    }
-    if (pathname === '/' || pathname === '') return '/en'
-    return `/en${pathname.startsWith('/') ? pathname : `/${pathname}`}`
-  }
-
   document.addEventListener('click', (event) => {
     const target = event.target as HTMLElement | null
     const btn = target?.closest('#toggleLang') as HTMLButtonElement | null
     if (!btn) return
     const current = (btn.dataset.lang === 'en' ? 'en' : 'zh') as 'zh' | 'en'
-    const next = targetPathname(window.location.pathname, current)
+    const next = btn.dataset.target ?? '/en'
     trackSiteEvent('language_switch_click', {
       page: window.location.pathname,
       from_locale: current,

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -84,10 +84,14 @@ export function localizedPath(path: string, lang: Lang): string {
  */
 export function hasEnAlternate(barePath: string): boolean {
   if (barePath === '/') return true
-  if (['/about', '/projects', '/links', '/contact', '/search', '/curated'].includes(barePath))
+  if (
+    ['/about', '/projects', '/links', '/contact', '/search', '/curated', '/tags'].includes(barePath)
+  )
     return true
   // blog & notes: only the paginated list is mirrored under /en, not detail pages
   if (/^\/blog(\/\d+)?$/.test(barePath)) return true
   if (/^\/notes(\/\d+)?$/.test(barePath)) return true
+  // /tags/<tag> detail pages are NOT mirrored: en posts carry translated tag
+  // names, so there is no 1:1 /en/tags/<zh-tag> URL
   return false
 }


### PR DESCRIPTION
英文站导航的 Talks 指向不存在的 /en/talks；在 /talks、/agent-teams、/notes/tags 等无英文版页面点语言切换也会 404。现在切换目标由服务端 hasEnVersion 计算，无英文版时降级回 /en 首页；英文导航隐藏无镜像的菜单项。

🤖 Generated with [Claude Code](https://claude.com/claude-code)