### PR TITLE
feat(agent-teams): improve development-phase team experience

### DIFF
--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -1040,7 +1040,7 @@ const signupClosed = isSignupClosed()
     const label = card.querySelector<HTMLElement>('[data-count-label]')
     if (label) {
       label.classList.remove('skeleton')
-      label.textContent = capacity != null ? `${team.count} / ${capacity} 人` : `${team.count} 人`
+      label.textContent = `${team.count} 人`
     }
 
     const full = capacity != null && team.count >= capacity

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -332,7 +332,7 @@ const signupClosed = isSignupClosed()
 
   {/* 分页控件：order-last 保证它排在赛道网格下面（而不是排到「创建赛道」下面）。 */}
   <div
-    class='board-pagination order-last mt-5 mb-4 items-center justify-center gap-3 text-sm text-muted-foreground'
+    class='board-pagination order-last mt-5 mb-4 flex-wrap items-center justify-center gap-2 text-sm text-muted-foreground'
     data-board-pagination
     hidden
   >
@@ -1449,7 +1449,8 @@ const signupClosed = isSignupClosed()
       'inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40'
 
     const goTo = (next: number) => {
-      board.dataset.page = String(next)
+      const target = Math.min(pageCount - 1, Math.max(0, next))
+      board.dataset.page = String(target)
       renderPagination(board, cards)
       // 翻页后卷回赛道网格顶部——不然人还停在页面底部的翻页按钮旁边，看不到新一页的卡片。
       // 页面顶部有个 sticky header（top:1rem、约 44px 高），scrollIntoView 的默认对齐
@@ -1468,8 +1469,24 @@ const signupClosed = isSignupClosed()
     prev.disabled = page === 0
     prev.addEventListener('click', () => goTo(page - 1))
 
-    const label = document.createElement('span')
-    label.textContent = `第 ${page + 1} / ${pageCount} 页`
+    const pageButtons = document.createElement('span')
+    pageButtons.className = 'inline-flex flex-wrap items-center justify-center gap-1.5'
+    const pageBtnClass =
+      'inline-flex size-8 items-center justify-center rounded-lg border text-sm font-medium transition-colors hover:bg-muted'
+    for (let index = 0; index < pageCount; index += 1) {
+      const pageButton = document.createElement('button')
+      const pageNumber = index + 1
+      const current = index === page
+      pageButton.type = 'button'
+      pageButton.className = current
+        ? `${pageBtnClass} border-foreground bg-foreground text-background`
+        : `${pageBtnClass} text-foreground`
+      pageButton.textContent = String(pageNumber)
+      pageButton.setAttribute('aria-label', current ? `当前第 ${pageNumber} 页` : `跳转到第 ${pageNumber} 页`)
+      if (current) pageButton.setAttribute('aria-current', 'page')
+      else pageButton.addEventListener('click', () => goTo(index))
+      pageButtons.appendChild(pageButton)
+    }
 
     const next = document.createElement('button')
     next.type = 'button'
@@ -1478,7 +1495,7 @@ const signupClosed = isSignupClosed()
     next.disabled = page === pageCount - 1
     next.addEventListener('click', () => goTo(page + 1))
 
-    pager.append(prev, label, next)
+    pager.append(prev, pageButtons, next)
   }
 
   function applyState(

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -1,5 +1,6 @@
 ---
 import { activity, isSignupClosed, teams } from '@/data/agent-teams'
+import qqGroup from '@/assets/qq-group-contact.jpg'
 
 // 服务端只渲染静态壳（队伍卡 + 表单结构）；实时名单、计数、配置状态由客户端
 // 脚本挂载后 fetch('/api/agent-teams') 填充。这样页面本身可静态缓存。
@@ -8,8 +9,8 @@ const signupClosed = isSignupClosed()
 ---
 
 <section class='agent-board not-prose mt-6 flex flex-col' data-agent-board>
-  <header class='board-hero mb-8 overflow-hidden rounded-2xl border p-6 sm:p-8'>
-    <div class='flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between'>
+  <header class='board-hero mb-6 overflow-visible rounded-2xl border p-5 sm:mb-8 sm:overflow-hidden sm:p-8'>
+    <div class='flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6'>
       <div class='min-w-0 sm:flex-1'>
         <div class='flex flex-wrap items-center gap-2 text-xs font-medium'>
           <span
@@ -36,19 +37,26 @@ const signupClosed = isSignupClosed()
           >
             活动详情 ↗
           </a>
-          <a
-            class='inline-flex items-center gap-1.5 rounded-full bg-amber-500 px-3 py-1.5 font-medium text-amber-950 no-underline transition-colors hover:bg-amber-400'
-            href={activity.qqGroupHref}
-          >
-            加入 QQ 群围观 <span aria-hidden='true'>→</span>
-          </a>
+          <span class='qq-group-wrap relative inline-flex' data-qq-group-wrap>
+            <button
+              type='button'
+              class='inline-flex items-center gap-1.5 rounded-full bg-amber-500 px-3 py-1.5 font-medium text-amber-950 transition-colors hover:bg-amber-400'
+              data-qq-group-toggle
+              aria-expanded='false'
+            >
+              加入 QQ 群围观 <span aria-hidden='true'>↗</span>
+            </button>
+            <span
+              class='qq-group-popover absolute left-0 top-full z-20 mt-2 w-56 rounded-xl border bg-background p-3 text-center shadow-lg'
+              data-qq-group-popover
+              role='dialog'
+              aria-label='QQ 群二维码'
+            >
+              <img class='mx-auto aspect-square w-full rounded-lg' src={qqGroup.src} alt='QQ 群二维码' />
+              <span class='mt-2 block text-xs text-muted-foreground'>群号 831907794 · 扫码加入</span>
+            </span>
+          </span>
         </div>
-        <p
-          class='mt-5 max-w-2xl rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm leading-relaxed text-foreground'
-          role='note'
-        >
-          {activity.notice}
-        </p>
       </div>
 
       {/* 参评队伍数：只统计至少有一位报名队员、最终可以参加评选的队伍。
@@ -92,6 +100,27 @@ const signupClosed = isSignupClosed()
   >
   </p>
 
+  <div class='team-search mb-5 flex items-center gap-3 rounded-xl border bg-background px-3 py-2.5'>
+    <svg aria-hidden='true' viewBox='0 0 24 24' class='size-4 shrink-0 text-muted-foreground' fill='none' stroke='currentColor' stroke-width='2'>
+      <circle cx='11' cy='11' r='8'></circle>
+      <path d='m21 21-4.3-4.3'></path>
+    </svg>
+    <label class='sr-only' for='agent-team-search'>搜索队伍、标签或成员</label>
+    <input
+      id='agent-team-search'
+      class='min-w-0 flex-1 border-0 bg-transparent text-sm text-foreground outline-none'
+      type='search'
+      placeholder='搜索队名、标签或成员…'
+      autocomplete='off'
+      data-team-search
+    />
+    <span class='shrink-0 text-xs text-muted-foreground' data-search-status aria-live='polite'></span>
+  </div>
+
+  <p class='mb-5 hidden rounded-lg border border-dashed px-4 py-6 text-center text-sm text-muted-foreground' data-search-empty>
+    没找到匹配的队伍，换个关键词试试。
+  </p>
+
   {/* order-last：视觉上把「创建赛道」卡排到队伍列表上面（DOM 里它仍在后面） */}
   <div class='order-last grid grid-cols-1 gap-4 sm:grid-cols-2' data-team-grid>
     {
@@ -126,6 +155,18 @@ const signupClosed = isSignupClosed()
             </div>
           )}
 
+          <a
+            class='github-link hidden items-center gap-1.5 self-start text-xs font-medium text-foreground underline-offset-4 hover:underline'
+            data-github-link
+            target='_blank'
+            rel='noopener noreferrer'
+          >
+            <svg aria-hidden='true' viewBox='0 0 24 24' class='size-3.5' fill='currentColor'>
+              <path d='M12 .7a11.5 11.5 0 0 0-3.64 22.41c.58.1.79-.25.79-.56v-2.23c-3.22.7-3.9-1.37-3.9-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.7.08-.7 1.16.08 1.78 1.2 1.78 1.2 1.03 1.77 2.71 1.26 3.37.96.1-.75.4-1.26.74-1.55-2.57-.29-5.27-1.29-5.27-5.69 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.47.11-3.05 0 0 .97-.31 3.16 1.18a10.9 10.9 0 0 1 5.75 0c2.19-1.49 3.16-1.18 3.16-1.18.63 1.58.23 2.76.11 3.05.74.81 1.19 1.83 1.19 3.09 0 4.41-2.71 5.4-5.29 5.68.42.36.78 1.07.78 2.16v3.2c0 .31.21.67.8.56A11.5 11.5 0 0 0 12 .7Z'></path>
+            </svg>
+            GitHub 仓库 ↗
+          </a>
+
           <ul class='roster m-0 flex list-none flex-wrap gap-1.5 p-0' data-roster>
             <li class='roster-empty flex flex-wrap gap-1.5'>
               <span class='sr-only'>名单加载中…</span>
@@ -150,31 +191,29 @@ const signupClosed = isSignupClosed()
           </button>
 
           <div class='mt-auto flex flex-wrap items-center gap-2 pt-1'>
+            <span
+              class='development-status inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-sm font-medium'
+              data-development-status
+              hidden={!signupClosed}
+            >
+              开发中
+            </span>
             <button
               type='button'
               class='signup-toggle inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
               data-signup-toggle
-              data-development={signupClosed ? 'true' : undefined}
               aria-expanded='false'
-              disabled={signupClosed}
+              hidden={signupClosed}
             >
-              {signupClosed ? '开发中' : '报名'}
+              报名
             </button>
             <button
               type='button'
-              class='leave-toggle inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
-              data-leave-toggle
+              class='manage-toggle inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+              data-manage-toggle
               aria-expanded='false'
             >
-              退出
-            </button>
-            <button
-              type='button'
-              class='detail-edit-toggle hidden items-center gap-1 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
-              data-detail-edit-toggle
-              aria-expanded='false'
-            >
-              队长编辑
+              队伍管理
             </button>
           </div>
 
@@ -251,7 +290,11 @@ const signupClosed = isSignupClosed()
             </div>
           </form>
 
-          <form class='leave-form mt-1 flex-col gap-2' data-leave-form hidden>
+          <div class='manage-panel mt-1 rounded-xl border bg-muted/30 p-3' data-manage-panel hidden>
+            <section>
+              <h3 class='m-0 text-sm font-medium text-foreground'>个人退出</h3>
+              <p class='m-0 mt-0.5 text-xs text-muted-foreground'>仅退出你自己的报名，需要 QQ 群口令。</p>
+          <form class='leave-form mt-3 flex flex-col gap-2' data-leave-form>
             <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
               你的 QQ 昵称（要和报名时一致）
               <input
@@ -293,8 +336,12 @@ const signupClosed = isSignupClosed()
               <p class='form-msg m-0 text-xs' data-leave-msg role='status'></p>
             </div>
           </form>
+            </section>
 
-          <form class='detail-form mt-1 flex-col gap-2' data-detail-form hidden>
+            <section class='mt-4 border-t pt-4' data-captain-management>
+              <h3 class='m-0 text-sm font-medium text-foreground'>队长管理</h3>
+              <p class='m-0 mt-0.5 text-xs text-muted-foreground'>维护项目资料、转让队长或移除摸鱼队员。</p>
+          <form class='detail-form mt-3 flex flex-col gap-2' data-detail-form>
             <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
               口令（粉丝群的名字）
               <input
@@ -317,6 +364,17 @@ const signupClosed = isSignupClosed()
               ></textarea>
             </label>
             <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+              GitHub 仓库（可选）
+              <input
+                class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
+                name='githubUrl'
+                type='url'
+                maxlength='200'
+                autocomplete='url'
+                placeholder='https://github.com/用户名/仓库名'
+              />
+            </label>
+            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
               转让队长给（可选，填名单里某人的昵称）
               <input
                 class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
@@ -325,6 +383,17 @@ const signupClosed = isSignupClosed()
                 maxlength='24'
                 autocomplete='off'
                 placeholder='留空则不变'
+              />
+            </label>
+            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+              移除队员（可选，填名单里的昵称）
+              <input
+                class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
+                name='kick'
+                type='text'
+                maxlength='24'
+                autocomplete='off'
+                placeholder='队长本人需先转让队长'
               />
             </label>
             <div class='flex items-center gap-3'>
