### PR TITLE
feat(rss): add English feed at /en/rss.xml

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "rehype-katex": "^7.0.1",
         "remark-cjk-friendly": "^2.3.1",
         "remark-math": "^6.0.0",
+        "remark-mdx": "^3.1.0",
         "satori": "^0.26.0",
         "sharp": "^0.34.2",
         "typescript": "^5.8.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-dom": "^19.2.4",
     "rehype-katex": "^7.0.1",
     "remark-cjk-friendly": "^2.3.1",
+    "remark-mdx": "^3.1.0",
     "remark-math": "^6.0.0",
     "satori": "^0.26.0",
     "sharp": "^0.34.2",

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -138,12 +138,12 @@ const siteGraph = {
 {/* Sitemap */}
 <link href='/sitemap.xml' rel='sitemap' type='application/xml' />
 
-{/* RSS auto-discovery */}
+{/* RSS auto-discovery — per-language feed */}
 <link
   rel='alternate'
   type='application/rss+xml'
-  title={config.title}
-  href={`${Astro.site}rss.xml`}
+  title={lang === 'en' ? `${config.title} (EN)` : config.title}
+  href={`${Astro.site}${lang === 'en' ? 'en/rss.xml' : 'rss.xml'}`}
 />
 
 <meta content={Astro.generator} name='generator' />

--- a/src/pages/en/rss.xml.ts
+++ b/src/pages/en/rss.xml.ts
@@ -4,6 +4,7 @@ import { getCollection, type CollectionEntry } from 'astro:content'
 import rss from '@astrojs/rss'
 import type { Root } from 'mdast'
 import rehypeStringify from 'rehype-stringify'
+import remarkCjkFriendly from 'remark-cjk-friendly'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
@@ -46,6 +47,7 @@ const renderContent = async (post: CollectionEntry<'blog' | 'blogEn'>, site: URL
 
   const file = await unified()
     .use(remarkParse)
+    .use(remarkCjkFriendly)
     .use(remarkReplaceImageLink)
     .use(remarkRehype)
     .use(rehypeStringify)
@@ -76,14 +78,22 @@ const GET = async (context: AstroGlobal) => {
     site: `${import.meta.env.SITE}/en`,
     customData: '<language>en-us</language>',
     items: await Promise.all(
-      allPostsByDate.map(async (post) => ({
-        pubDate: post.data.publishDate,
-        link: `/en/blog/${post.data.translationKey}`,
-        customData: `<h:img src="${typeof post.data.heroImage?.src === 'string' ? post.data.heroImage?.src : post.data.heroImage?.src.src}" />
-          <enclosure url="${typeof post.data.heroImage?.src === 'string' ? post.data.heroImage?.src : post.data.heroImage?.src.src}" />`,
-        content: await renderContent(post, siteUrl),
-        ...post.data
-      }))
+      allPostsByDate.map(async (post) => {
+        const heroSrc =
+          typeof post.data.heroImage?.src === 'string'
+            ? post.data.heroImage.src
+            : post.data.heroImage?.src.src
+        return {
+          pubDate: post.data.publishDate,
+          link: `/en/blog/${post.data.translationKey}`,
+          // no heroImage -> no customData; interpolating undefined emits src="undefined"
+          ...(heroSrc
+            ? { customData: `<h:img src="${heroSrc}" />\n          <enclosure url="${heroSrc}" />` }
+            : {}),
+          content: await renderContent(post, siteUrl),
+          ...post.data
+        }
+      })
     )
   })
 }

--- a/src/pages/en/rss.xml.ts
+++ b/src/pages/en/rss.xml.ts
@@ -1,3 +1,4 @@
+import { posix } from 'node:path'
 import type { AstroGlobal, ImageMetadata } from 'astro'
 import { getImage } from 'astro:assets'
 import { getCollection, type CollectionEntry } from 'astro:content'
@@ -5,6 +6,7 @@ import rss from '@astrojs/rss'
 import type { Root } from 'mdast'
 import rehypeStringify from 'rehype-stringify'
 import remarkCjkFriendly from 'remark-cjk-friendly'
