### PR TITLE
chore(search): unify on the JSON search API, drop Pagefind

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Notes 的 `status` 可选：
 - `projects/ProjectSection.astro`: 项目页分组 section。
 - `projects/Sponsors.astro`: 赞助者列表。
 - `projects/Sponsorship.astro`: 赞助入口。
-- `search/PFSearch.astro`: Pagefind 搜索 UI。
+- `search/SiteSearch.astro`: 站内搜索 UI（走 /api/search.json，中英文各自索引）。
 - `talks/TalksSeries.astro`: Talks 时间线/系列展示。
 - `terminal/*`: terminal dev mode、pseudo-FS、命令系统、文章 viewer 和样式。
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -32,8 +32,7 @@ const excludedSitemapPathPatterns = [
   /^\/(?:en\/)?404\/?$/,
   /^\/(?:en\/)?search\/?$/,
   /^\/api(?:\/|$)/,
-  /^\/\.well-known\/joye-manifest\.json$/,
-  /^\/pagefind(?:\/|$)/
+  /^\/\.well-known\/joye-manifest\.json$/
 ]
 
 const shouldIncludeInSitemap = (page: string) => {

--- a/src/components/HeroEn.astro
+++ b/src/components/HeroEn.astro
@@ -102,7 +102,6 @@ const dateTimeOptions: Intl.DateTimeFormatOptions = {
               <a
                 aria-label={`View more blogs with the tag ${tag}`}
                 class='hover:underline hover:underline-offset-4'
-                data-pagefind-filter='tag'
                 href={`/en/tags/${tag}`}
               >
                 {tag}

--- a/src/components/search/SiteSearch.astro
+++ b/src/components/search/SiteSearch.astro
@@ -1,30 +1,19 @@
----
-import '@pagefind/default-ui/css/ui.css'
-
-const isLocalDev = import.meta.env.DEV
----
-
-<joye-site-search data-mode={isLocalDev ? 'local' : 'pagefind'}>
+{/* 站内搜索：走 /api/search.json（terminal 的 search 命令同款后端），dev/prod 行为一致 */}
+<joye-site-search>
   <aside class='form my-4'>
-    {
-      isLocalDev ? (
-        <div id='local-site-search' class='local-search'>
-          <input
-            id='local-search-input'
-            class='local-search-input'
-            type='search'
-            placeholder='Search posts and notes...'
-            autocomplete='off'
-            spellcheck='false'
-            aria-label='Search posts and notes'
-          />
-          <div id='local-search-status' class='local-search-status' aria-live='polite' />
-          <ol id='local-search-results' class='local-search-results' />
-        </div>
-      ) : (
-        <div id='site-search' />
-      )
-    }
+    <div id='local-site-search' class='local-search'>
+      <input
+        id='local-search-input'
+        class='local-search-input'
+        type='search'
+        placeholder='Search posts and notes...'
+        autocomplete='off'
+        spellcheck='false'
+        aria-label='Search posts and notes'
+      />
+      <div id='local-search-status' class='local-search-status' aria-live='polite'></div>
+      <ol id='local-search-results' class='local-search-results'></ol>
+    </div>
   </aside>
 </joye-site-search>
 
@@ -44,38 +33,6 @@ const isLocalDev = import.meta.env.DEV
       if (this.dataset.ready === 'true') return
       this.dataset.ready = 'true'
 
-      if (this.dataset.mode === 'local') {
-        this.initLocalSearch()
-      } else {
-        this.initPagefind()
-      }
-    }
-
-    private initPagefind() {
-      const formatURL = (path: string) => path.replace(/(.)\/(#.*)?$/, '$1$2')
-      const onIdle = window.requestIdleCallback || ((cb) => setTimeout(cb, 1))
-
-      onIdle(async () => {
-        // @ts-expect-error — Missing types for @pagefind/default-ui package.
-        const { PagefindUI } = await import('@pagefind/default-ui')
-        new PagefindUI({
-          element: '#site-search',
-          baseUrl: import.meta.env.BASE_URL,
-          bundlePath: import.meta.env.BASE_URL.replace(/\/$/, '') + '/pagefind/',
-          showImages: false,
-          showSubResults: true,
-          processResult: (result: { url: string; sub_results: Array<{ url: string }> }) => {
-            result.url = formatURL(result.url)
-            result.sub_results = result.sub_results.map((sub_result) => {
-              sub_result.url = formatURL(sub_result.url)
-              return sub_result
-            })
-          }
-        })
-      })
-    }
-
-    private initLocalSearch() {
       const input = this.querySelector<HTMLInputElement>('#local-search-input')
       const status = this.querySelector<HTMLElement>('#local-search-status')
       const results = this.querySelector<HTMLOListElement>('#local-search-results')
@@ -155,20 +112,6 @@ const isLocalDev = import.meta.env.DEV
 </script>
 
 <style>
-  #site-search {
-    --pagefind-ui-scale: 0.8;
-    --pagefind-ui-primary: hsl(var(--primary) / var(--un-bg-opacity, 1));
-    --pagefind-ui-text: hsl(var(--foreground) / var(--un-text-opacity, 1));
-    --pagefind-ui-background: hsl(var(--muted) / var(--un-bg-opacity, 1));
-    --pagefind-ui-border: hsl(var(--border) / var(--un-border-opacity, 1));
-    --pagefind-ui-tag: hsl(var(--muted-foreground) / var(--un-text-opacity, 1));
-    --pagefind-ui-border-width: 2px;
-    --pagefind-ui-border-radius: calc(var(--radius) + 2px);
-    --pagefind-ui-image-border-radius: calc(var(--radius) + 2px);
-    --pagefind-ui-image-box-ratio: 3 / 2;
-    --pagefind-ui-font: sans-serif;
-  }
-
   .local-search {
     display: grid;
     gap: 0.9rem;

--- a/src/components/search/SiteSearch.astro
+++ b/src/components/search/SiteSearch.astro
@@ -59,9 +59,11 @@
         status.textContent = 'Searching...'
 
         try {
-          const response = await fetch(`/api/search.json?q=${encodeURIComponent(query)}&limit=10`, {
-            signal: activeRequest.signal
-          })
+          const lang = window.location.pathname.startsWith('/en') ? 'en' : 'zh'
+          const response = await fetch(
+            `/api/search.json?q=${encodeURIComponent(query)}&limit=10&lang=${lang}`,
+            { signal: activeRequest.signal }
+          )
           if (!response.ok) throw new Error(`HTTP ${response.status}`)
           const payload = (await response.json()) as { results: LocalSearchResult[] }
           renderResults(payload.results)

--- a/src/components/terminal/commands.tsx
+++ b/src/components/terminal/commands.tsx
@@ -310,7 +310,11 @@ export const commands: CommandRegistry = {
       push([{ kind: 'text', tone: 'muted', text: `searching "${query}" …` }])
 
       try {
-        const response = await fetch(`/api/search.json?q=${encodeURIComponent(query)}&limit=6`)
+        const lang =
+          typeof window !== 'undefined' && window.location.pathname.startsWith('/en') ? 'en' : 'zh'
+        const response = await fetch(
+          `/api/search.json?q=${encodeURIComponent(query)}&limit=6&lang=${lang}`
+        )
         if (!response.ok) throw new Error(`HTTP ${response.status}`)
         const payload = (await response.json()) as { results: SearchApiResult[] }
 

--- a/src/pages/api/search.json.ts
+++ b/src/pages/api/search.json.ts
@@ -21,12 +21,13 @@ type SearchResult = Omit<SearchDoc, 'body'> & {
 export const GET: APIRoute = async ({ url }) => {
   const query = (url.searchParams.get('q') ?? '').trim()
   const limit = clampLimit(Number(url.searchParams.get('limit') ?? 10))
+  const lang = url.searchParams.get('lang') === 'en' ? 'en' : 'zh'
 
   if (query.length < 2) {
     return json({ query, results: [] })
   }
 
-  const docs = await buildSearchDocs()
+  const docs = await buildSearchDocs(lang)
   const results = docs
     .map((doc) => scoreDoc(doc, query))
     .filter((result): result is SearchResult => Boolean(result))
@@ -50,7 +51,37 @@ function clampLimit(limit: number) {
   return Math.max(1, Math.min(20, Math.floor(limit)))
 }
 
-async function buildSearchDocs(): Promise<SearchDoc[]> {
+async function buildSearchDocs(lang: 'zh' | 'en'): Promise<SearchDoc[]> {
+  // en 集合的路由用 translationKey（.en 文件名 slug 化后不是合法路由）
+  if (lang === 'en') {
+    const [blogPosts, notesEntries] = await Promise.all([
+      getCollection('blogEn', ({ data }) => !data.draft && Boolean(data.translationKey)),
+      getCollection('notesEn', ({ data }) => !data.draft && Boolean(data.translationKey))
+    ])
+
+    const blogDocs = blogPosts.map<SearchDoc>((entry) => ({
+      collection: 'blog',
+      title: entry.data.title,
+      description: entry.data.description,
+      url: `/en/blog/${encodeURI(entry.data.translationKey!)}`,
+      date: formatDate(entry.data.publishDate),
+      tags: entry.data.tags,
+      body: normalizeBody((entry as { body?: string }).body ?? '')
+    }))
+
+    const noteDocs = notesEntries.map<SearchDoc>((entry) => ({
+      collection: 'notes',
+      title: entry.data.title,
+      description: entry.data.description,
+      url: `/en/notes/${encodeURI(entry.data.translationKey!)}`,
+      date: formatDate(entry.data.date),
+      tags: entry.data.tags,
+      body: normalizeBody((entry as { body?: string }).body ?? '')
+    }))
+
+    return [...blogDocs, ...noteDocs]
+  }
+
   const [blogPosts, notesEntries] = await Promise.all([
     getCollection('blog', ({ data }) => !data.draft),
     getCollection('notes', ({ data }) => !data.draft)

--- a/src/pages/en/search/index.astro
+++ b/src/pages/en/search/index.astro
@@ -1,8 +1,7 @@
 ---
 import { Button } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
-import PFSearch from '@/components/search/PFSearch.astro'
-import { integ } from '@/site-config'
+import SiteSearch from '@/components/search/SiteSearch.astro'
 
 const meta = {
   description: 'Search relative posts of the whole blog',
@@ -19,16 +18,8 @@ const meta = {
     </div>
 
     <div id='content' class='animate'>
-      {
-        integ.pagefind ? (
-          <>
-            <p>Enter a search term or phrase to search the blog.</p>
-            <PFSearch />
-          </>
-        ) : (
-          <p>Pagefind is disabled.</p>
-        )
-      }
+      <p>Enter a search term or phrase to search the blog.</p>
+      <SiteSearch />
     </div>
   </main>
 </PageLayout>

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -7,7 +7,6 @@ const robotsTxt = [
   'User-agent: *',
   'Allow: /',
   'Disallow: /api/',
-  'Disallow: /pagefind/',
   '',
   `Sitemap: ${new URL('/sitemap.xml', site).href}`
 ].join('\n')

--- a/src/pages/search/index.astro
+++ b/src/pages/search/index.astro
@@ -1,8 +1,7 @@
 ---
 import { Button } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
-import PFSearch from '@/components/search/PFSearch.astro'
-import { integ } from '@/site-config'
+import SiteSearch from '@/components/search/SiteSearch.astro'
 
 const meta = {
   description: 'Search relative posts of the whole blog',
@@ -19,16 +18,8 @@ const meta = {
     </div>
 
     <div id='content' class='animate'>
-      {
-        integ.pagefind ? (
-          <>
-            <p>Enter a search term or phrase to search the blog.</p>
-            <PFSearch />
-          </>
-        ) : (
-          <p>Pagefind is disabled.</p>
-        )
-      }
+      <p>Enter a search term or phrase to search the blog.</p>
+      <SiteSearch />
     </div>
   </main>
 </PageLayout>

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -122,8 +122,8 @@ export const integ: IntegrationUserConfig = {
       { name: 'Avatar', val: 'https://joyehuang.me/favicon/favicon.ico' }
     ]
   },
-  // Enable page search function
-  pagefind: true,
+  // Page search runs on /api/search.json (see SiteSearch.astro); pagefind build hook disabled
+  pagefind: false,
   // Add a random quote to the footer (default on homepage footer)
   // See: https://astro-pure.js.org/docs/integrations/advanced#web-content-render
   quote: {


### PR DESCRIPTION
两套搜索合并为一套：/search 页和 terminal 的 search 命令统一走 /api/search.json，dev 和生产行为一致。删除 Pagefind 构建钩子及配置残留。

Notes: 放弃的是 Pagefind 的静态索引和高亮 UI——内容量小、且中文 substring 匹配比 Pagefind 的 CJK 分词更稳，权衡后选 JSON API。

🤖 Generated with [Claude Code](https://claude.com/claude-code)