@@ -344,6 +413,8 @@ const signupClosed = isSignupClosed()
               <p class='form-msg m-0 text-xs' data-detail-msg role='status'></p>
             </div>
           </form>
+            </section>
+          </div>
         </article>
       ))
     }
@@ -530,6 +601,24 @@ const signupClosed = isSignupClosed()
     width: fit-content;
   }
 
+  .qq-group-popover {
+    visibility: hidden;
+    opacity: 0;
+    transform: translateY(-0.35rem) scale(0.97);
+    transform-origin: top left;
+    transition:
+      opacity 180ms ease,
+      transform 180ms ease,
+      visibility 180ms;
+  }
+  .qq-group-wrap:hover .qq-group-popover,
+  .qq-group-wrap:focus-within .qq-group-popover,
+  .qq-group-wrap[data-open] .qq-group-popover {
+    visibility: visible;
+    opacity: 1;
+    transform: none;
+  }
+
   /* 参评队伍数：单独一块摆在 hero 右侧，用暖色描边与正文区隔。 */
   .team-count-card {
     position: relative;
@@ -639,6 +728,34 @@ const signupClosed = isSignupClosed()
     .team-count-loader,
     .team-count-number {
       transition: none;
+    }
+    .qq-group-popover {
+      transition: none;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .team-count-card {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      align-self: stretch;
+      padding: 0.7rem 1rem;
+      text-align: left;
+    }
+    .team-count-stage {
+      width: 3.5rem;
+      height: 2.5rem;
+      margin-inline: 0;
+    }
+    .team-count-number {
+      font-size: 2rem !important;
+    }
+    .team-count-card > div:last-child {
+      margin-top: 0;
+    }
+    .qq-group-popover {
+      width: min(14rem, calc(100vw - 5rem));
     }
   }
 
@@ -824,16 +941,10 @@ const signupClosed = isSignupClosed()
   .signup-form[data-open] {
     display: flex;
   }
-  .leave-form[data-open] {
-    display: flex;
-  }
-  .detail-form[data-open] {
-    display: flex;
-  }
   .create-form[data-open] {
     display: flex;
   }
-  .detail-edit-toggle[data-show] {
+  .github-link[data-show] {
     display: inline-flex;
   }
   .passcode-field[data-show] {
@@ -847,7 +958,8 @@ const signupClosed = isSignupClosed()
   }
   /* team-card 自带 .flex（内部要用 flex-col 排版），普通的 [hidden]/.hidden 优先级
      干不过它——分页隐藏另开一个更高优先级的属性选择器，而不是复用 .hidden。 */
-  .team-card[data-page-hidden] {
+  .team-card[data-page-hidden],
+  .team-card[data-search-hidden] {
     display: none;
   }
   /* 类型选择做成两张可点的卡片而不是裸单选框：原生 radio 视觉隐藏，
@@ -935,16 +1047,16 @@ const signupClosed = isSignupClosed()
     pointer-events: none;
     opacity: 0.5;
   }
-  /* 组队截止后，报名按钮转为当前阶段状态；不再用灰掉的禁用态暗示还能报名。 */
-  .signup-toggle[data-development='true'] {
-    cursor: default !important;
+  .development-status {
     border-color: rgb(245 158 11 / 0.45);
     background: rgb(245 158 11 / 0.12);
     color: #b45309;
-    opacity: 1 !important;
-    pointer-events: none;
   }
-  .signup-toggle[data-development='true']::before {
+  .development-status[hidden],
+  .signup-toggle[hidden] {
+    display: none;
+  }
+  .development-status::before {
     content: '';
     width: 0.4rem;
     height: 0.4rem;
@@ -952,7 +1064,7 @@ const signupClosed = isSignupClosed()
     background: #f59e0b;
     box-shadow: 0 0 0 3px rgb(245 158 11 / 0.14);
   }
-  :global(.dark) .signup-toggle[data-development='true'] {
+  :global(.dark) .development-status {
     color: #fcd34d;
   }
 
@@ -971,6 +1083,8 @@ const signupClosed = isSignupClosed()
 </style>
 
 <script>
+  import { normalizeTeamSearch, pageSizeForWidth, paginationFor } from '@/lib/agent-teams/board'
+
   type Member = { name: string; note: string | null; ts: number }
   type Team = {
     id: string
@@ -981,6 +1095,7 @@ const signupClosed = isSignupClosed()
     capacity: number | null
     members: Member[]
     detail: string | null
+    githubUrl: string | null
     captain?: string | null
   }
   type BoardData = {
@@ -1060,6 +1175,27 @@ const signupClosed = isSignupClosed()
     refreshDetailToggle(card)
   }
 
+  function renderGithub(card: HTMLElement, value: string | null) {
+    const link = card.querySelector<HTMLAnchorElement>('[data-github-link]')
+    if (!link) return
+    card.dataset.githubUrl = value ?? ''
+    if (value) {
+      link.href = value
+      link.dataset.show = ''
+      link.classList.remove('hidden')
+    } else {
+      link.removeAttribute('href')
+      delete link.dataset.show
+      link.classList.add('hidden')
+    }
+  }
+
+  function updateCardSearchText(card: HTMLElement, team: Team) {
+    card.dataset.searchText = normalizeTeamSearch(
+      [team.title, ...team.tags, ...team.members.map((member) => member.name)].join(' ')
+    )
+  }
+
   // 「查看详细介绍」按钮的显隐：有详细介绍，或者一句话简介被裁到看不全，就显示。
   // 注意要在卡片可见时量 scrollHeight——display:none 的卡（翻页隐藏）量出来是 0，
   // 所以翻页把某张卡显示出来时会再调一次这个函数重新判断。
@@ -1086,11 +1222,12 @@ const signupClosed = isSignupClosed()
     card.dataset.full = full ? 'true' : 'false'
     const toggle = card.querySelector<HTMLButtonElement>('[data-signup-toggle]')
     if (toggle) {
-      toggle.disabled = full || signupClosed
-      if (signupClosed) toggle.dataset.development = 'true'
-      else delete toggle.dataset.development
-      toggle.textContent = signupClosed ? '开发中' : full ? '名额已满' : '报名'
+      toggle.disabled = full
+      toggle.hidden = signupClosed
+      toggle.textContent = full ? '名额已满' : '报名'
     }
+    const status = card.querySelector<HTMLElement>('[data-development-status]')
+    if (status) status.hidden = !signupClosed
 
     const roster = card.querySelector<HTMLElement>('[data-roster]')
     if (!roster) return
@@ -1196,6 +1333,8 @@ const signupClosed = isSignupClosed()
     card.dataset.teamId = team.id
     delete card.dataset.full
     delete card.dataset.detail
+    delete card.dataset.githubUrl
+    delete card.dataset.searchText
 
     renderMeta(card, team)
 
@@ -1307,24 +1446,29 @@ const signupClosed = isSignupClosed()
       toggle.setAttribute('aria-expanded', 'false')
     })
 
-    // 退出 / 退赛：按昵称把自己从名单里删掉
-    const leaveToggle = card.querySelector<HTMLButtonElement>('[data-leave-toggle]')
+    const manageToggle = card.querySelector<HTMLButtonElement>('[data-manage-toggle]')
+    const managePanel = card.querySelector<HTMLElement>('[data-manage-panel]')
     const leaveForm = card.querySelector<HTMLFormElement>('[data-leave-form]')
-    if (leaveToggle && leaveForm) {
-      leaveToggle.addEventListener('click', () => {
-        if (board.dataset.configured !== 'true') return
-        const open = leaveForm.hasAttribute('data-open')
-        if (open) {
-          leaveForm.removeAttribute('data-open')
-          leaveForm.hidden = true
-          leaveToggle.setAttribute('aria-expanded', 'false')
-        } else {
-          leaveForm.setAttribute('data-open', '')
-          leaveForm.hidden = false
-          leaveToggle.setAttribute('aria-expanded', 'true')
-          leaveForm.querySelector<HTMLInputElement>('input[name="name"]')?.focus()
-        }
-      })
+    const detailForm = card.querySelector<HTMLFormElement>('[data-detail-form]')
+    const setManageOpen = (open: boolean) => {
+      if (!managePanel || !manageToggle) return
+      managePanel.hidden = !open
+      manageToggle.setAttribute('aria-expanded', open ? 'true' : 'false')
+      if (open && detailForm) {
+        const textarea = detailForm.querySelector<HTMLTextAreaElement>('textarea[name="detail"]')
+        const githubInput = detailForm.querySelector<HTMLInputElement>('input[name="githubUrl"]')
+        if (textarea) textarea.value = card.dataset.detail || ''
+        if (githubInput) githubInput.value = card.dataset.githubUrl || ''
+      }
+    }
+
+    manageToggle?.addEventListener('click', () => {
+      if (board.dataset.configured !== 'true') return
+      setManageOpen(managePanel?.hidden ?? true)
+    })
+
+    // 退出 / 退赛：按昵称软删除自己的有效报名。
+    if (leaveForm) {
 
       leaveForm.addEventListener('submit', async (event) => {
         event.preventDefault()
@@ -1349,10 +1493,9 @@ const signupClosed = isSignupClosed()
           if (res.ok && body.ok) {
             renderRoster(card, body.roster as Team)
             leaveForm.reset()
-            leaveForm.removeAttribute('data-open')
-            leaveForm.hidden = true
-            leaveToggle.setAttribute('aria-expanded', 'false')
+            setManageOpen(false)
             setMsg(leaveForm, '已退出', 'success', '[data-leave-msg]')
+            board.dispatchEvent(new CustomEvent('agent-teams:reload'))
           } else {
             setMsg(leaveForm, (body && body.message) || '操作失败，请稍后再试', 'error', '[data-leave-msg]')
           }
@@ -1364,33 +1507,12 @@ const signupClosed = isSignupClosed()
       })
 
       leaveForm.querySelector<HTMLButtonElement>('[data-cancel]')?.addEventListener('click', () => {
-        leaveForm.removeAttribute('data-open')
-        leaveForm.hidden = true
-        leaveToggle.setAttribute('aria-expanded', 'false')
+        setManageOpen(false)
       })
     }
 
-    // 队长编辑「详细介绍」
-    const detailToggle = card.querySelector<HTMLButtonElement>('[data-detail-edit-toggle]')
-    const detailForm = card.querySelector<HTMLFormElement>('[data-detail-form]')
-    if (detailToggle && detailForm) {
-      const textarea = detailForm.querySelector<HTMLTextAreaElement>('textarea[name="detail"]')
-
-      detailToggle.addEventListener('click', () => {
-        const open = detailForm.hasAttribute('data-open')
-        if (open) {
-          detailForm.removeAttribute('data-open')
-          detailForm.hidden = true
-          detailToggle.setAttribute('aria-expanded', 'false')
-        } else {
-          if (textarea) textarea.value = card.dataset.detail || ''
-          detailForm.setAttribute('data-open', '')
-          detailForm.hidden = false
-          detailToggle.setAttribute('aria-expanded', 'true')
-          detailForm.querySelector<HTMLInputElement>('input[name="passcode"]')?.focus()
-        }
-      })
-
+    // 队长维护项目资料、转让队长、移除队员。
+    if (detailForm) {
       detailForm.addEventListener('submit', async (event) => {
         event.preventDefault()
         const teamId = card.dataset.teamId || ''
@@ -1398,7 +1520,13 @@ const signupClosed = isSignupClosed()
         const data = new FormData(detailForm)
         const passcode = String(data.get('passcode') || '')
         const captainName = String(data.get('captain') || '').trim()
-        const detailPayload = { teamId, detail: String(data.get('detail') || ''), passcode }
+        const kickName = String(data.get('kick') || '').trim()
+        const detailPayload = {
+          teamId,
+          detail: String(data.get('detail') || ''),
+          githubUrl: String(data.get('githubUrl') || ''),
+          passcode
+        }
 
         if (saveBtn) saveBtn.disabled = true
         setMsg(detailForm, '保存中…', '', '[data-detail-msg]')
@@ -1414,8 +1542,8 @@ const signupClosed = isSignupClosed()
             return
           }
           renderDetail(card, typeof body.detail === 'string' ? body.detail : '')
+          renderGithub(card, typeof body.githubUrl === 'string' ? body.githubUrl : null)
 
-          // 填了「转让队长」就再发一次，然后刷新这张卡的名单让皇冠挪位。
           if (captainName) {
             const cres = await fetch('/api/agent-teams', {
               method: 'PUT',
@@ -1427,18 +1555,24 @@ const signupClosed = isSignupClosed()
               setMsg(detailForm, (cbody && cbody.message) || '队长转让失败', 'error', '[data-detail-msg]')
               return
             }
-            const fresh = await fetch('/api/agent-teams', { cache: 'no-store' })
-              .then((r) => r.json())
-              .catch(() => null)
-            const t = fresh && (fresh.teams || []).find((x: Team) => x.id === teamId)
-            if (t) renderRoster(card, t as Team)
           }
 
-          detailForm.reset()
-          detailForm.removeAttribute('data-open')
-          detailForm.hidden = true
-          detailToggle.setAttribute('aria-expanded', 'false')
-          setMsg(detailForm, captainName ? '已保存，队长已转让' : '已更新！', 'success', '[data-detail-msg]')
+          if (kickName) {
+            const kres = await fetch('/api/agent-teams', {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ action: 'kick', teamId, name: kickName, passcode })
+            })
+            const kbody = await kres.json()
+            if (!(kres.ok && kbody.ok)) {
+              setMsg(detailForm, (kbody && kbody.message) || '移除队员失败', 'error', '[data-detail-msg]')
+              return
+            }
+          }
+
+          if (captainName || kickName) board.dispatchEvent(new CustomEvent('agent-teams:reload'))
+
+          setMsg(detailForm, '队伍资料已更新', 'success', '[data-detail-msg]')
         } catch {
           setMsg(detailForm, '网络错误，请稍后再试', 'error', '[data-detail-msg]')
         } finally {
@@ -1447,29 +1581,31 @@ const signupClosed = isSignupClosed()
       })
 
       detailForm.querySelector<HTMLButtonElement>('[data-cancel]')?.addEventListener('click', () => {
-        detailForm.removeAttribute('data-open')
-        detailForm.hidden = true
-        detailToggle.setAttribute('aria-expanded', 'false')
+        setManageOpen(false)
       })
     }
   }
-
-  // 赛道太多堆一页不好翻，按固定页大小分页；新建的自定义赛道加进来后也要重新计算页数。
-  const PAGE_SIZE = 8
 
   function renderPagination(board: HTMLElement, cards: Map<string, HTMLElement>) {
     const pager = board.querySelector<HTMLElement>('[data-board-pagination]')
     if (!pager) return
 
     const cardEls = [...cards.values()]
-    const pageCount = Math.max(1, Math.ceil(cardEls.length / PAGE_SIZE))
-    let page = Number.parseInt(board.dataset.page ?? '0', 10)
-    if (!Number.isFinite(page) || page < 0) page = 0
-    if (page > pageCount - 1) page = pageCount - 1
+    const query = normalizeTeamSearch(board.dataset.query ?? '').replace(/^#/, '')
+    const matchingCards = cardEls.filter((card) => (card.dataset.searchText ?? '').includes(query))
+    const requestedPage = Number.parseInt(board.dataset.page ?? '0', 10)
+    const pageSize = pageSizeForWidth(window.innerWidth)
+    const { page, pageCount, start, end } = paginationFor(matchingCards.length, requestedPage, pageSize)
     board.dataset.page = String(page)
 
-    cardEls.forEach((card, i) => {
-      const onPage = Math.floor(i / PAGE_SIZE) === page
+    const matchingSet = new Set(matchingCards)
+    cardEls.forEach((card) => {
+      const matches = matchingSet.has(card)
+      card.toggleAttribute('data-search-hidden', !matches)
+      if (!matches) delete card.dataset.pageHidden
+    })
+    matchingCards.forEach((card, index) => {
+      const onPage = index >= start && index < end
       // 不用 .hidden/[hidden]：team-card 自带 .flex，二者优先级打不过，切换了也白切换。
       if (onPage) {
         delete card.dataset.pageHidden
@@ -1479,6 +1615,14 @@ const signupClosed = isSignupClosed()
         card.dataset.pageHidden = ''
       }
     })
+
+    const status = board.querySelector<HTMLElement>('[data-search-status]')
+    if (status) status.textContent = `${matchingCards.length} 支队伍`
+    const empty = board.querySelector<HTMLElement>('[data-search-empty]')
+    if (empty) {
+      empty.hidden = matchingCards.length > 0
+      empty.classList.toggle('hidden', matchingCards.length > 0)
+    }
 
     pager.replaceChildren()
     if (pageCount <= 1) {
@@ -1512,7 +1656,7 @@ const signupClosed = isSignupClosed()
     prev.addEventListener('click', () => goTo(page - 1))
 
     const pageButtons = document.createElement('span')
-    pageButtons.className = 'inline-flex flex-wrap items-center justify-center gap-1.5'
+    pageButtons.className = 'hidden flex-wrap items-center justify-center gap-1.5 sm:inline-flex'
     const pageBtnClass =
       'inline-flex size-8 items-center justify-center rounded-lg border text-sm font-medium transition-colors hover:bg-muted'
     for (let index = 0; index < pageCount; index += 1) {
@@ -1530,6 +1674,18 @@ const signupClosed = isSignupClosed()
       pageButtons.appendChild(pageButton)
     }
 
+    const pageSelect = document.createElement('select')
+    pageSelect.className = 'rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground sm:hidden'
+    pageSelect.setAttribute('aria-label', '跳转到指定页')
+    for (let index = 0; index < pageCount; index += 1) {
+      const option = document.createElement('option')
+      option.value = String(index)
+      option.textContent = `第 ${index + 1} / ${pageCount} 页`
+      option.selected = index === page
+      pageSelect.appendChild(option)
+    }
+    pageSelect.addEventListener('change', () => goTo(Number(pageSelect.value)))
+
     const next = document.createElement('button')
     next.type = 'button'
     next.className = pagerBtnClass
@@ -1537,7 +1693,7 @@ const signupClosed = isSignupClosed()
     next.disabled = page === pageCount - 1
     next.addEventListener('click', () => goTo(page + 1))
 
-    pager.append(prev, pageButtons, next)
+    pager.append(prev, pageButtons, pageSelect, next)
   }
 
   function applyState(
@@ -1593,6 +1749,8 @@ const signupClosed = isSignupClosed()
       renderMeta(card, team) // 标题/简介/标签以 DB 为准，覆盖预渲染值
       renderRoster(card, team)
       renderDetail(card, team.detail)
+      renderGithub(card, team.githubUrl)
+      updateCardSearchText(card, team)
       card.dataset.loaded = 'true'
     }
 
@@ -1613,27 +1771,21 @@ const signupClosed = isSignupClosed()
       }
     }
 
-    // 开放了队长编辑：显示每张卡的「队长编辑」入口
-    if (data.detailEditable) {
-      for (const card of cards.values()) {
-        const toggle = card.querySelector<HTMLElement>('[data-detail-edit-toggle]')
-        if (toggle) {
-          toggle.dataset.show = ''
-          toggle.classList.remove('hidden')
-        }
-      }
+    for (const card of cards.values()) {
+      const captainManagement = card.querySelector<HTMLElement>('[data-captain-management]')
+      if (captainManagement) captainManagement.hidden = !data.detailEditable
     }
 
-    // 未配置：禁用所有报名 / 退出按钮
+    // 未配置：禁用报名与队伍管理入口。
     if (!data.configured) {
       for (const card of cards.values()) {
         card
-          .querySelectorAll<HTMLButtonElement>('[data-signup-toggle], [data-leave-toggle]')
+          .querySelectorAll<HTMLButtonElement>('[data-signup-toggle], [data-manage-toggle]')
           .forEach((toggle) => (toggle.disabled = true))
       }
     }
 
-    // 需要口令：显示每个表单里的口令输入（报名表单 + 退出表单都有）
+    // 需要口令：显示报名表单里的口令输入；退出与队长管理的口令始终必填。
     if (data.passcodeRequired) {
       for (const card of cards.values()) {
         card.querySelectorAll<HTMLElement>('[data-passcode-field]').forEach((field) => {
@@ -1755,6 +1907,30 @@ const signupClosed = isSignupClosed()
       cards.set(id, card)
       wireCard(card, board)
     })
+
+    const search = board.querySelector<HTMLInputElement>('[data-team-search]')
+    search?.addEventListener('input', () => {
+      board.dataset.query = search.value
+      board.dataset.page = '0'
+      renderPagination(board, cards)
+    })
+    window.matchMedia('(max-width: 640px)').addEventListener('change', () => {
+      board.dataset.page = '0'
+      renderPagination(board, cards)
+    })
+
+    const qqWrap = board.querySelector<HTMLElement>('[data-qq-group-wrap]')
+    const qqToggle = board.querySelector<HTMLButtonElement>('[data-qq-group-toggle]')
+    qqToggle?.addEventListener('click', () => {
+      const open = !qqWrap?.hasAttribute('data-open')
+      qqWrap?.toggleAttribute('data-open', open)
+      qqToggle.setAttribute('aria-expanded', open ? 'true' : 'false')
+    })
+    document.addEventListener('click', (event) => {
+      if (!qqWrap?.hasAttribute('data-open') || qqWrap.contains(event.target as Node)) return
+      qqWrap.removeAttribute('data-open')
+      qqToggle?.setAttribute('aria-expanded', 'false')
+    })
     // 数据到手前先按 SSR 渲染出的静态赛道分页，首屏就不会把几十张卡全堆出来。
     renderPagination(board, cards)
 
@@ -1779,6 +1955,7 @@ const signupClosed = isSignupClosed()
         .catch(showBannerError)
         .finally(hideLoadingBar)
 
+    board.addEventListener('agent-teams:reload', reload)
     wireCreateCard(board, reload)
     reload()
   }

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -9,7 +9,7 @@ const signupClosed = isSignupClosed()
 
 <section class='agent-board not-prose mt-6 flex flex-col' data-agent-board>
   <header class='board-hero mb-6 overflow-visible rounded-2xl border p-5 sm:mb-8 sm:overflow-hidden sm:p-8'>
-    <div class='flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6'>
+    <div class='board-hero-inner flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6'>
       <div class='min-w-0 sm:flex-1'>
         <div class='flex flex-wrap items-center gap-2 text-xs font-medium'>
           <span
@@ -77,8 +77,8 @@ const signupClosed = isSignupClosed()
             0
           </div>
         </div>
-        <div class='mt-1.5 text-xs font-medium text-muted-foreground'>
-          <span class='sr-only' data-team-count-loading-label>参评队伍数量加载中，</span>支参评队伍
+        <div class='team-count-label mt-1.5 text-xs font-medium text-muted-foreground'>
+          <span class='sr-only' data-team-count-loading-label>参评队伍数量加载中，</span>支队伍参评
         </div>
       </div>
     </div>
@@ -291,17 +291,17 @@ const signupClosed = isSignupClosed()
             <div class='manage-dialog-inner'>
               <header class='manage-dialog-head'>
                 <div>
-                  <h2 class='m-0 text-lg font-semibold text-foreground'>队伍管理</h2>
-                  <p class='m-0 mt-1 text-xs text-muted-foreground'>退出报名、维护资料或管理队员</p>
+                  <h2 class='m-0 text-lg font-medium text-foreground'>队伍管理</h2>
+                  <p class='manage-dialog-subtitle'>退出报名、维护资料或管理队员</p>
                 </div>
                 <button type='button' class='manage-dialog-close' data-manage-close aria-label='关闭'>✕</button>
               </header>
               <div class='manage-dialog-body'>
-            <section>
-              <h3 class='m-0 text-sm font-medium text-foreground'>个人退出</h3>
-              <p class='m-0 mt-0.5 text-xs text-muted-foreground'>仅退出你自己的报名，需要 QQ 群口令。</p>
-          <form class='leave-form mt-3 flex flex-col gap-2' data-leave-form>
-            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+            <section class='manage-section'>
+              <h3 class='manage-section-title'>个人退出</h3>
+              <p class='manage-section-hint'>仅退出你自己的报名，需要 QQ 群口令。</p>
+          <form class='leave-form manage-form' data-leave-form>
+            <label class='manage-field'>
               你的 QQ 昵称（要和报名时一致）
               <input
                 class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
@@ -313,7 +313,7 @@ const signupClosed = isSignupClosed()
                 placeholder='报名时填的昵称'
               />
             </label>
-            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+            <label class='manage-field'>
               QQ 群口令（和报名时一致）
               <input
                 class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
@@ -325,7 +325,7 @@ const signupClosed = isSignupClosed()
                 placeholder='群里公布的口令'
               />
             </label>
-            <div class='flex items-center gap-3'>
+            <div class='manage-actions'>
               <button
                 type='submit'
                 class='inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
@@ -344,11 +344,11 @@ const signupClosed = isSignupClosed()
           </form>
             </section>
 
-            <section class='mt-4 border-t pt-4' data-captain-management>
-              <h3 class='m-0 text-sm font-medium text-foreground'>队长管理</h3>
-              <p class='m-0 mt-0.5 text-xs text-muted-foreground'>维护项目资料、转让队长或移除摸鱼队员。</p>
-          <form class='detail-form mt-3 flex flex-col gap-2' data-detail-form>
-            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+            <section class='manage-section manage-section-divided' data-captain-management>
+              <h3 class='manage-section-title'>队长管理</h3>
+              <p class='manage-section-hint'>维护项目资料、转让队长或移除摸鱼队员。</p>
+          <form class='detail-form manage-form' data-detail-form>
+            <label class='manage-field'>
               口令（粉丝群的名字）
               <input
                 class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
@@ -360,7 +360,7 @@ const signupClosed = isSignupClosed()
                 required
               />
             </label>
-            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+            <label class='manage-field'>
               详细介绍（会公开显示，最多 600 字，可分段）
               <textarea
                 class='min-h-[7rem] rounded-lg border bg-background px-2.5 py-1.5 text-sm leading-relaxed text-foreground'
@@ -369,7 +369,7 @@ const signupClosed = isSignupClosed()
                 placeholder='多写点：这支队想做成什么样、技术路线、想找什么样的队友…'
               ></textarea>
             </label>
-            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+            <label class='manage-field'>
               GitHub 仓库（可选）
               <input
                 class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
@@ -380,7 +380,7 @@ const signupClosed = isSignupClosed()
                 placeholder='https://github.com/用户名/仓库名'
               />
             </label>
-            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+            <label class='manage-field'>
               转让队长给（可选，填名单里某人的昵称）
               <input
                 class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
@@ -391,7 +391,7 @@ const signupClosed = isSignupClosed()
                 placeholder='留空则不变'
               />
             </label>
-            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+            <label class='manage-field'>
               移除队员（可选，填名单里的昵称）
               <input
                 class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
@@ -402,7 +402,7 @@ const signupClosed = isSignupClosed()
                 placeholder='队长本人需先转让队长'
               />
             </label>
-            <div class='flex items-center gap-3'>
+            <div class='manage-actions'>
               <button
                 type='submit'
                 class='inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
@@ -628,22 +628,27 @@ const signupClosed = isSignupClosed()
   }
 
   .manage-dialog {
-    width: min(92vw, 44rem);
-    max-height: min(86vh, 48rem);
+    width: min(calc(100vw - 3rem), 42rem);
+    max-height: none;
+    overflow: hidden;
     padding: 0;
     border: 1px solid hsl(var(--border));
-    border-radius: 1rem;
-    background: hsl(var(--background));
-    color: hsl(var(--foreground));
-    box-shadow: 0 24px 70px rgb(0 0 0 / 0.28);
+    border-radius: 0.75rem;
+    background: hsl(var(--popover));
+    color: hsl(var(--popover-foreground));
+    box-shadow: 0 14px 38px hsl(var(--foreground) / 0.12);
   }
   .manage-dialog::backdrop {
-    background: rgb(0 0 0 / 0.55);
+    background: hsl(var(--foreground) / 0.36);
     backdrop-filter: blur(2px);
+  }
+  :global(html:has(.manage-dialog[open])) {
+    overflow: hidden;
   }
   .manage-dialog-inner {
     display: flex;
-    max-height: min(86vh, 48rem);
+    height: min(82vh, 44rem);
+    min-height: 0;
     flex-direction: column;
   }
   .manage-dialog-head {
@@ -651,14 +656,26 @@ const signupClosed = isSignupClosed()
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    padding: 1rem 1.25rem;
+    flex: none;
+    padding: 1.25rem 1.5rem;
     border-bottom: 1px solid hsl(var(--border));
   }
+  .manage-dialog-subtitle {
+    margin: 0.375rem 0 0;
+    color: hsl(var(--muted-foreground));
+    font-size: 0.75rem;
+    line-height: 1.25rem;
+  }
   .manage-dialog-close {
+    display: grid;
+    width: 2rem;
+    height: 2rem;
+    flex: none;
+    place-items: center;
     border: 0;
-    border-radius: 0.5rem;
+    border-radius: 0.375rem;
     background: transparent;
-    padding: 0.5rem;
+    padding: 0.375rem;
     color: hsl(var(--muted-foreground));
     line-height: 1;
     cursor: pointer;
@@ -668,8 +685,54 @@ const signupClosed = isSignupClosed()
     color: hsl(var(--foreground));
   }
   .manage-dialog-body {
+    min-height: 0;
+    flex: 1;
     overflow-y: auto;
-    padding: 1.25rem;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    padding: 1.5rem;
+  }
+  .manage-section-title {
+    margin: 0;
+    color: hsl(var(--foreground));
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.25rem;
+  }
+  .manage-section-hint {
+    margin: 0.5rem 0 0;
+    color: hsl(var(--muted-foreground));
+    font-size: 0.75rem;
+    line-height: 1.25rem;
+  }
+  .manage-section-divided {
+    margin-top: 1.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid hsl(var(--border));
+  }
+  .manage-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 1.25rem;
+  }
+  .manage-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    color: hsl(var(--muted-foreground));
+    font-size: 0.75rem;
+    line-height: 1.25rem;
+  }
+  .manage-field :is(input, textarea) {
+    padding: 0.625rem 0.75rem;
+  }
+  .manage-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.25rem;
   }
 
   /* 参评队伍数：单独一块摆在 hero 右侧，用暖色描边与正文区隔。 */
@@ -788,24 +851,37 @@ const signupClosed = isSignupClosed()
   }
 
   @media (max-width: 640px) {
-    .team-count-card {
+    .board-hero-inner {
+      gap: 0;
+    }
+    .board-hero .team-count-card {
       display: flex;
       align-items: center;
-      gap: 0.6rem;
+      gap: 0.5rem;
+      width: 100%;
       align-self: stretch;
-      padding: 0.7rem 1rem;
+      margin-top: 1rem;
+      padding: 1rem 0 0;
+      border: 0;
+      border-top: 1px solid hsl(var(--border));
+      border-radius: 0;
+      background: none;
       text-align: left;
     }
+    .team-count-card::after {
+      display: none;
+    }
     .team-count-stage {
-      width: 3.5rem;
-      height: 2.5rem;
+      width: 2.5rem;
+      height: 2rem;
       margin-inline: 0;
     }
     .team-count-number {
-      font-size: 2rem !important;
+      font-size: 1.75rem !important;
     }
-    .team-count-card > div:last-child {
+    .team-count-card .team-count-label {
       margin-top: 0;
+      font-size: 0.75rem;
     }
   }
 

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -45,9 +45,8 @@ const signupClosed = isSignupClosed()
         </p>
       </div>
 
-      {/* 主题总数：独立成一块，摆右边（原本这里一大片空白），数字够大才叫突出。
-          先只知道内置赛道数，自定义赛道还没拉到——与其先秀一个错的数字再跳成对的，
-          不如先用骨架屏占位，数据到手后再数字滚动到位。 */}
+      {/* 参评队伍数：只统计至少有一位报名队员、最终可以参加评选的队伍。
+          名单还没拉到前无法判断，先用骨架屏占位，数据到手后再数字滚动到位。 */}
       <div class='team-count-card shrink-0 self-start rounded-xl border px-6 py-5 text-center sm:self-center'>
         <div
           class='team-count-skeleton skeleton mx-auto h-12 w-20 rounded-lg sm:h-[3.75rem] sm:w-24'
@@ -62,7 +61,7 @@ const signupClosed = isSignupClosed()
           0
         </div>
         <div class='mt-1.5 text-xs font-medium text-muted-foreground'>
-          <span class='sr-only' data-team-count-loading-label>主题数量加载中，</span>个可选主题
+          <span class='sr-only' data-team-count-loading-label>参评队伍数量加载中，</span>支参评队伍
         </div>
       </div>
     </div>
@@ -882,8 +881,7 @@ const signupClosed = isSignupClosed()
     else delete el.dataset.tone
   }
 
-  // 主题总数「数字滚动」：从当前显示的值滚到目标值，而不是直接跳字——
-  // 首次加载是 0 滚到真实总数，之后（比如建了新赛道）是旧总数滚到新总数。
+  // 参评队伍数「数字滚动」：从当前显示的值滚到目标值，而不是直接跳字。
   function animateCount(el: HTMLElement, to: number, duration = 700) {
     const from = Number.parseInt(el.textContent ?? '0', 10) || 0
     if (from === to) {
@@ -1393,6 +1391,10 @@ const signupClosed = isSignupClosed()
     board.dataset.passcodeRequired = data.passcodeRequired ? 'true' : 'false'
     signupClosed = data.signupClosed ?? false
 
+    // 只有至少一位队员报名的队伍才能参加最终评选。数据库降级时名单未知，
+    // 保留静态兜底卡片和计数骨架，避免把「加载失败」误判成「无人报名」。
+    const eligibleTeams = data.degraded ? data.teams : data.teams.filter((team) => team.count > 0)
+
     const banner = board.querySelector<HTMLElement>('[data-board-banner]')
     if (banner) {
       if (!data.configured) {
@@ -1409,7 +1411,16 @@ const signupClosed = isSignupClosed()
       }
     }
 
-    for (const team of data.teams) {
+    if (!data.degraded) {
+      const eligibleIds = new Set(eligibleTeams.map((team) => team.id))
+      for (const [id, card] of cards) {
+        if (eligibleIds.has(id)) continue
+        card.remove()
+        cards.delete(id)
+      }
+    }
+
+    for (const team of eligibleTeams) {
       let card = cards.get(team.id)
       if (!card) {
         // 自定义赛道：动态建卡并接线
@@ -1425,8 +1436,8 @@ const signupClosed = isSignupClosed()
       card.dataset.loaded = 'true'
     }
 
-    // 主题总数：以接口拿到的完整列表为准（含自定义赛道），数字滚动到位。
-    revealTeamCount(board, data.teams.length)
+    // 与下方实际展示保持一致：只数有报名队员、可以参加评选的队伍。
+    if (!data.degraded) revealTeamCount(board, eligibleTeams.length)
 
     // 未配置或组队已截止：禁用「创建赛道」入口
     const createToggle = board.querySelector<HTMLButtonElement>('[data-create-toggle]')

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -264,6 +264,18 @@ const signupClosed = isSignupClosed()
                 placeholder='报名时填的昵称'
               />
             </label>
+            <label class='flex flex-col gap-1 text-xs text-muted-foreground'>
+              QQ 群口令（和报名时一致）
+              <input
+                class='rounded-lg border bg-background px-2.5 py-1.5 text-sm text-foreground'
+                name='passcode'
+                type='text'
+                maxlength='40'
+                required
+                autocomplete='off'
+                placeholder='群里公布的口令'
+              />
+            </label>
             <div class='flex items-center gap-3'>
               <button
                 type='submit'
@@ -1321,7 +1333,8 @@ const signupClosed = isSignupClosed()
         const data = new FormData(leaveForm)
         const payload = {
           teamId,
-          name: String(data.get('name') || '')
+          name: String(data.get('name') || ''),
+          passcode: String(data.get('passcode') || '')
         }
 
         if (submitBtn) submitBtn.disabled = true

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -332,13 +332,6 @@ const signupClosed = isSignupClosed()
               >
                 确认退出
               </button>
-              <button
-                type='button'
-                class='inline-flex items-center rounded-lg px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
-                data-cancel
-              >
-                收起
-              </button>
               <p class='form-msg m-0 text-xs' data-leave-msg role='status'></p>
             </div>
           </form>
@@ -408,13 +401,6 @@ const signupClosed = isSignupClosed()
                 class='inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
               >
                 保存
-              </button>
-              <button
-                type='button'
-                class='inline-flex items-center rounded-lg px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
-                data-cancel
-              >
-                收起
               </button>
               <p class='form-msg m-0 text-xs' data-detail-msg role='status'></p>
             </div>
@@ -1599,6 +1585,9 @@ const signupClosed = isSignupClosed()
     managePanel?.addEventListener('close', () => {
       manageToggle?.setAttribute('aria-expanded', 'false')
     })
+    managePanel?.addEventListener('click', (event) => {
+      if (event.target === managePanel) setManageOpen(false)
+    })
 
     // 退出 / 退赛：按昵称软删除自己的有效报名。
     if (leaveForm) {
@@ -1639,9 +1628,6 @@ const signupClosed = isSignupClosed()
         }
       })
 
-      leaveForm.querySelector<HTMLButtonElement>('[data-cancel]')?.addEventListener('click', () => {
-        setManageOpen(false)
-      })
     }
 
     // 队长维护项目资料、转让队长、移除队员。
@@ -1713,9 +1699,6 @@ const signupClosed = isSignupClosed()
         }
       })
 
-      detailForm.querySelector<HTMLButtonElement>('[data-cancel]')?.addEventListener('click', () => {
-        setManageOpen(false)
-      })
     }
   }
 

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -1,6 +1,5 @@
 ---
 import { activity, isSignupClosed, teams } from '@/data/agent-teams'
