### PR TITLE
Restrict intro animation to v2 previews

### DIFF
--- a/src/components/intro/IntroOverlay.astro
+++ b/src/components/intro/IntroOverlay.astro
@@ -98,6 +98,16 @@ const copy =
   ;(() => {
     const overlay = document.getElementById('intro-overlay')
     if (!overlay) return
+    const isPublicSite = /^(?:www\.)?joyehuang\.me$/i.test(location.hostname)
+    if (isPublicSite) {
+      overlay.classList.add('intro-idle')
+      overlay.classList.remove('intro-pending')
+      overlay.setAttribute('aria-hidden', 'true')
+      document.documentElement.classList.remove('intro-scroll-lock')
+      const dock = document.getElementById('intro-trigger-dock')
+      if (dock) dock.hidden = true
+      return
+    }
     const value = new URLSearchParams(location.search).get('intro')
     const forced = value === 'focus' || value === 'line' || value === 'jojo'
     const disabled = value === 'off' || value === 'picker'

--- a/src/components/intro/intro-controller.ts
+++ b/src/components/intro/intro-controller.ts
@@ -83,6 +83,8 @@ function trackIntro(
 }
 
 function initIntro() {
+  if (/^(?:www\.)?joyehuang\.me$/i.test(location.hostname)) return
+
   const overlayQuery = document.getElementById('intro-overlay')
   const skipButtonQuery = document.getElementById('intro-skip') as HTMLButtonElement | null
   const triggerDockQuery = document.getElementById('intro-trigger-dock')

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -10,7 +10,6 @@ import LinkCard from '@/components/home/LinkCard.astro'
 import Section from '@/components/home/Section.astro'
 import SiteStats from '@/components/home/SiteStats.astro'
 import SkillLayout from '@/components/home/SkillLayout.astro'
-import IntroOverlay from '@/components/intro/IntroOverlay.astro'
 import JoJo from '@/components/mascot/JoJo'
 import PostPreviewEn from '@/components/PostPreviewEn.astro'
 import Terminal from '@/components/terminal/Terminal.astro'
@@ -93,7 +92,6 @@ const latestNotes = (await getCollection('notesEn'))
 ---
 
 <PageLayout meta={{ title: 'Home' }} highlightColor='#659EB9'>
-  <IntroOverlay />
   <main class='flex w-full flex-col items-center'>
     <section
       class='animate mb-10 flex flex-col items-center gap-y-7 relative z-50'

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,6 @@ import LinkCard from '@/components/home/LinkCard.astro'
 import Section from '@/components/home/Section.astro'
 import SiteStats from '@/components/home/SiteStats.astro'
 import SkillLayout from '@/components/home/SkillLayout.astro'
-import IntroOverlay from '@/components/intro/IntroOverlay.astro'
 import JoJo from '@/components/mascot/JoJo'
 import Terminal from '@/components/terminal/Terminal.astro'
 import config from '@/site-config'
@@ -94,7 +93,6 @@ const agentHackathonLink =
 ---
 
 <PageLayout meta={{ title: 'Home' }} highlightColor='#659EB9'>
-  <IntroOverlay />
   <main class='flex w-full flex-col items-center'>
     <section
       class='animate mb-10 flex flex-col items-center gap-y-7 relative z-50'


### PR DESCRIPTION
## What changed

- Removed the entrance animation from the Chinese and English home pages.
- Kept the animation available on `/v2` and `/en/v2`.
- Disabled the overlay and replay controls on `joyehuang.me` and `www.joyehuang.me`.

## Why

The entrance animation should only be exercised through the v2 preview routes and must not appear on the public production domain.

## Impact

Visitors to the regular home pages no longer load or see the intro. V2 preview environments can still exercise it, while the production hostname exits before controller initialization and hides the overlay immediately to avoid a flash.

## Validation

- `bun run check` — 139 files, 0 errors, 0 warnings, 0 hints
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restrict the intro animation to v2 preview routes (`/v2`, `/en/v2`) and remove it from the main home pages. On production hosts joyehuang.me and www.joyehuang.me, the overlay is hidden and the replay controls are disabled to prevent initialization and avoid any flash.

<sup>Written for commit 8e6697ee2ae79c152cdda0f28521bb5e8b58b7ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/joyehuang/blog/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

