### PR TITLE
fix(i18n): render en pages with English dates and Waline locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Notes 的 `status` 可选：
 
 - `AnalyticsEvents.astro`: 统一处理 `data-analytics-event` 点击上报。
 - `BaseHead.astro`: SEO、OG、favicon、字体预加载、双语 hreflang。
+- `FormattedDate.astro`: 按页面语言格式化日期（主题自带版本锁死站点级 zh-CN）。
 - `Header.astro`: 双语导航、搜索入口、dev mode 入口。
 - `HeroEn.astro`: 英文博客详情页 hero，修正英文 tag/link 路由。
 - `LanguageSwitcher.astro`: 中英文页面切换按钮。
@@ -135,6 +136,7 @@ Notes 的 `status` 可选：
 - `WechatReveal.astro`: 微信号悬停/聚焦显示。
 - `about/Substats.astro`: 关于页外部平台数据/粉丝数展示。
 - `about/ToolSection.astro`: 关于页工具栈展示。
+- `blog/CopyrightEn.astro`: 英文博客详情页版权卡片，日期走 en-US。
 - `blog/FeatureCalloutCard.astro`: 博客内功能/重点卡片。
 - `blog/TalkEpisodeCard.astro`: 博客内嵌分享会入口卡片。
 - `blog/TalkSlideFigure.astro`: 博客内嵌分享会 slide 图片。

--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -1,0 +1,25 @@
+---
+import { formatDate } from '@/i18n/date'
+import type { Lang } from '@/i18n/ui'
+import type { HTMLAttributes } from 'astro/types'
+
+import { cn } from 'astro-pure/utils'
+
+// Locale-aware mirror of astro-pure's FormattedDate: identical markup/styles,
+// but the locale follows the page language instead of the single global
+// `locale.dateLocale` (zh-CN) in `site.config.ts`.
+type Props = HTMLAttributes<'time'> & {
+  date: Date
+  lang: Lang
+  dateTimeOptions?: Intl.DateTimeFormatOptions
+  class?: string
+}
+
+const { date, lang, dateTimeOptions, class: className, ...attrs } = Astro.props
+---
+
+<span class={cn('text-muted-foreground font-mono', className)} {...attrs}>
+  <time datetime={date.toISOString()}>
+    {formatDate(date, lang, dateTimeOptions)}
+  </time>
+</span>