-import qqGroup from '@/assets/qq-group-contact.jpg'
 
 // 服务端只渲染静态壳（队伍卡 + 表单结构）；实时名单、计数、配置状态由客户端
 // 脚本挂载后 fetch('/api/agent-teams') 填充。这样页面本身可静态缓存。
@@ -47,13 +46,11 @@ const signupClosed = isSignupClosed()
               加入 QQ 群围观 <span aria-hidden='true'>↗</span>
             </button>
             <span
-              class='qq-group-popover absolute left-0 top-full z-20 mt-2 w-56 rounded-xl border bg-background p-3 text-center shadow-lg'
+              class='qq-group-popover absolute left-0 top-full z-20 mt-2 whitespace-nowrap rounded-lg border bg-background px-3 py-2 text-sm shadow-lg'
               data-qq-group-popover
-              role='dialog'
-              aria-label='QQ 群二维码'
+              role='tooltip'
             >
-              <img class='mx-auto aspect-square w-full rounded-lg' src={qqGroup.src} alt='QQ 群二维码' />
-              <span class='mt-2 block text-xs text-muted-foreground'>群号 831907794 · 扫码加入</span>
+              QQ 群：<strong class='font-semibold text-foreground'>831907794</strong>
             </span>
           </span>
         </div>
@@ -209,7 +206,7 @@ const signupClosed = isSignupClosed()
             </button>
             <button
               type='button'