+import remarkMdx from 'remark-mdx'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
@@ -28,18 +30,25 @@ const renderContent = async (post: CollectionEntry<'blog' | 'blogEn'>, site: URL
     return async function (tree: Root) {
       const promises: Promise<void>[] = []
       visit(tree, 'image', (node) => {
-        if (node.url.startsWith('/images')) {
-          node.url = `${site}${node.url.replace('/', '')}`
-        } else {
-          const imagePathPrefix = `/src/content/blog/${post.id}/${node.url.replace('./', '')}`
-          const promise = imagesGlob[imagePathPrefix]?.().then(async (res) => {
-            const imagePath = res?.default
-            if (imagePath) {
-              node.url = `${site}${(await getImage({ src: imagePath })).src.replace('/', '')}`
-            }
-          })
-          if (promise) promises.push(promise)
+        if (/^[a-z][a-z\d+.-]*:/i.test(node.url)) return
+        if (node.url.startsWith('/')) {
+          node.url = new URL(node.url, site).href
+          return
         }
+
+        const filePath = post.filePath?.replaceAll('\\', '/')
+        if (!filePath) throw new Error(`Missing source path for RSS entry: ${post.id}`)
+
+        const imageKey = `/${posix.normalize(posix.join(posix.dirname(filePath), node.url))}`
+        const loadImage = imagesGlob[imageKey]
+        if (!loadImage) throw new Error(`Unable to resolve RSS image: ${imageKey}`)
+
+        promises.push(
+          loadImage().then(async ({ default: imagePath }) => {
+            const optimized = await getImage({ src: imagePath })
+            node.url = new URL(optimized.src, site).href
+          })
+        )
       })
       await Promise.all(promises)
     }
@@ -47,6 +56,7 @@ const renderContent = async (post: CollectionEntry<'blog' | 'blogEn'>, site: URL
 
   const file = await unified()
     .use(remarkParse)
+    .use(remarkMdx)
     .use(remarkCjkFriendly)
     .use(remarkReplaceImageLink)
     .use(remarkRehype)

--- a/src/pages/en/rss.xml.ts
+++ b/src/pages/en/rss.xml.ts
@@ -1,0 +1,91 @@
+import type { AstroGlobal, ImageMetadata } from 'astro'
+import { getImage } from 'astro:assets'
+import { getCollection, type CollectionEntry } from 'astro:content'
+import rss from '@astrojs/rss'
+import type { Root } from 'mdast'
+import rehypeStringify from 'rehype-stringify'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import { unified } from 'unified'
+import { visit } from 'unist-util-visit'
+import config from 'virtual:config'
+import { sortMDByDate } from 'astro-pure/server'
+
+export const prerender = true
+
+// Get dynamic import of images as a map collection
+const imagesGlob = import.meta.glob<{ default: ImageMetadata }>(
+  '/src/content/blog/**/*.{jpeg,jpg,png,gif}' // add more image formats if needed
+)
+
+const renderContent = async (post: CollectionEntry<'blog' | 'blogEn'>, site: URL) => {
+  // Replace image links with the correct path
+  function remarkReplaceImageLink() {
+    /**
+     * @param {Root} tree
+     */
+    return async function (tree: Root) {
+      const promises: Promise<void>[] = []
+      visit(tree, 'image', (node) => {
+        if (node.url.startsWith('/images')) {
+          node.url = `${site}${node.url.replace('/', '')}`
+        } else {
+          const imagePathPrefix = `/src/content/blog/${post.id}/${node.url.replace('./', '')}`
+          const promise = imagesGlob[imagePathPrefix]?.().then(async (res) => {
+            const imagePath = res?.default
+            if (imagePath) {
+              node.url = `${site}${(await getImage({ src: imagePath })).src.replace('/', '')}`
+            }
+          })
+          if (promise) promises.push(promise)
+        }
+      })
+      await Promise.all(promises)
+    }
+  }
+
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkReplaceImageLink)
+    .use(remarkRehype)
+    .use(rehypeStringify)
+    .process(post.body)
+
+  return String(file)
+}
+
+const GET = async (context: AstroGlobal) => {
+  // EN post URLs are keyed by translationKey (post.id slugifies the `.en`
+  // filename and is not a valid route), so drop entries without one.
+  const allPostsByDate = sortMDByDate(
+    (await getCollection('blogEn')).filter(
+      (post) => (import.meta.env.PROD ? !post.data.draft : true) && post.data.translationKey
+    )
+  ) as CollectionEntry<'blogEn'>[]
+  const siteUrl = context.site ?? new URL(import.meta.env.SITE)
+
+  return rss({
+    // Basic configs
+    trailingSlash: false,
+    xmlns: { h: 'http://www.w3.org/TR/html4/' },
+    stylesheet: '/scripts/pretty-feed-v3.xsl',
+
+    // Contents
+    title: `${config.title} (EN)`,
+    description: 'English posts — agents, LLM internals, and engineering notes.',
+    site: `${import.meta.env.SITE}/en`,
+    customData: '<language>en-us</language>',
+    items: await Promise.all(
+      allPostsByDate.map(async (post) => ({
+        pubDate: post.data.publishDate,
+        link: `/en/blog/${post.data.translationKey}`,
+        customData: `<h:img src="${typeof post.data.heroImage?.src === 'string' ? post.data.heroImage?.src : post.data.heroImage?.src.src}" />
+          <enclosure url="${typeof post.data.heroImage?.src === 'string' ? post.data.heroImage?.src : post.data.heroImage?.src.src}" />`,
+        content: await renderContent(post, siteUrl),
+        ...post.data
+      }))
+    )
+  })
+}
+
+export { GET }

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,3 +1,4 @@
+import { posix } from 'node:path'
 import type { AstroGlobal, ImageMetadata } from 'astro'
 import { getImage } from 'astro:assets'
 import type { CollectionEntry } from 'astro:content'
@@ -5,6 +6,7 @@ import rss from '@astrojs/rss'
 import type { Root } from 'mdast'
 import rehypeStringify from 'rehype-stringify'
 import remarkCjkFriendly from 'remark-cjk-friendly'
+import remarkMdx from 'remark-mdx'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
@@ -28,18 +30,25 @@ const renderContent = async (post: CollectionEntry<'blog'>, site: URL) => {
     return async function (tree: Root) {
       const promises: Promise<void>[] = []
       visit(tree, 'image', (node) => {
-        if (node.url.startsWith('/images')) {
-          node.url = `${site}${node.url.replace('/', '')}`
-        } else {
-          const imagePathPrefix = `/src/content/blog/${post.id}/${node.url.replace('./', '')}`
-          const promise = imagesGlob[imagePathPrefix]?.().then(async (res) => {
-            const imagePath = res?.default
-            if (imagePath) {
-              node.url = `${site}${(await getImage({ src: imagePath })).src.replace('/', '')}`
-            }
-          })
-          if (promise) promises.push(promise)
+        if (/^[a-z][a-z\d+.-]*:/i.test(node.url)) return
+        if (node.url.startsWith('/')) {
+          node.url = new URL(node.url, site).href
+          return
         }
+
+        const filePath = post.filePath?.replaceAll('\\', '/')
+        if (!filePath) throw new Error(`Missing source path for RSS entry: ${post.id}`)
+
+        const imageKey = `/${posix.normalize(posix.join(posix.dirname(filePath), node.url))}`
+        const loadImage = imagesGlob[imageKey]
+        if (!loadImage) throw new Error(`Unable to resolve RSS image: ${imageKey}`)
+
+        promises.push(
+          loadImage().then(async ({ default: imagePath }) => {
+            const optimized = await getImage({ src: imagePath })
+            node.url = new URL(optimized.src, site).href
+          })
+        )
       })
       await Promise.all(promises)
     }
@@ -47,6 +56,7 @@ const renderContent = async (post: CollectionEntry<'blog'>, site: URL) => {
 
   const file = await unified()
     .use(remarkParse)
+    .use(remarkMdx)
     .use(remarkCjkFriendly)
     .use(remarkReplaceImageLink)
     .use(remarkRehype)

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -71,14 +71,22 @@ const GET = async (context: AstroGlobal) => {
     description: config.description,
     site: import.meta.env.SITE,
     items: await Promise.all(
-      allPostsByDate.map(async (post) => ({
-        pubDate: post.data.publishDate,
-        link: `/blog/${post.id}`,
-        customData: `<h:img src="${typeof post.data.heroImage?.src === 'string' ? post.data.heroImage?.src : post.data.heroImage?.src.src}" />
-          <enclosure url="${typeof post.data.heroImage?.src === 'string' ? post.data.heroImage?.src : post.data.heroImage?.src.src}" />`,
-        content: await renderContent(post, siteUrl),
-        ...post.data
-      }))
+      allPostsByDate.map(async (post) => {
+        const heroSrc =
+          typeof post.data.heroImage?.src === 'string'
+            ? post.data.heroImage.src
+            : post.data.heroImage?.src.src
+        return {
+          pubDate: post.data.publishDate,
+          link: `/blog/${post.id}`,
+          // no heroImage -> no customData; interpolating undefined emits src="undefined"
+          ...(heroSrc
+            ? { customData: `<h:img src="${heroSrc}" />\n          <enclosure url="${heroSrc}" />` }
+            : {}),
+          content: await renderContent(post, siteUrl),
+          ...post.data
+        }
+      })
     )
   })
 }


### PR DESCRIPTION
13 篇英文镜像此前没有任何订阅入口。新增 /en/rss.xml（全文输出，复用现有 XSL 样式表），英文页面的 RSS autodiscovery 改为指向英文 feed。

Notes: item link 必须用 translationKey 而不是 post.id——blogEn 的 id 会把 .en 文件名 slug 化成不存在的路由。

🤖 Generated with [Claude Code](https://claude.com/claude-code)