### PR TITLE
fix(waline): throttle pageview writes and harden stats fallback

### DIFF
--- a/src/components/comment/Comment.astro
+++ b/src/components/comment/Comment.astro
@@ -24,6 +24,7 @@ const { class: className, path } = Astro.props as Props
 }
 
 <script>
+  import { stripEn } from '@/lib/waline-views'
   import { init as walineInit } from '@waline/client'
   import type { WalineEmojiPresets } from '@waline/client'
   import config from 'virtual:config'
@@ -46,21 +47,12 @@ const { class: className, path } = Astro.props as Props
         (preset) => `${config.npmCDN}/@waline/emojis@1.2.0/${preset}` as WalineEmojiPresets
       )
 
-      const stripEn = (p: string) => p.replace(/^\/en(?=\/|$)/, '') || '/'
       const overridePath = this.dataset.path
       const rawPath =
         overridePath && overridePath.length > 0 ? overridePath : window.location.pathname
       const path = stripEn(rawPath)
 
-      // Normalize any pre-rendered counter elements so /en/foo and /foo
-      // share the same Waline counter.
-      document
-        .querySelectorAll<HTMLElement>('.waline-pageview-count, .waline-comment-count')
-        .forEach((el) => {
-          const current = el.dataset.path
-          if (current) el.dataset.path = stripEn(current)
-        })
-
+      // Counter elements belong to ViewCounter — this only mounts the thread.
       walineInit({
         el: '#waline',
         serverURL: walineConfig.server || '',

--- a/src/components/comment/ViewCounter.astro
+++ b/src/components/comment/ViewCounter.astro
@@ -5,34 +5,16 @@ const walineConfig = config.integ.waline
 const enabled = walineConfig.enable && !!walineConfig.server
 ---
 
-{enabled && <waline-views data-server={walineConfig.server}></waline-views>}
+{enabled && <waline-views data-server={walineConfig.server} />}
 
 <script>
-  import { commentCount, pageviewCount } from '@waline/client'
-
-  const stripEn = (p: string) => p.replace(/^\/en(?=\/|$)/, '') || '/'
+  import { mountCounters } from '@/lib/waline-views'
 
   class WalineViews extends HTMLElement {
     connectedCallback() {
-      // The comment widget runs walineInit({ pageview, comment }), which
-      // already drives both counters. Skip here to avoid double-fetching.
-      if (document.querySelector('joye-comment, comment-component')) return
-
-      const serverURL = this.dataset.server || ''
-      if (!serverURL) return
-
-      // Normalize zh/en pairs to one key.
-      document
-        .querySelectorAll<HTMLElement>(
-          '.waline-pageview-count, .waline-pageview-readonly, .waline-comment-count'
-        )
-        .forEach((el) => {
-          if (el.dataset.path) el.dataset.path = stripEn(el.dataset.path)
-        })
-
-      pageviewCount({ serverURL, selector: '.waline-pageview-count' })
-      pageviewCount({ serverURL, selector: '.waline-pageview-readonly', update: false })
-      commentCount({ serverURL, selector: '.waline-comment-count' })
+      // Sole owner of every counter element on the page — the comment widget
+      // runs with `pageview`/`comment` off so nothing is fetched twice.
+      mountCounters(this.dataset.server || '')
     }
   }
 

--- a/src/components/home/SiteStats.astro
+++ b/src/components/home/SiteStats.astro
@@ -16,9 +16,12 @@ const [blogPosts, notes, talks] = await Promise.all([
   getCollection('talks', ({ data }) => !data.draft && data.status === 'published')
 ])
 
-// Live total page views from Waline (/api/stats endpoint on the waline server).
-// On a transient failure we render 0 — better than a stale number.
-let pageViews = 0
+// Total page views from Waline (/api/stats on the waline server). The page is
+// prerendered, so this is read once at build time and baked into the HTML.
+// Stays null if the server is unreachable: a database outage during a build
+// used to bake a hard 0 into the homepage, which reads as real data and only
+// clears on the next deploy. An em dash is honest about not knowing.
+let pageViews: number | null = null
 const walineServer = config.integ.waline.server
 if (walineServer) {
   try {
@@ -30,7 +33,7 @@ if (walineServer) {
       if (typeof data.totalViews === 'number') pageViews = data.totalViews
     }
   } catch {
-    // Network/timeout — leave pageViews at 0.
+    // Network/timeout — leave pageViews unknown.
   }
 }
 
@@ -55,7 +58,7 @@ const items = [
   { label: labels.blog, value: blogPosts.length.toString() },
   { label: labels.notes, value: notes.length.toString() },
   { label: labels.talks, value: talks.length.toString() },
-  { label: labels.pageViews, value: pageViews.toLocaleString() }
+  { label: labels.pageViews, value: pageViews === null ? '—' : pageViews.toLocaleString() }
 ]
 ---
 

--- a/src/lib/waline-views.ts
+++ b/src/lib/waline-views.ts
@@ -1,0 +1,265 @@
+/**
+ * Throttled client for the self-hosted Waline counter API.
+ *
+ * Waline's own `pageviewCount` fires its increment `POST /api/article`
+ * unconditionally — even on pages that render no counter element — and its
+ * read-only branch issues a GET without checking that anything matched. Since
+ * `ViewCounter` renders from `BaseLayout`, that meant a write plus a read
+ * against Postgres on every page view across the whole site, which is what
+ * drained the database's compute quota.
+ *
+ * This module talks to the same endpoints, but:
+ * - counts a visit at most once per path per browser per day,
+ * - reads every visible counter in a single batched request,
+ * - reuses a fetched count for a few minutes within a tab,
+ * - waits for the visit to settle, so bounces and background tabs never
+ *   reach the database at all.
+ */
+
+/** How long a browser is remembered as having already counted a path. */
+const WRITE_TTL = 24 * 60 * 60 * 1000
+/** How long a fetched count is reused within a tab before refetching. */
+const READ_TTL = 5 * 60 * 1000
+/** Settle delay before touching the network, so quick bounces cost nothing. */
+const SETTLE_MS = 1500
+
+/** `/en/foo` and `/foo` are the same page, so they share one counter. */
+export const stripEn = (path: string) => path.replace(/^\/en(?=\/|$)/, '') || '/'
+
+const storage = (kind: 'local' | 'session'): Storage | null => {
+  try {
+    const store = kind === 'local' ? window.localStorage : window.sessionStorage
+    const probe = '__waline_probe__'
+    store.setItem(probe, '1')
+    store.removeItem(probe)
+    return store
+  } catch {
+    // Private mode or blocked cookies — fall back to counting every visit.
+    return null
+  }
+}
+
+const cacheGet = (store: Storage | null, key: string, ttl: number): number | null => {
+  if (!store) return null
+  try {
+    const raw = store.getItem(key)
+    if (!raw) return null
+    const { n, t } = JSON.parse(raw) as { n?: number; t?: number }
+    if (typeof n !== 'number' || typeof t !== 'number') return null
+    return Date.now() - t < ttl ? n : null
+  } catch {
+    return null
+  }
+}
+
+const cacheSet = (store: Storage | null, key: string, n: number) => {
+  if (!store) return
+  try {
+    store.setItem(key, JSON.stringify({ n, t: Date.now() }))
+  } catch {
+    // Storage full — the counter still works, it just refetches next time.
+  }
+}
+
+const apiBase = (server: string) => `${server.replace(/\/?$/, '/')}api/`
+
+const unwrap = (payload: unknown, label: string): unknown => {
+  if (payload && typeof payload === 'object' && 'errno' in payload) {
+    const { errno, errmsg } = payload as { errno?: number; errmsg?: string }
+    if (errno) throw new Error(`${label} failed with ${errno}: ${errmsg ?? ''}`)
+  }
+  return (payload as { data?: unknown } | null)?.data
+}
+
+const fetchViews = async (server: string, paths: string[], lang: string, signal: AbortSignal) => {
+  const url = `${apiBase(server)}article?path=${encodeURIComponent(paths.join(','))}&type=time&lang=${encodeURIComponent(lang)}`
+  const data = unwrap(await (await fetch(url, { signal })).json(), 'Get counter')
+  return (Array.isArray(data) ? data : []).map((item) => Number((item as { time?: number })?.time))
+}
+
+const incrementView = async (server: string, path: string, lang: string) => {
+  const url = `${apiBase(server)}article?lang=${encodeURIComponent(lang)}`
+  const data = unwrap(
+    await (
+      await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path, type: 'time', action: 'inc' })
+      })
+    ).json(),
+    'Update counter'
+  )
+  const first = Array.isArray(data) ? data[0] : data
+  const n = Number((first as { time?: number })?.time)
+  return Number.isFinite(n) ? n : null
+}
+
+const fetchComments = async (
+  server: string,
+  paths: string[],
+  lang: string,
+  signal: AbortSignal
+) => {
+  const decoded = paths.map((path) => {
+    try {
+      return decodeURI(path)
+    } catch {
+      return path
+    }
+  })
+  const url = `${apiBase(server)}comment?type=count&url=${encodeURIComponent(decoded.join(','))}&lang=${encodeURIComponent(lang)}`
+  const data = unwrap(await (await fetch(url, { signal })).json(), 'Get comment count')
+  // Waline answers with a bare number when a single path is requested.
+  return (Array.isArray(data) ? data : [data]).map(Number)
+}
+
+const groupBy = (map: Map<string, HTMLElement[]>, path: string, el: HTMLElement) => {
+  const group = map.get(path)
+  if (group) group.push(el)
+  else map.set(path, [el])
+}
+
+const paint = (els: HTMLElement[], n: number) => {
+  for (const el of els) el.textContent = String(n)
+}
+
+/**
+ * Fill every counter element on the page, doing as little database work as the
+ * page actually needs. Safe to call on pages that render no counters at all.
+ */
+export const mountCounters = (serverURL: string) => {
+  if (!serverURL) return
+
+  const lang = document.documentElement.lang || navigator.language || 'en'
+  const here = stripEn(window.location.pathname)
+  const session = storage('session')
+  const local = storage('local')
+
+  const viewEls = [
+    ...document.querySelectorAll<HTMLElement>('.waline-pageview-count, .waline-pageview-readonly')
+  ]
+  const commentEls = [...document.querySelectorAll<HTMLElement>('.waline-comment-count')]
+
+  const pathOf = (el: HTMLElement) => {
+    const raw = el.dataset.path
+    const path = raw && raw.length > 0 ? stripEn(raw) : here
+    el.dataset.path = path
+    return path
+  }
+
+  const writeKey = `waline:hit:${here}`
+  const shouldCount = cacheGet(local, writeKey, WRITE_TTL) === null
+
+  // Elements showing the current path take their value from the increment
+  // itself, so they never need a separate read.
+  const writeTargets: HTMLElement[] = []
+  const pendingViews = new Map<string, HTMLElement[]>()
+  for (const el of viewEls) {
+    const path = pathOf(el)
+    if (shouldCount && path === here) {
+      writeTargets.push(el)
+      continue
+    }
+    const cached = cacheGet(session, `waline:v:${path}`, READ_TTL)
+    if (cached !== null) {
+      el.textContent = String(cached)
+      continue
+    }
+    groupBy(pendingViews, path, el)
+  }
+
+  const pendingComments = new Map<string, HTMLElement[]>()
+  for (const el of commentEls) {
+    const path = pathOf(el)
+    const cached = cacheGet(session, `waline:c:${path}`, READ_TTL)
+    if (cached !== null) {
+      el.textContent = String(cached)
+      continue
+    }
+    groupBy(pendingComments, path, el)
+  }
+
+  const controller = new AbortController()
+  const jobs: Array<() => Promise<void>> = []
+
+  if (shouldCount) {
+    jobs.push(async () => {
+      const n = await incrementView(serverURL, here, lang)
+      // Only remember the visit once the write actually landed, so an outage
+      // does not silently swallow a day of counts.
+      cacheSet(local, writeKey, 1)
+      if (n === null) return
+      cacheSet(session, `waline:v:${here}`, n)
+      paint(writeTargets, n)
+    })
+  }
+
+  if (pendingViews.size > 0) {
+    jobs.push(async () => {
+      const paths = [...pendingViews.keys()]
+      const counts = await fetchViews(serverURL, paths, lang, controller.signal)
+      paths.forEach((path, i) => {
+        const n = counts[i]
+        if (!Number.isFinite(n)) return
+        cacheSet(session, `waline:v:${path}`, n)
+        paint(pendingViews.get(path) ?? [], n)
+      })
+    })
+  }
+
+  if (pendingComments.size > 0) {
+    jobs.push(async () => {
+      const paths = [...pendingComments.keys()]
+      const counts = await fetchComments(serverURL, paths, lang, controller.signal)
+      paths.forEach((path, i) => {
+        const n = counts[i]
+        if (!Number.isFinite(n)) return
+        cacheSet(session, `waline:c:${path}`, n)
+        paint(pendingComments.get(path) ?? [], n)
+      })
+    })
+  }
+
+  // Everything was served from cache and this visit is already counted.
+  if (jobs.length === 0) return
+
+  let timer = 0
+
+  const cleanup = () => {
+    window.clearTimeout(timer)
+    document.removeEventListener('visibilitychange', onVisibility)
+    window.removeEventListener('pagehide', onLeave)
+  }
+
+  const fire = () => {
+    cleanup()
+    for (const job of jobs) {
+      job().catch((error: unknown) => {
+        if (error instanceof Error && error.name === 'AbortError') return
+        console.error(error)
+      })
+    }
+  }
+
+  const arm = () => {
+    window.clearTimeout(timer)
+    timer = window.setTimeout(() => {
+      if (document.visibilityState === 'visible') fire()
+    }, SETTLE_MS)
+  }
+
+  // A tab restored in the background re-arms once it is actually looked at.
+  function onVisibility() {
+    if (document.visibilityState === 'visible') arm()
+  }
+
+  // Left before settling — this visit costs the database nothing.
+  function onLeave() {
+    cleanup()
+    controller.abort()
+  }
+
+  document.addEventListener('visibilitychange', onVisibility)
+  window.addEventListener('pagehide', onLeave)
+  arm()
+}

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -151,9 +151,11 @@ export const integ: IntegrationUserConfig = {
   waline: {
     enable: true,
     server: 'https://waline.joyehuang.me',
+    // Counter elements are driven by `lib/waline-views`, which throttles the
+    // database writes. Letting the widget count too would double every query.
     additionalConfigs: {
-      pageview: true,
-      comment: true
+      pageview: false,
+      comment: false
     }
   }
 }