-              class='manage-toggle inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+              class='manage-toggle hidden items-center gap-1 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground md:inline-flex'
               data-manage-toggle
               aria-expanded='false'
             >
@@ -290,7 +287,16 @@ const signupClosed = isSignupClosed()
             </div>
           </form>
 
-          <div class='manage-panel mt-1 rounded-xl border bg-muted/30 p-3' data-manage-panel hidden>
+          <dialog class='manage-dialog' data-manage-panel>
+            <div class='manage-dialog-inner'>
+              <header class='manage-dialog-head'>
+                <div>
+                  <h2 class='m-0 text-lg font-semibold text-foreground'>队伍管理</h2>
+                  <p class='m-0 mt-1 text-xs text-muted-foreground'>退出报名、维护资料或管理队员</p>
+                </div>
+                <button type='button' class='manage-dialog-close' data-manage-close aria-label='关闭'>✕</button>
+              </header>
+              <div class='manage-dialog-body'>
             <section>
               <h3 class='m-0 text-sm font-medium text-foreground'>个人退出</h3>
               <p class='m-0 mt-0.5 text-xs text-muted-foreground'>仅退出你自己的报名，需要 QQ 群口令。</p>
@@ -414,7 +420,9 @@ const signupClosed = isSignupClosed()
             </div>
           </form>
             </section>