--- a/src/components/blog/CopyrightEn.astro
+++ b/src/components/blog/CopyrightEn.astro
@@ -1,0 +1,148 @@
+---
+import type { CollectionEntry } from 'astro:content'
+import { formatDate } from '@/i18n/date'
+import config from 'virtual:config'
+
+import { QRCode } from 'astro-pure/advanced'
+import { Icon } from 'astro-pure/user'
+import { cn } from 'astro-pure/utils'
+
+// English mirror of astro-pure's Copyright: identical markup/styles, but the
+// publish date formats in en-US instead of the site-wide zh-CN date locale
+// (astro-pure's `getFormattedDate` reads a single global `locale.dateLocale`).
+interface Props {
+  data: CollectionEntry<'blog' | 'blogEn'>['data']
+  class?: string
+}
+
+const {
+  data: { heroImage, title, publishDate },
+  class: className
+} = Astro.props
+
+const image = typeof heroImage?.src === 'string' ? heroImage?.src : (heroImage?.src?.src ?? '')
+
+const shares = {
+  weibo: {
+    link: `http://service.weibo.com/share/share.php?url=${Astro.url}&title=${title}&pic=${image}`
+  },
+  x: {
+    link: `https://x.com/intent/tweet?text='${title}'&url='${Astro.url}'&via='${config.author}'`
+  },
+  bluesky: {
+    link: `https://bsky.app/intent/compose?text=${title}%0A${Astro.url}`
+  }
+} as const
+---
+
+<div
+  class={cn(
+    'relative flex flex-col gap-y-2 rounded-xl border px-3 sm:px-4 py-2 sm:py-3',
+    className
+  )}
+>
+  <Icon class='absolute end-4 top-4 size-20 opacity-10' name='copyright' />
+
+  {/* title & link */}
+  <div class='flex flex-col'>
+    <div class='font-medium text-foreground'>{title}</div>
+    <div class='text-sm'>{Astro.url}</div>
+  </div>
+
+  {/* common info */}
+  <div class='flex flex-row flex-wrap justify-start gap-x-5 gap-y-1 sm:gap-x-8'>
+    <div class='flex gap-x-2 sm:flex-col'>
+      <span>Author</span>
+      <span class='text-sm text-foreground max-sm:place-self-center'>{config.author}</span>
+    </div>
+    {
+      publishDate && (
+        <div class='flex gap-x-2 sm:min-w-16 sm:flex-col'>
+          <span>Published at</span>
+          <span class='text-sm text-foreground max-sm:place-self-center'>
+            {formatDate(publishDate, 'en', { month: 'long' })}
+          </span>
+        </div>
+      )
+    }
+    <div class='flex gap-x-2 sm:flex-col'>
+      <span>Copyright</span>
+      <a
+        class='text-sm text-foreground max-sm:place-self-center'
+        href='https://creativecommons.org/licenses/by/4.0/'
+        target='_blank'
+      >
+        CC BY-NC-SA 4.0
+      </a>
+    </div>
+  </div>
+
+  {/* functions */}
+  <div class='relative'>
+    <div class='flex flex-row gap-3'>
+      <button
+        id='copy-link'
+        class='group rounded-full bg-muted p-1 text-muted-foreground transition-colors hover:text-primary sm:p-1.5'
+      >
+        <Icon class='size-5' name='link' />
+      </button>
+      <button
+        id='get-qrcode'
+        class='group rounded-full bg-muted p-1 text-muted-foreground transition-colors hover:text-primary sm:p-1.5'
+      >
+        <Icon class='size-5' name='qrcode' />
+      </button>
+      {
+        config.content.share.map((share) => (
+          <a
+            href={shares[share].link}
+            target='_blank'
+            id={`share-${share}`}
+            class='group rounded-full bg-muted p-1 text-muted-foreground transition-colors hover:text-primary sm:p-1.5'
+          >
+            <Icon class='size-5' name={share} />
+          </a>
+        ))
+      }
+    </div>
+    <QRCode
+      aria-expanded='false'
+      class='absolute z-10 -mt-2 box-content max-h-0 max-w-44 overflow-hidden rounded-xl border bg-muted p-4 opacity-0 transition-all duration-300 ease-in-out aria-expanded:max-h-44 aria-expanded:translate-y-4 aria-expanded:opacity-100'
+    />
+  </div>
+</div>
+
+<div class='mx-6 rounded-b-xl border border-t-0 px-3 pb-1.5 pt-1 sm:mx-8 sm:px-4'>
+  <a
+    href='/en/projects#sponsorship'
+    class='flex items-center justify-between text-muted-foreground no-underline'
+    target='_blank'
+  >
+    <span>Buy me a cup of coffee ☕.</span>
+    <Icon class='box-content size-5 p-1' name='receive-money' />
+  </a>
+</div>
+
+<script>
+  import { showToast } from 'astro-pure/utils'
+
+  // Copy link
+  const copyLink = document.getElementById('copy-link')
+  copyLink?.addEventListener('click', () => {
+    navigator.clipboard.writeText(window.location.href)
+    // Show toast
+    showToast({ message: 'Link copied!' })
+  })
+
+  // QRCode
+  const getQRCode = document.getElementById('get-qrcode')
+  const qrcodeContainer = document.getElementById('qrcode-container')
+  if (!qrcodeContainer) throw new Error('qrcode container not found')
+  getQRCode?.addEventListener('click', () => {
+    if (qrcodeContainer.ariaExpanded === 'true') {
+      qrcodeContainer.ariaExpanded = 'false'
+    } else {
+      qrcodeContainer.ariaExpanded = 'true'
+    }
+  })
+</script>

