### PR TITLE
fix(i18n): route unmatched /en/* paths to the English 404

### DIFF
--- a/src/pages/en/[...slug].astro
+++ b/src/pages/en/[...slug].astro
@@ -1,0 +1,24 @@
+---
+import { Button } from 'astro-pure/user'
+import PageLayout from '@/layouts/BaseLayout.astro'
+
+// Catch-all for any /en/* path with no matching page (e.g. /en/talks, which
+// has no English mirror). Without this, Vercel's routing falls back to the
+// root /404.html — the Chinese-locale 404 — instead of the English one.
+Astro.response.status = 404
+
+const meta = {
+  description: 'Not found',
+  noindex: true,
+  title: '404'
+}
+---
+
+<PageLayout {meta}>
+  <div class='px-4 py-10 text-center sm:px-6 lg:px-8'>
+    <h1 class='block text-7xl font-bold sm:text-9xl'>404</h1>
+    <p class='mt-3 text-muted-foreground'>Oops, something went wrong.</p>
+    <p class='text-lg'>Sorry, we couldn't find your page.</p>
+    <Button title='Back to home' href='/en' style='ahead' class='mt-5' />
+  </div>
+</PageLayout>


### PR DESCRIPTION
/talks has no English mirror. Directly visiting /en/talks (or any other unmatched /en/* path) fell through Vercel's routing straight to the root 404.html — the Chinese-locale 404, wrong language, "back home" linking to / instead of /en. An src/pages/en/404.astro page already existed but nothing ever routed to it for arbitrary bad URLs.

Adds an /en catch-all page that returns 404 with the correct English-locale content.

Notes: verified against a full local build — Vercel's generated routing config now sends unmatched /en/* to the render function instead of the static root 404, and all real /en/* pages (blog, notes, about, etc.) are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes any unmatched /en/* URL to the English 404 page instead of the root Chinese 404. Adds a catch-all at src/pages/en/[...slug].astro that sets 404 and renders English content with a link back to /en; valid /en pages are unaffected.

<sup>Written for commit dfc61f14cbb5c7b71450cca501cbbd4f941ea346. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/joyehuang/blog/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