-          </div>
+              </div>
+            </div>
+          </dialog>
         </article>
       ))
     }
@@ -619,6 +627,51 @@ const signupClosed = isSignupClosed()
     transform: none;
   }
 
+  .manage-dialog {
+    width: min(92vw, 44rem);
+    max-height: min(86vh, 48rem);
+    padding: 0;
+    border: 1px solid hsl(var(--border));
+    border-radius: 1rem;
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    box-shadow: 0 24px 70px rgb(0 0 0 / 0.28);
+  }
+  .manage-dialog::backdrop {
+    background: rgb(0 0 0 / 0.55);
+    backdrop-filter: blur(2px);
+  }
+  .manage-dialog-inner {
+    display: flex;
+    max-height: min(86vh, 48rem);
+    flex-direction: column;
+  }
+  .manage-dialog-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid hsl(var(--border));
+  }
+  .manage-dialog-close {
+    border: 0;
+    border-radius: 0.5rem;
+    background: transparent;
+    padding: 0.5rem;
+    color: hsl(var(--muted-foreground));
+    line-height: 1;
+    cursor: pointer;
+  }
+  .manage-dialog-close:hover {
+    background: hsl(var(--muted));
+    color: hsl(var(--foreground));
+  }
+  .manage-dialog-body {
+    overflow-y: auto;
+    padding: 1.25rem;
+  }
+
   /* 参评队伍数：单独一块摆在 hero 右侧，用暖色描边与正文区隔。 */
   .team-count-card {
     position: relative;
@@ -753,9 +806,6 @@ const signupClosed = isSignupClosed()
     }
     .team-count-card > div:last-child {
       margin-top: 0;
-    }
-    .qq-group-popover {
-      width: min(14rem, calc(100vw - 5rem));
     }
   }
 
@@ -1447,12 +1497,13 @@ const signupClosed = isSignupClosed()
     })
 
     const manageToggle = card.querySelector<HTMLButtonElement>('[data-manage-toggle]')
-    const managePanel = card.querySelector<HTMLElement>('[data-manage-panel]')
+    const managePanel = card.querySelector<HTMLDialogElement>('[data-manage-panel]')
     const leaveForm = card.querySelector<HTMLFormElement>('[data-leave-form]')
     const detailForm = card.querySelector<HTMLFormElement>('[data-detail-form]')
     const setManageOpen = (open: boolean) => {
       if (!managePanel || !manageToggle) return
-      managePanel.hidden = !open
+      if (open && !managePanel.open) managePanel.showModal()
+      if (!open && managePanel.open) managePanel.close()
       manageToggle.setAttribute('aria-expanded', open ? 'true' : 'false')
       if (open && detailForm) {
         const textarea = detailForm.querySelector<HTMLTextAreaElement>('textarea[name="detail"]')
@@ -1464,7 +1515,13 @@ const signupClosed = isSignupClosed()
 
     manageToggle?.addEventListener('click', () => {
       if (board.dataset.configured !== 'true') return
-      setManageOpen(managePanel?.hidden ?? true)
+      setManageOpen(!(managePanel?.open ?? false))
+    })
+    managePanel?.querySelector<HTMLButtonElement>('[data-manage-close]')?.addEventListener('click', () => {
+      setManageOpen(false)
+    })
+    managePanel?.addEventListener('close', () => {
+      manageToggle?.setAttribute('aria-expanded', 'false')
     })
 
     // 退出 / 退赛：按昵称软删除自己的有效报名。

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -36,6 +36,12 @@ const signupClosed = isSignupClosed()
           >
             活动详情 ↗
           </a>
+          <a
+            class='inline-flex items-center gap-1.5 rounded-full bg-amber-500 px-3 py-1.5 font-medium text-amber-950 no-underline transition-colors hover:bg-amber-400'
+            href={activity.qqGroupHref}
+          >
+            加入 QQ 群围观 <span aria-hidden='true'>→</span>
+          </a>
         </div>
         <p
           class='mt-5 max-w-2xl rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm leading-relaxed text-foreground'
@@ -148,10 +154,11 @@ const signupClosed = isSignupClosed()
               type='button'
               class='signup-toggle inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
               data-signup-toggle
+              data-development={signupClosed ? 'true' : undefined}
               aria-expanded='false'
               disabled={signupClosed}
             >
-              {signupClosed ? '报名已截止' : '报名'}
+              {signupClosed ? '开发中' : '报名'}
             </button>
             <button
               type='button'
@@ -916,6 +923,26 @@ const signupClosed = isSignupClosed()
     pointer-events: none;
     opacity: 0.5;
   }
+  /* 组队截止后，报名按钮转为当前阶段状态；不再用灰掉的禁用态暗示还能报名。 */
+  .signup-toggle[data-development='true'] {
+    cursor: default !important;
+    border-color: rgb(245 158 11 / 0.45);
+    background: rgb(245 158 11 / 0.12);
+    color: #b45309;
+    opacity: 1 !important;
+    pointer-events: none;
+  }
+  .signup-toggle[data-development='true']::before {
+    content: '';
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: 9999px;
+    background: #f59e0b;
+    box-shadow: 0 0 0 3px rgb(245 158 11 / 0.14);
+  }
+  :global(.dark) .signup-toggle[data-development='true'] {
+    color: #fcd34d;
+  }
 
   .form-msg[data-tone='error'] {
     color: #dc2626;
@@ -1048,7 +1075,9 @@ const signupClosed = isSignupClosed()
     const toggle = card.querySelector<HTMLButtonElement>('[data-signup-toggle]')
     if (toggle) {
       toggle.disabled = full || signupClosed
-      toggle.textContent = signupClosed ? '报名已截止' : full ? '名额已满' : '报名'
+      if (signupClosed) toggle.dataset.development = 'true'
+      else delete toggle.dataset.development
+      toggle.textContent = signupClosed ? '开发中' : full ? '名额已满' : '报名'
     }
 
     const roster = card.querySelector<HTMLElement>('[data-roster]')

--- a/src/components/agent-teams/AgentTeamsBoard.astro
+++ b/src/components/agent-teams/AgentTeamsBoard.astro
@@ -46,19 +46,25 @@ const signupClosed = isSignupClosed()
       </div>
 
       {/* 参评队伍数：只统计至少有一位报名队员、最终可以参加评选的队伍。
-          名单还没拉到前无法判断，先用骨架屏占位，数据到手后再数字滚动到位。 */}
-      <div class='team-count-card shrink-0 self-start rounded-xl border px-6 py-5 text-center sm:self-center'>
-        <div
-          class='team-count-skeleton skeleton mx-auto h-12 w-20 rounded-lg sm:h-[3.75rem] sm:w-24'
-          data-team-count-skeleton
-          aria-hidden='true'
-        >
-        </div>
-        <div
-          class='team-count-number hidden text-5xl font-bold leading-none sm:text-6xl'
-          data-team-count-number
-        >
-          0
+          名单还没拉到前无法判断，先播放 loading 动效，数据到手后再数字滚动到位。 */}
+      <div
+        class='team-count-card shrink-0 self-start overflow-hidden rounded-xl border px-6 py-5 text-center sm:self-center'
+        data-team-count-card
+      >
+        <div class='team-count-stage'>
+          <div class='team-count-loader' data-team-count-loader aria-hidden='true'>
+            <span class='team-count-dot'></span>
+            <span class='team-count-dot'></span>
+            <span class='team-count-dot'></span>
+          </div>
+          <div
+            class='team-count-number text-5xl font-bold leading-none sm:text-6xl'
+            data-team-count-number
+            aria-live='polite'
+            aria-hidden='true'
+          >
+            0
+          </div>
         </div>
         <div class='mt-1.5 text-xs font-medium text-muted-foreground'>
           <span class='sr-only' data-team-count-loading-label>参评队伍数量加载中，</span>支参评队伍
@@ -505,8 +511,9 @@ const signupClosed = isSignupClosed()
     width: fit-content;
   }
 
-  /* 主题总数：单独一块摆在 hero 右侧的空白处，暖色描边 + 底色，跟正文明显区隔开。 */
+  /* 参评队伍数：单独一块摆在 hero 右侧，用暖色描边与正文区隔。 */
   .team-count-card {
+    position: relative;
     border-color: rgb(245 158 11 / 0.4);
     background-image: linear-gradient(
       to bottom right,
@@ -515,13 +522,105 @@ const signupClosed = isSignupClosed()
       rgb(249 115 22 / 0.12)
     );
   }