### PR DESCRIPTION
Waline's `pageviewCount` fires its increment POST unconditionally, and its read-only branch GETs without checking that any element matched. `ViewCounter` renders from `BaseLayout`, so every page view site-wide cost a Postgres write plus a read — even on pages with no counter to show. That exhausted the Neon free-tier compute quota, which took comments and view counts down with it.

- Counting moves to `lib/waline-views`: one write per path per browser per day, all visible counters batched into a single read, counts cached per tab for five minutes, and a 1.5s settle delay so bounces and background tabs never reach the database.
- The comment widget runs with `pageview`/`comment` off so nothing is fetched twice. Those flags only drive the standalone count elements; the thread mounts independently.
- `SiteStats` no longer falls back to `0` when `/api/stats` is unreachable. The outage baked "0 浏览量" into the prerendered homepage, where it reads as real data and survives until the next deploy. Renders an em dash instead.

Notes: the counters cannot be exercised on this preview — Waline's `SECURE_DOMAINS` allows only `joyehuang.me`, so `/api/comment` and `/api/article` return 403 from `*.vercel.app` and from localhost. That is pre-existing, not a regression. `/api/stats` is not domain-guarded, so the homepage view count *is* verifiable on the preview. Merging triggers a production build, which also clears the stale `0` currently live on the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttles Waline pageview writes and batches reads to reduce database load, fixing the Neon quota issue. Also avoids baking a fake “0” on the homepage by rendering an em dash when stats are unavailable.

- **Bug Fixes**
  - Move counting to `src/lib/waline-views.ts`: one write per path per browser per day, batched reads for visible counters, 5‑minute per‑tab cache, 1.5s settle delay, and `/en` path normalization.
  - `ViewCounter` renders all counters via `mountCounters`; disable `pageview`/`comment` in `site.config.ts` so the `@waline/client` widget doesn’t double‑fetch.
  - `SiteStats` shows an em dash when `/api/stats` fails instead of baking a `0` into prerendered HTML.

<sup>Written for commit 9a01c28fb631a55ce6a4b50807ca861b1b470b5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/joyehuang/blog/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