--- a/src/components/blog/CopyrightEn.astro
+++ b/src/components/blog/CopyrightEn.astro
@@ -71,6 +71,7 @@ const shares = {
         class='text-sm text-foreground max-sm:place-self-center'
         href='https://creativecommons.org/licenses/by/4.0/'
         target='_blank'
+        rel='noopener noreferrer'
       >
         CC BY-NC-SA 4.0
       </a>
@@ -97,6 +98,7 @@ const shares = {
           <a
             href={shares[share].link}
             target='_blank'
+            rel='noopener noreferrer'
             id={`share-${share}`}
             class='group rounded-full bg-muted p-1 text-muted-foreground transition-colors hover:text-primary sm:p-1.5'
           >

--- a/src/components/blog/HeroEn.astro
+++ b/src/components/blog/HeroEn.astro
@@ -3,10 +3,12 @@ import { Image } from 'astro:assets'
 import type { InferEntrySchema } from 'astro:content'
 
 import { PageInfo } from 'astro-pure/components/pages'
-import { FormattedDate, Icon } from 'astro-pure/user'
+import { Icon } from 'astro-pure/user'
+import FormattedDate from '@/components/FormattedDate.astro'
 
 // English mirror of astro-pure's Hero: identical markup/styles, but tag links
-// point to /en/tags/<tag> instead of the hardcoded /tags/<tag>.
+// point to /en/tags/<tag> instead of the hardcoded /tags/<tag>, and dates format
+// in en-US rather than the site-wide zh-CN date locale.
 interface Props {
   data: InferEntrySchema<'blog'>
   remarkPluginFrontmatter: Record<string, unknown>
@@ -61,7 +63,12 @@ const dateTimeOptions: Intl.DateTimeFormatOptions = {
     {/* Article date */}
     <div class='flex items-center gap-1'>
       <Icon name='calendar' class='size-5' />
-      <FormattedDate class='font-sans' date={publishDate} dateTimeOptions={dateTimeOptions} />
+      <FormattedDate
+        class='font-sans'
+        lang='en'
+        date={publishDate}
+        dateTimeOptions={dateTimeOptions}
+      />
       {
         updatedDate && (
           <div class='flex items-center gap-1'>
@@ -70,6 +77,7 @@ const dateTimeOptions: Intl.DateTimeFormatOptions = {
               Update
               <FormattedDate
                 class='font-sans'
+                lang='en'
                 date={updatedDate}
                 dateTimeOptions={dateTimeOptions}
               />

--- a/src/components/blog/PostPreviewEn.astro
+++ b/src/components/blog/PostPreviewEn.astro
@@ -2,10 +2,12 @@
 import { Image } from 'astro:assets'
 import { render, type CollectionEntry } from 'astro:content'
 
-import { Button, FormattedDate, Icon } from 'astro-pure/user'
+import { Button, Icon } from 'astro-pure/user'
+import FormattedDate from '@/components/FormattedDate.astro'
 
 // English mirror of astro-pure's PostPreview: identical markup/styles, but links
-// to /en/blog/<translationKey> instead of the hardcoded /blog/<id>.
+// to /en/blog/<translationKey> instead of the hardcoded /blog/<id>, and dates
+// format in en-US rather than the site-wide zh-CN date locale.
 interface Props {
   post: CollectionEntry<'blogEn'>
   detailed?: boolean
@@ -53,7 +55,7 @@ const heroStyle =
       )
     }
 
-    <FormattedDate class='min-w-[95px] py-1 text-xs' date={postDate} />
+    <FormattedDate class='min-w-[95px] py-1 text-xs' lang='en' date={postDate} />
 
     <div class='z-10 flex-grow'>
       <div class='flex justify-between'>

--- a/src/components/comment/Comment.astro
+++ b/src/components/comment/Comment.astro
@@ -3,6 +3,8 @@ import config from 'virtual:config'
 
 import '@waline/client/style'
 
+import { getLangFromUrl } from '@/i18n/ui'
+
 import { cn } from 'astro-pure/utils'
 
 interface Props {
@@ -11,11 +13,16 @@ interface Props {
 }
 
 const { class: className, path } = Astro.props as Props
+
+// Waline defaults to `navigator.language`, which renders the whole widget in
+// Chinese for zh-CN readers even on /en pages. Pin it to the page's language.
+const walineLangs = { zh: 'zh-CN', en: 'en-US' } as const
+const lang = walineLangs[getLangFromUrl(Astro.url)]
 ---
 
 {
   config.integ.waline.enable && (
-    <joye-comment data-path={path ?? ''}>
+    <joye-comment data-path={path ?? ''} data-lang={lang}>
       <div id='waline' class={cn('not-prose', className)}>
         Comment seems to stuck. Try to refresh?✨
       </div>
@@ -57,6 +64,7 @@ const { class: className, path } = Astro.props as Props
         el: '#waline',
         serverURL: walineConfig.server || '',
         path,
+        lang: this.dataset.lang,
         emoji,
         reaction: ['/icons/heart-item.svg'],
         ...walineConfig.additionalConfigs

--- a/src/i18n/date.ts
+++ b/src/i18n/date.ts
@@ -1,0 +1,33 @@
+import type { Lang } from './ui'
+
+/**
+ * Date locale per site language.
+ *
+ * astro-pure's `getFormattedDate` is hardwired to the single
+ * `locale.dateLocale` in `site.config.ts` (`zh-CN`), so every English page that
+ * used it rendered dates like `2026年5月23日`. Anything under `/en` formats its
+ * dates through this module instead.
+ */
+export const dateLocales = {
+  zh: 'zh-CN',
+  en: 'en-US'
+} as const satisfies Record<Lang, string>
+
+/** Mirrors `locale.dateOptions` in `site.config.ts`, so both languages agree on granularity. */
+const defaultDateOptions: Intl.DateTimeFormatOptions = {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric'
+}
+
+/** `2026年5月23日` for `zh`, `May 23, 2026` for `en`. */
+export function formatDate(
+  date: string | number | Date,
+  lang: Lang,
+  options?: Intl.DateTimeFormatOptions
+) {
+  return new Date(date).toLocaleDateString(dateLocales[lang], {
+    ...defaultDateOptions,
+    ...options
+  })
+}

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -5,14 +5,16 @@ import type { CollectionEntry } from 'astro:content'
 // Plugin styles
 import 'katex/dist/katex.min.css'
 
+import { getLangFromUrl } from '@/i18n/ui'
+
 import { MediumZoom } from 'astro-pure/advanced'
 import { ArticleBottom, Copyright, Hero } from 'astro-pure/components/pages'
 import PageLayout from '@/layouts/ContentLayout.astro'
-import Comment from '@/components/comment/Comment.astro'
+import CopyrightEn from '@/components/blog/CopyrightEn.astro'
 import HeroEn from '@/components/blog/HeroEn.astro'
+import Comment from '@/components/comment/Comment.astro'
 import JsonLd from '@/components/JsonLd.astro'
 import TableOfContents from '@/components/navigation/TableOfContents.astro'
-import { getLangFromUrl } from '@/i18n/ui'
 import { integ } from '@/site-config'
 
 interface Props {
@@ -117,7 +119,7 @@ const breadcrumbLd = {
 
   <Fragment slot='bottom'>
     {/* Copyright */}
-    <Copyright {data} />
+    {lang === 'en' ? <CopyrightEn {data} /> : <Copyright {data} />}
     {/* Article recommend */}
     {recommend && <ArticleBottom collections={posts} {id} class='mt-3 sm:mt-6' />}
     {/* Comments */}


### PR DESCRIPTION
`/en` pages leaked the Chinese locale in two places: post dates rendered as `2026年5月23日` (astro-pure's `getFormattedDate` is hardwired to the single `locale.dateLocale` in `site.config.ts`), and Waline fell back to `navigator.language` so the whole widget was Chinese for zh-CN readers.

- New `i18n/date.ts` + `FormattedDate.astro` format by page language; `HeroEn` / `PostPreviewEn` use them.
- New `blog/CopyrightEn.astro` — mirror of astro-pure's `Copyright`, which held the second Chinese date ("Published at").
- `Comment.astro` pins Waline's `lang` from the URL, so `/en` gets `en-US` and everything else stays `zh-CN`.

Notes: the comment `path` override is unchanged, so `/en/about` and `/about` still share one thread — only the widget's display language differs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix English pages showing Chinese dates and a Chinese Waline UI. Dates now follow the page language, and the comment widget uses `en-US` on `/en`.

- **Bug Fixes**
  - Added `i18n/date.ts` and `FormattedDate.astro` to format dates by page language; used in `HeroEn` and `PostPreviewEn`.
  - Added `blog/CopyrightEn.astro` and switched the blog layout to use it on `/en` so “Published at” shows an English date.
  - Forced `@waline/client` locale from the URL (`zh-CN`/`en-US`) in `Comment.astro`, avoiding `navigator.language` bleed; comment `path` is unchanged so `/en/...` and `/...` share a thread.
  - Added `rel=noopener` to external links in `CopyrightEn.astro` for consistency.

<sup>Written for commit 093309ed318f9ac19cfb44c590cc056912fa12ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/joyehuang/blog/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