-  /* 数字要比「个可选主题」这行小字大出一大截、颜色也跳出来，一眼能看到量级。 */
+  /* 加载期间让一束很淡的暖光掠过数字区；只动 transform，避免触发布局。 */
+  .team-count-card:not([data-count-ready])::after {
+    content: '';
+    position: absolute;
+    inset: -60% -100%;
+    background: linear-gradient(
+      100deg,
+      transparent 42%,
+      rgb(251 191 36 / 0.14) 50%,
+      transparent 58%
+    );
+    animation: team-count-shine 1.8s ease-in-out infinite;
+    pointer-events: none;
+  }
+  .team-count-stage {
+    position: relative;
+    display: grid;
+    width: 6rem;
+    height: 3.75rem;
+    margin-inline: auto;
+    place-items: center;
+  }
+  .team-count-loader,
   .team-count-number {
+    grid-area: 1 / 1;
+  }
+  .team-count-loader {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    transition:
+      opacity 180ms ease,
+      transform 240ms ease;
+  }
+  .team-count-dot {
+    display: block;
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 9999px;
+    background: linear-gradient(135deg, #fbbf24, #f97316);
+    box-shadow: 0 0 12px rgb(245 158 11 / 0.3);
+    animation: team-count-dot 1.1s ease-in-out infinite;
+  }
+  .team-count-dot:nth-child(2) {
+    animation-delay: 120ms;
+  }
+  .team-count-dot:nth-child(3) {
+    animation-delay: 240ms;
+  }
+  /* 真数字与 loading 共用同一块固定尺寸区域，切换时卡片不会跳。 */
+  .team-count-number {
+    opacity: 0;
+    transform: translateY(0.45rem) scale(0.94);
+    transition:
+      opacity 220ms ease,
+      transform 320ms cubic-bezier(0.2, 0.8, 0.2, 1);
     background-image: linear-gradient(to right, #fbbf24, #f59e0b, #f97316);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
     color: transparent;
+  }
+  .team-count-card[data-count-ready] .team-count-loader {
+    opacity: 0;
+    transform: translateY(-0.35rem) scale(0.85);
+  }
+  .team-count-card[data-count-ready] .team-count-number {
+    opacity: 1;
+    transform: none;
+  }
+  @keyframes team-count-dot {
+    0%,
+    60%,
+    100% {
+      opacity: 0.35;
+      transform: translateY(0) scale(0.78);
+    }
+    30% {
+      opacity: 1;
+      transform: translateY(-0.4rem) scale(1);
+    }
+  }
+  @keyframes team-count-shine {
+    from {
+      transform: translateX(-45%);
+    }
+    to {
+      transform: translateX(45%);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .team-count-card:not([data-count-ready])::after,
+    .team-count-dot {
+      animation: none;
+    }
+    .team-count-loader,
+    .team-count-number {
+      transition: none;
+    }
   }
 
   /* 创建赛道卡：暖色描边 + 呼吸光环，让它在一堆队伍卡里跳出来，别人一眼就知道这是入口。 */
@@ -883,6 +982,10 @@ const signupClosed = isSignupClosed()
 
   // 参评队伍数「数字滚动」：从当前显示的值滚到目标值，而不是直接跳字。
   function animateCount(el: HTMLElement, to: number, duration = 700) {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      el.textContent = String(to)
+      return
+    }
     const from = Number.parseInt(el.textContent ?? '0', 10) || 0
     if (from === to) {
       el.textContent = String(to)
@@ -898,16 +1001,14 @@ const signupClosed = isSignupClosed()
     requestAnimationFrame(step)
   }
 
-  // 骨架屏 → 数字滚动：第一次拿到真实总数时切掉骨架屏、露出数字并开始滚动。
+  // 跳动圆点 → 数字滚动：两种状态叠在固定尺寸的 stage 里，切换时不引发布局跳动。
   function revealTeamCount(board: HTMLElement, total: number) {
-    const skeleton = board.querySelector<HTMLElement>('[data-team-count-skeleton]')
+    const card = board.querySelector<HTMLElement>('[data-team-count-card]')
     const number = board.querySelector<HTMLElement>('[data-team-count-number]')
     if (!number) return
-    if (skeleton && !skeleton.hidden) {
-      skeleton.hidden = true
-      skeleton.classList.add('hidden')
-      number.hidden = false
-      number.classList.remove('hidden')
+    if (card && !card.hasAttribute('data-count-ready')) {
+      card.dataset.countReady = ''
+      number.setAttribute('aria-hidden', 'false')
       const loadingLabel = board.querySelector<HTMLElement>('[data-team-count-loading-label]')
       if (loadingLabel) loadingLabel.remove()
     }

--- a/src/data/agent-teams.test.ts
+++ b/src/data/agent-teams.test.ts
@@ -73,10 +73,6 @@ describe('activity 配置', () => {
     expect(activity.docHref).toMatch(/^https?:\/\//)
   })
 
-  test('QQ 群入口指向联系页二维码', () => {
-    expect(activity.qqGroupHref).toBe('/contact#how-to-reach')
-  })
-
   test('signupClosesAt 是带时区的合法时刻，且与 deadline 同一天（北京时间晚 12 点）', () => {
     const closes = Date.parse(activity.signupClosesAt)
     expect(Number.isNaN(closes)).toBe(false)

--- a/src/data/agent-teams.test.ts
+++ b/src/data/agent-teams.test.ts
@@ -73,6 +73,10 @@ describe('activity 配置', () => {
     expect(activity.docHref).toMatch(/^https?:\/\//)
   })
 
+  test('QQ 群入口指向联系页二维码', () => {
+    expect(activity.qqGroupHref).toBe('/contact#how-to-reach')
+  })
+
   test('signupClosesAt 是带时区的合法时刻，且与 deadline 同一天（北京时间晚 12 点）', () => {
     const closes = Date.parse(activity.signupClosesAt)
     expect(Number.isNaN(closes)).toBe(false)

--- a/src/data/agent-teams.ts
+++ b/src/data/agent-teams.ts
@@ -31,7 +31,9 @@ export const activity = {
   signupClosesAt: '2026-07-11T00:00:00+08:00',
   /** 头部醒目提示：当前阶段说明 */
   notice:
-    '组队已经截止啦，报名和建队通道已关闭。现在是开发阶段，各队正在打磨自己的 Agent——主题和名单都在下面，围观、追进度、找灵感都欢迎。说不定还会有第二届 😄',
+    '组队已经截止啦，报名和建队通道已关闭。现在是开发阶段，各队正在打磨自己的 Agent——主题和名单都在下面。想围观、追进度、找灵感，欢迎加入 QQ 群一起聊。说不定还会有第二届 😄',
+  /** QQ 群二维码入口 */
+  qqGroupHref: '/contact#how-to-reach',
   /** 活动详情文档（飞书 wiki） */
   docHref: 'https://my.feishu.cn/wiki/LHJiw36mxietv4kKZjacOIbznhe?from=from_copylink'
 }

--- a/src/data/agent-teams.ts
+++ b/src/data/agent-teams.ts
@@ -24,7 +24,7 @@ export const activity = {
   name: 'Summer of Agents',
   title: '第一届 Joye 粉丝 Agent 比赛',
   subtitle: '比赛进行中',
-  tagline: '组队已经截止啦，现在各队都在开发中。围观、追进度、找灵感都欢迎，对 Agent 感兴趣就来看看 👀',
+  tagline: '组队已经截止啦，现在各队都在开发中。围观、追进度、找灵感都欢迎，对 Agent 感兴趣就来看看 🤖',
   /** 组队截止日（YYYY-MM-DD，测试会校验格式） */
   deadline: '2026-07-10',
   /** 组队截止时刻（北京时间 7/10 晚 12 点）——过点后 API 与看板同时关闭报名/建队 */

--- a/src/data/agent-teams.ts
+++ b/src/data/agent-teams.ts
@@ -29,11 +29,6 @@ export const activity = {
   deadline: '2026-07-10',
   /** 组队截止时刻（北京时间 7/10 晚 12 点）——过点后 API 与看板同时关闭报名/建队 */
   signupClosesAt: '2026-07-11T00:00:00+08:00',
-  /** 头部醒目提示：当前阶段说明 */
-  notice:
-    '组队已经截止啦，报名和建队通道已关闭。现在是开发阶段，各队正在打磨自己的 Agent——主题和名单都在下面。想围观、追进度、找灵感，欢迎加入 QQ 群一起聊。说不定还会有第二届 😄',
-  /** QQ 群二维码入口 */
-  qqGroupHref: '/contact#how-to-reach',
   /** 活动详情文档（飞书 wiki） */
   docHref: 'https://my.feishu.cn/wiki/LHJiw36mxietv4kKZjacOIbznhe?from=from_copylink'
 }

--- a/src/lib/agent-teams/board.test.ts
+++ b/src/lib/agent-teams/board.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test'
+
+import { normalizeTeamSearch, pageSizeForWidth, paginationFor, teamMatchesSearch } from './board'
+import {
+  normalizeGithubRepoUrl,
+  resolveActiveCaptainKey,
+  SIGNUP_DELETION_REASONS,
+  validateKickTarget
+} from './store'
+
+const team = {
+  title: '游戏 Agent（杀戮尖塔 2）',
+  tags: ['game', 'planning'],
+  members: [{ name: 'Joye' }, { name: '摸鱼选手' }]
+}
+
+describe('队伍搜索', () => {
+  test('统一大小写、全角字符和多余空白', () => {
+    expect(normalizeTeamSearch('  ＧＡＭＥ  Agent ')).toBe('game agent')
+  })
+
+  test('支持队名、标签和成员昵称', () => {
+    expect(teamMatchesSearch(team, '杀戮尖塔')).toBe(true)
+    expect(teamMatchesSearch(team, '#PLANNING')).toBe(true)
+    expect(teamMatchesSearch(team, 'joye')).toBe(true)
+    expect(teamMatchesSearch(team, '摸鱼')).toBe(true)
+    expect(teamMatchesSearch(team, '不存在')).toBe(false)
+  })
+})
+
+describe('响应式分页', () => {
+  test('移动端每页 4 支，桌面端每页 8 支', () => {
+    expect(pageSizeForWidth(390)).toBe(4)
+    expect(pageSizeForWidth(640)).toBe(4)
+    expect(pageSizeForWidth(641)).toBe(8)
+  })
+
+  test('页码会限制在有效范围', () => {
+    expect(paginationFor(41, 99, 8)).toEqual({ page: 5, pageCount: 6, start: 40, end: 41 })
+    expect(paginationFor(0, 2, 4)).toEqual({ page: 0, pageCount: 0, start: 0, end: 0 })
+  })
+})
+
+describe('GitHub 仓库链接', () => {
+  test('归一化仓库首页链接', () => {
+    expect(normalizeGithubRepoUrl('https://www.github.com/joyehuang/blog.git?tab=readme')).toEqual({
+      ok: true,
+      value: 'https://github.com/joyehuang/blog'
+    })
+  })
+
+  test('拒绝非 GitHub 或非仓库首页链接', () => {
+    expect(normalizeGithubRepoUrl('https://example.com/a/b').ok).toBe(false)
+    expect(normalizeGithubRepoUrl('https://github.com/a/b/issues').ok).toBe(false)
+  })
+})
+
+describe('队伍管理', () => {
+  test('保存的队长已退出时回退到第一位有效成员', () => {
+    expect(resolveActiveCaptainKey(['a', 'b'], 'missing')).toBe('a')
+    expect(resolveActiveCaptainKey(['a', 'b'], 'b')).toBe('b')
+  })
+
+  test('不能踢当前队长，可以踢普通成员', () => {
+    expect(validateKickTarget(['captain', 'member'], 'captain', 'captain').ok).toBe(false)
+    expect(validateKickTarget(['captain', 'member'], 'captain', 'member')).toEqual({
+      ok: true,
+      captainKey: 'captain'
+    })
+  })
+
+  test('软删除原因保持稳定', () => {
+    expect(SIGNUP_DELETION_REASONS).toEqual({
+      selfLeave: 'self_leave',
+      captainKick: 'captain_kick'
+    })
+  })
+})

--- a/src/lib/agent-teams/board.ts
+++ b/src/lib/agent-teams/board.ts
@@ -1,0 +1,33 @@
+export type SearchableTeam = {
+  title: string
+  tags: string[]
+  members: { name: string }[]
+}
+
+export function normalizeTeamSearch(value: string): string {
+  return value.normalize('NFKC').toLocaleLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+export function teamMatchesSearch(team: SearchableTeam, query: string): boolean {
+  const needle = normalizeTeamSearch(query).replace(/^#/, '')
+  if (!needle) return true
+  const fields = [team.title, ...team.tags, ...team.members.map((member) => member.name)]
+  return fields.some((field) => normalizeTeamSearch(field).includes(needle))
+}
+
+export function pageSizeForWidth(width: number): number {
+  return width <= 640 ? 4 : 8
+}
+
+export function paginationFor(total: number, requestedPage: number, pageSize: number) {
+  const safeSize = Math.max(1, Math.trunc(pageSize) || 1)
+  const pageCount = total === 0 ? 0 : Math.ceil(total / safeSize)
+  const maxPage = Math.max(0, pageCount - 1)
+  const page = Math.min(maxPage, Math.max(0, Math.trunc(requestedPage) || 0))
+  return {
+    page,
+    pageCount,
+    start: page * safeSize,
+    end: Math.min(total, (page + 1) * safeSize)
+  }
+}

--- a/src/lib/agent-teams/store.ts
+++ b/src/lib/agent-teams/store.ts
@@ -74,6 +74,7 @@ const NAME_MAX = 24
 const NOTE_MAX = 60
 const CONTACT_MAX = 60
 const DETAIL_MAX = 600
+const GITHUB_URL_MAX = 200
 const TITLE_MAX = 30
 const SUMMARY_MAX = 80
 // 组队赛道的名额上限范围；不在这个区间就当没填，按不限处理。
@@ -84,6 +85,11 @@ const RATE_LIMIT = 5
 const RATE_WINDOW_SEC = 600
 // 同一 IP 在窗口内最多创建这么多个自定义赛道。
 const CREATE_RATE_LIMIT = 3
+
+export const SIGNUP_DELETION_REASONS = {
+  selfLeave: 'self_leave',
+  captainKick: 'captain_kick'
+} as const
 
 // --- 环境 / 配置 ---------------------------------------------------------
 
@@ -156,12 +162,21 @@ async function ensureSchema(sql: Sql): Promise<void> {
       contact TEXT,
       note TEXT,
       ip TEXT,
+      deleted_at TIMESTAMPTZ,
+      deleted_reason TEXT,
+      deleted_by TEXT,
       created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     )
   `
+  await sql`ALTER TABLE agent_team_signups ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`
+  await sql`ALTER TABLE agent_team_signups ADD COLUMN IF NOT EXISTS deleted_reason TEXT`
+  await sql`ALTER TABLE agent_team_signups ADD COLUMN IF NOT EXISTS deleted_by TEXT`
+  // 旧索引不允许已退出成员重新报名；迁移成只约束有效报名的部分唯一索引。
+  await sql`DROP INDEX IF EXISTS agent_team_signups_team_name`
   await sql`
-    CREATE UNIQUE INDEX IF NOT EXISTS agent_team_signups_team_name
+    CREATE UNIQUE INDEX IF NOT EXISTS agent_team_signups_active_team_name
       ON agent_team_signups (team_id, name_key)
+      WHERE deleted_at IS NULL
   `
   await sql`
     CREATE INDEX IF NOT EXISTS agent_team_signups_team_created
@@ -172,9 +187,11 @@ async function ensureSchema(sql: Sql): Promise<void> {
     CREATE TABLE IF NOT EXISTS agent_team_details (
       team_id TEXT PRIMARY KEY,
       detail TEXT NOT NULL,
+      github_url TEXT,
       updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
     )
   `
+  await sql`ALTER TABLE agent_team_details ADD COLUMN IF NOT EXISTS github_url TEXT`
   // 用户自助创建的「自命题赛道」，一队一行。id 用 custom-<uuid8>，名单/介绍与静态赛道共表。
   await sql`
     CREATE TABLE IF NOT EXISTS agent_team_customs (
@@ -259,6 +276,31 @@ function cleanMultiline(input: string): string {
     .trim()
 }
 
+export type GithubRepoUrlResult =
+  | { ok: true; value: string | null }
+  | { ok: false; message: string }
+
+/** 只接受 GitHub 仓库首页链接，并归一化掉 .git、query、hash 与尾部斜杠。 */
+export function normalizeGithubRepoUrl(input: string): GithubRepoUrlResult {
+  const raw = input.trim()
+  if (raw.length === 0) return { ok: true, value: null }
+  if (raw.length > GITHUB_URL_MAX) return { ok: false, message: 'GitHub 链接太长' }
+  try {
+    const url = new URL(raw)
+    if (url.protocol !== 'https:' || !['github.com', 'www.github.com'].includes(url.hostname)) {
+      return { ok: false, message: '请填写 https://github.com/用户名/仓库名' }
+    }
+    const parts = url.pathname.split('/').filter(Boolean)
+    if (parts.length !== 2) return { ok: false, message: '请填写 GitHub 仓库首页链接' }
+    const owner = parts[0]
+    const repo = parts[1].replace(/\.git$/i, '')
+    if (!owner || !repo) return { ok: false, message: 'GitHub 仓库链接不完整' }
+    return { ok: true, value: `https://github.com/${owner}/${repo}` }
+  } catch {
+    return { ok: false, message: 'GitHub 链接格式不正确' }
+  }
+}
+
 type RosterRow = { name: string; note: string | null; ts_sec: number }
 
 function rowToMember(row: RosterRow): PublicMember {
@@ -280,7 +322,7 @@ export async function getRosters(teamIds: string[]): Promise<Record<string, Publ
   const rows = (await sql`
     SELECT team_id, name, note, EXTRACT(EPOCH FROM created_at)::float8 AS ts_sec
     FROM agent_team_signups
-    WHERE team_id = ANY(${teamIds})
+    WHERE team_id = ANY(${teamIds}) AND deleted_at IS NULL
     ORDER BY created_at ASC
   `) as (RosterRow & { team_id: string })[]
 
@@ -307,6 +349,42 @@ export async function getDetails(teamIds: string[]): Promise<Record<string, stri
   `) as { team_id: string; detail: string }[]
 
   for (const row of rows) out[row.team_id] = row.detail
+  return out
+}
+
+export function resolveActiveCaptainKey(activeMemberKeys: string[], savedCaptain?: string): string | null {
+  if (savedCaptain && activeMemberKeys.includes(savedCaptain)) return savedCaptain
+  return activeMemberKeys[0] ?? null
+}
+
+export function validateKickTarget(
+  activeMemberKeys: string[],
+  savedCaptain: string | undefined,
+  targetKey: string
+): { ok: true; captainKey: string } | { ok: false; message: string } {
+  if (!activeMemberKeys.includes(targetKey)) return { ok: false, message: '这个昵称不在当前名单里' }
+  const captainKey = resolveActiveCaptainKey(activeMemberKeys, savedCaptain)
+  if (!captainKey) return { ok: false, message: '队伍当前没有有效成员' }
+  if (targetKey === captainKey) return { ok: false, message: '不能移除当前队长，请先转让队长' }
+  return { ok: true, captainKey }
+}
+
+/** 批量读取队伍 GitHub 仓库链接。 */
+export async function getGithubUrls(teamIds: string[]): Promise<Record<string, string>> {
+  const out: Record<string, string> = {}
+  if (teamIds.length === 0) return out
+
+  const sql = getSql()
+  if (!sql) return out
+  await ensureSchema(sql)
+
+  const rows = (await sql`
+    SELECT team_id, github_url
+    FROM agent_team_details
+    WHERE team_id = ANY(${teamIds}) AND github_url IS NOT NULL
+  `) as { team_id: string; github_url: string }[]
+
+  for (const row of rows) out[row.team_id] = row.github_url
   return out
 }
 
@@ -364,7 +442,7 @@ export async function addSignup(
     const existing = (await sql`
       SELECT name, note, EXTRACT(EPOCH FROM created_at)::float8 AS ts_sec
       FROM agent_team_signups
-      WHERE team_id = ${input.teamId}
+      WHERE team_id = ${input.teamId} AND deleted_at IS NULL
       ORDER BY created_at ASC
     `) as RosterRow[]
 
@@ -379,7 +457,7 @@ export async function addSignup(
     const inserted = (await sql`
       INSERT INTO agent_team_signups (team_id, name, name_key, contact, note, ip)
       VALUES (${input.teamId}, ${name}, ${nameKey}, ${contact}, ${note}, ${ip})
-      ON CONFLICT (team_id, name_key) DO NOTHING
+      ON CONFLICT (team_id, name_key) WHERE deleted_at IS NULL DO NOTHING
       RETURNING EXTRACT(EPOCH FROM created_at)::float8 AS ts_sec
     `) as { ts_sec: number }[]
 
@@ -410,7 +488,7 @@ export async function addSignup(
   }
 }
 
-// --- 退出 / 退赛（自助删除自己的报名）----------------------------------
+// --- 退出 / 退赛（软删除报名，保留审计记录）-----------------------------
 
 export type LeaveInput = {
   teamId: string
@@ -425,7 +503,7 @@ export type LeaveResult =
   | { ok: false; code: LeaveErrorCode; message: string }
 
 /**
- * 按昵称把某人从某队名单里删掉。退出与报名共用 QQ 群口令，避免他人冒用昵称退队。
+ * 按昵称把某人的有效报名标记为退出。退出与报名共用 QQ 群口令。
  */
 export async function removeSignup(
   input: LeaveInput,
@@ -449,8 +527,9 @@ export async function removeSignup(
     await ensureSchema(sql)
 
     const deleted = (await sql`
-      DELETE FROM agent_team_signups
-      WHERE team_id = ${input.teamId} AND name_key = ${nameKey}
+      UPDATE agent_team_signups
+      SET deleted_at = now(), deleted_reason = ${SIGNUP_DELETION_REASONS.selfLeave}, deleted_by = ${nameKey}
+      WHERE team_id = ${input.teamId} AND name_key = ${nameKey} AND deleted_at IS NULL
       RETURNING id
     `) as { id: number }[]
     if (deleted.length === 0) {
@@ -460,9 +539,14 @@ export async function removeSignup(
     const existing = (await sql`
       SELECT name, note, EXTRACT(EPOCH FROM created_at)::float8 AS ts_sec
       FROM agent_team_signups
-      WHERE team_id = ${input.teamId}
+      WHERE team_id = ${input.teamId} AND deleted_at IS NULL
       ORDER BY created_at ASC
     `) as RosterRow[]
+    // 队长退出后清掉显式队长记录，前端与后续管理会回退到第一位有效成员。
+    await sql`
+      DELETE FROM agent_team_captains
+      WHERE team_id = ${input.teamId} AND captain_key = ${nameKey}
+    `
     const members = existing.map(rowToMember)
     return {
       ok: true,
@@ -478,18 +562,19 @@ export async function removeSignup(
 export type DetailUpdateInput = {
   teamId: string
   detail: string
+  githubUrl?: string
   passcode?: string
 }
 
-export type DetailErrorCode = 'not_configured' | 'passcode' | 'store_error'
+export type DetailErrorCode = 'not_configured' | 'invalid' | 'passcode' | 'store_error'
 
 export type DetailResult =
-  | { ok: true; teamId: string; detail: string }
+  | { ok: true; teamId: string; detail: string; githubUrl: string | null }
   | { ok: false; code: DetailErrorCode; message: string }
 
 /**
  * 队长更新某队的详细介绍。口令匹配该队的队长口令、或匹配管理员口令才放行。
- * detail 传空串表示清空（删除该行）。teamId 合法性由调用方校验。
+ * detail / githubUrl 都可传空清除。teamId 合法性由调用方校验。
  */
 export async function updateDetail(input: DetailUpdateInput): Promise<DetailResult> {
   const sql = getSql()
@@ -500,19 +585,24 @@ export async function updateDetail(input: DetailUpdateInput): Promise<DetailResu
   }
 
   const detail = cleanMultiline(input.detail ?? '').slice(0, DETAIL_MAX)
+  const github = normalizeGithubRepoUrl(input.githubUrl ?? '')
+  if (!github.ok) return { ok: false, code: 'invalid', message: github.message }
 
   try {
     await ensureSchema(sql)
-    if (detail.length === 0) {
+    if (detail.length === 0 && github.value === null) {
       await sql`DELETE FROM agent_team_details WHERE team_id = ${input.teamId}`
-      return { ok: true, teamId: input.teamId, detail: '' }
+      return { ok: true, teamId: input.teamId, detail: '', githubUrl: null }
     }
     await sql`
-      INSERT INTO agent_team_details (team_id, detail, updated_at)
-      VALUES (${input.teamId}, ${detail}, now())
-      ON CONFLICT (team_id) DO UPDATE SET detail = EXCLUDED.detail, updated_at = now()
+      INSERT INTO agent_team_details (team_id, detail, github_url, updated_at)
+      VALUES (${input.teamId}, ${detail}, ${github.value}, now())
+      ON CONFLICT (team_id) DO UPDATE SET
+        detail = EXCLUDED.detail,
+        github_url = EXCLUDED.github_url,
+        updated_at = now()
     `
-    return { ok: true, teamId: input.teamId, detail }
+    return { ok: true, teamId: input.teamId, detail, githubUrl: github.value }
   } catch {
     return { ok: false, code: 'store_error', message: '保存失败，请稍后再试' }
   }
@@ -658,7 +748,7 @@ export async function createTeam(input: CreateTeamInput): Promise<CreateResult> 
       await sql`
         INSERT INTO agent_team_signups (team_id, name, name_key, ip)
         VALUES (${id}, ${creatorName}, ${nameKey}, ${ip})
-        ON CONFLICT (team_id, name_key) DO NOTHING
+        ON CONFLICT (team_id, name_key) WHERE deleted_at IS NULL DO NOTHING
       `
       await sql`
         INSERT INTO agent_team_captains (team_id, captain_key)
@@ -725,7 +815,7 @@ export async function setCaptain(input: {
     await ensureSchema(sql)
     const member = (await sql`
       SELECT 1 FROM agent_team_signups
-      WHERE team_id = ${input.teamId} AND name_key = ${nameKey}
+      WHERE team_id = ${input.teamId} AND name_key = ${nameKey} AND deleted_at IS NULL
       LIMIT 1
     `) as { '?column?': number }[]
     if (member.length === 0) {
@@ -739,5 +829,61 @@ export async function setCaptain(input: {
     return { ok: true, teamId: input.teamId, captainKey: nameKey }
   } catch {
     return { ok: false, code: 'store_error', message: '转让失败，请稍后再试' }
+  }
+}
+
+export type KickMemberResult =
+  | { ok: true; roster: TeamRoster }
+  | { ok: false; code: CaptainErrorCode; message: string }
+
+/** 队长移除一名有效队员；队长本人必须先转让队长，不能直接踢掉。 */
+export async function kickMember(
+  input: { teamId: string; name: string; passcode?: string },
+  opts: { capacity: number | null }
+): Promise<KickMemberResult> {
+  const sql = getSql()
+  if (!sql) return { ok: false, code: 'not_configured', message: '系统尚未配置' }
+  if ((input.passcode ?? '') !== getEditPasscode()) {
+    return { ok: false, code: 'passcode', message: '口令不正确' }
+  }
+
+  const name = cleanText(input.name ?? '')
+  const nameKey = name.toLowerCase()
+  if (nameKey.length === 0) return { ok: false, code: 'invalid', message: '请填写要移除的队员昵称' }
+
+  try {
+    await ensureSchema(sql)
+    const active = (await sql`
+      SELECT name, name_key, note, EXTRACT(EPOCH FROM created_at)::float8 AS ts_sec
+      FROM agent_team_signups
+      WHERE team_id = ${input.teamId} AND deleted_at IS NULL
+      ORDER BY created_at ASC
+    `) as (RosterRow & { name_key: string })[]
+    const captainRows = (await sql`
+      SELECT captain_key FROM agent_team_captains WHERE team_id = ${input.teamId}
+    `) as { captain_key: string }[]
+    const savedCaptain = captainRows[0]?.captain_key
+    const validation = validateKickTarget(
+      active.map((member) => member.name_key),
+      savedCaptain,
+      nameKey
+    )
+    if (!validation.ok) {
+      const code = active.some((member) => member.name_key === nameKey) ? 'invalid' : 'not_found'
+      return { ok: false, code, message: validation.message }
+    }
+
+    await sql`
+      UPDATE agent_team_signups
+      SET deleted_at = now(), deleted_reason = ${SIGNUP_DELETION_REASONS.captainKick}, deleted_by = ${validation.captainKey}
+      WHERE team_id = ${input.teamId} AND name_key = ${nameKey} AND deleted_at IS NULL
+    `
+    const members = active.filter((member) => member.name_key !== nameKey).map(rowToMember)
+    return {
+      ok: true,
+      roster: { id: input.teamId, count: members.length, capacity: opts.capacity, members }
+    }
+  } catch {
+    return { ok: false, code: 'store_error', message: '移除失败，请稍后再试' }
   }
 }

--- a/src/lib/agent-teams/store.ts
+++ b/src/lib/agent-teams/store.ts
@@ -415,16 +415,17 @@ export async function addSignup(
 export type LeaveInput = {
   teamId: string
   name: string
+  passcode?: string
 }
 
-export type LeaveErrorCode = 'not_configured' | 'invalid' | 'not_found' | 'store_error'
+export type LeaveErrorCode = 'not_configured' | 'invalid' | 'not_found' | 'passcode' | 'store_error'
 
 export type LeaveResult =
   | { ok: true; roster: TeamRoster }
   | { ok: false; code: LeaveErrorCode; message: string }
 
 /**
- * 按昵称把某人从某队名单里删掉。退出不需要口令——自己想退随时能退。
+ * 按昵称把某人从某队名单里删掉。退出与报名共用 QQ 群口令，避免他人冒用昵称退队。
  */
 export async function removeSignup(
   input: LeaveInput,
@@ -432,6 +433,11 @@ export async function removeSignup(
 ): Promise<LeaveResult> {
   const sql = getSql()
   if (!sql) return { ok: false, code: 'not_configured', message: '报名系统尚未配置' }
+
+  const passcode = getPasscode()
+  if (passcode && input.passcode !== passcode) {
+    return { ok: false, code: 'passcode', message: '口令不正确' }
+  }
 
   const name = cleanText(input.name ?? '')
   if (name.length === 0 || name.length > NAME_MAX) {

--- a/src/pages/api/agent-teams.ts
+++ b/src/pages/api/agent-teams.ts
@@ -9,8 +9,10 @@ import {
   getCaptains,
   getCustomTeams,
   getDetails,
+  getGithubUrls,
   getRosters,
   isConfigured,
+  kickMember,
   passcodeRequired,
   removeSignup,
   setCaptain,
@@ -40,6 +42,7 @@ type TeamPayload = TeamMeta & {
   count: number
   members: PublicMember[]
   detail: string | null
+  githubUrl: string | null
   /** 队长的 name_key；无则前端默认第一个报名的人当队长 */
   captain: string | null
 }
@@ -48,6 +51,7 @@ function buildTeams(
   metas: TeamMeta[],
   rosters: Record<string, PublicMember[]> = {},
   details: Record<string, string> = {},
+  githubUrls: Record<string, string> = {},
   captains: Record<string, string> = {}
 ): TeamPayload[] {
   return metas.map((m) => {
@@ -57,6 +61,7 @@ function buildTeams(
       count: members.length,
       members,
       detail: details[m.id] ?? null,
+      githubUrl: githubUrls[m.id] ?? null,
       captain: captains[m.id] ?? null
     }
   })
@@ -91,9 +96,10 @@ export const GET: APIRoute = async () => {
     const [builtins, customs] = await Promise.all([getBuiltinTracks(), getCustomTeams()])
     const metas = [...builtins, ...customs]
     const ids = metas.map((m) => m.id)
-    const [rosters, details, captains] = await Promise.all([
+    const [rosters, details, githubUrls, captains] = await Promise.all([
       getRosters(ids),
       getDetails(ids),
+      getGithubUrls(ids),
       getCaptains(ids)
     ])
     return json({
@@ -101,7 +107,7 @@ export const GET: APIRoute = async () => {
       passcodeRequired: passcodeRequired(),
       detailEditable: editable,
       signupClosed,
-      teams: buildTeams(metas, rosters, details, captains)
+      teams: buildTeams(metas, rosters, details, githubUrls, captains)
     })
   } catch {
     // 数据库抖动——仍让页面渲染出赛道卡（用代码兜底），只是名单/介绍/自定义赛道暂时为空。
@@ -263,6 +269,7 @@ export const DELETE: APIRoute = async ({ request }) => {
 
 const DETAIL_STATUS_BY_CODE: Record<DetailErrorCode, number> = {
   not_configured: 503,
+  invalid: 400,
   passcode: 403,
   store_error: 500
 }
@@ -306,14 +313,36 @@ export const PUT: APIRoute = async ({ request }) => {
     )
   }
 
+  if (body.action === 'kick') {
+    const capacity = await resolveCapacity(teamId)
+    if (capacity === undefined) {
+      return json({ ok: false, code: 'invalid', message: '未知的队伍' }, 400)
+    }
+    const result = await kickMember(
+      { teamId, name: str(body.name) ?? '', passcode: str(body.passcode) },
+      { capacity }
+    )
+    if (result.ok) return json({ ok: true, roster: result.roster })
+    return json(
+      { ok: false, code: result.code, message: result.message },
+      CAPTAIN_STATUS_BY_CODE[result.code]
+    )
+  }
+
   const result = await updateDetail({
     teamId,
     detail: str(body.detail) ?? '',
+    githubUrl: str(body.githubUrl),
     passcode: str(body.passcode)
   })
 
   if (result.ok) {
-    return json({ ok: true, teamId: result.teamId, detail: result.detail })
+    return json({
+      ok: true,
+      teamId: result.teamId,
+      detail: result.detail,
+      githubUrl: result.githubUrl
+    })
   }
   return json(
     { ok: false, code: result.code, message: result.message },

--- a/src/pages/api/agent-teams.ts
+++ b/src/pages/api/agent-teams.ts
@@ -228,6 +228,7 @@ const LEAVE_STATUS_BY_CODE: Record<LeaveErrorCode, number> = {
   not_configured: 503,
   invalid: 400,
   not_found: 404,
+  passcode: 403,
   store_error: 500
 }
 
@@ -246,7 +247,10 @@ export const DELETE: APIRoute = async ({ request }) => {
     return json({ ok: false, code: 'invalid', message: '未知的队伍' }, 400)
   }
 
-  const result = await removeSignup({ teamId, name: str(body.name) ?? '' }, { capacity })
+  const result = await removeSignup(
+    { teamId, name: str(body.name) ?? '', passcode: str(body.passcode) },
+    { capacity }
+  )
 
   if (result.ok) {
     return json({ ok: true, roster: result.roster })


### PR DESCRIPTION
## What changed

- Only show teams with active members and report the eligible team count
- Refine the loading state, development-phase copy, team counts, and exact-page navigation
- Add team/member/tag search with responsive pagination
- Add desktop team management for self-leave, captain transfer, member removal, project details, and GitHub links
- Add QQ group guidance without a mobile QR-code layout
- Add soft deletion and active-member filtering for signups
- Add reusable unit coverage for search, pagination, GitHub URL validation, captain fallback, kicking, and deletion reasons
- Rework the management modal and mobile count layout to follow `DESIGN.md`

## Why

The competition has moved from signup into active development. The page needed to stop presenting empty teams, make real participating teams easier to browse, and provide lightweight management without introducing a full login system.

## Impact

Visitors get a shorter mobile first screen, accurate team data, search, and clearer development status. Team members and captains can manage participation with the existing group passcode. Historical signup records are retained through soft deletion.

## Root cause

The original page was designed around open signup: it rendered all configured themes, used capacity-style counts, and expanded management controls inside each card. That structure no longer matched the development phase and produced cramped mobile and modal layouts.

## Validation

- `bun run check`
- `bun test src/` — 21 passing tests
- `bun run build`
- Local browser verification at desktop and 390px mobile widths
