### PR TITLE
docs(claude): move lab entry guide to a nested CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,28 +5,7 @@
 - Analytics tracking contract: `ANALYTICS.md`. Check this before adding, renaming, or changing Vercel Analytics events.
 - UI/motion conventions: `DESIGN.md`. Check this before adding new interactive UI or transitions, so components reuse existing patterns (e.g. the Blurred Icon Transition) instead of inventing new ones.
 
-## Lab entries (frontend demos & tips)
-
-`/lab` is a gallery of small self-contained frontend demos. Collection `lab` is defined in `src/content.config.ts`; index + detail pages live in `src/pages/lab/`; shared chrome (`DemoFrame`, `LabCard`) and helpers (`src/lib/lab.ts`) already exist — **adding an entry should not touch any of that scaffolding.**
-
-To add one, create a folder under `src/content/lab/<slug>/` with:
-
-- `index.mdx` — frontmatter (`title`, `blurb` one-line 观点, `date`, `category` from the `lib/lab.ts` enum, `tags`, optional `source` URL) + the write-up. Embed the demo with:
-  ```mdx
-  import DemoFrame from '@/components/lab/DemoFrame.astro'
-  import Demo from './Demo.tsx'
-
-  <DemoFrame bleed>
-    <Demo client:visible />
-  </DemoFrame>
-  ```
-- `Demo.tsx` — the demo component, co-located (the md/mdx loader ignores it).
-
-Conventions:
-
-- A demo is a deliberate self-contained "artifact" (like the terminal sub-theme): it keeps its **own** palette via local CSS variables rather than the global semantic tokens. Make it theme-aware by defining a dark override keyed on `.dark` (e.g. `.dark .demo-root { --bg: … }`) — the demo's inline `<style>` is global CSS, so use `.dark <sel>`, not `:global()`. `DemoFrame`'s chrome (border/shadow) already follows the site light/dark tokens.
-- Keep every animation behind a `prefers-reduced-motion: reduce` override (see `DESIGN.md`).
-- Run `bun run check` before committing (the `.tsx`/`.mdx` are type-checked by Vercel's build).
+- Adding a `/lab` entry (frontend demos & tips): `src/content/lab/CLAUDE.md`.
 
 ## Git workflow
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -160,7 +160,10 @@ const talks = defineCollection({
 // component (a `.tsx` island, ignored by the md/mdx loader) with an `index.mdx`
 // that embeds it and adds the write-up.
 const lab = defineCollection({
-  loader: glob({ base: './src/content/lab', pattern: ['**/*.{md,mdx}', '!**/*.en.{md,mdx}'] }),
+  loader: glob({
+    base: './src/content/lab',
+    pattern: ['**/*.{md,mdx}', '!**/*.en.{md,mdx}', '!**/CLAUDE.md']
+  }),
   schema: ({ image }) =>
     z.object({
       // Required

--- a/src/content/lab/CLAUDE.md
+++ b/src/content/lab/CLAUDE.md
@@ -1,0 +1,22 @@
+# Lab entries (frontend demos & tips)
+
+`/lab` is a gallery of small self-contained frontend demos. Collection `lab` is defined in `src/content.config.ts`; index + detail pages live in `src/pages/lab/`; shared chrome (`DemoFrame`, `LabCard`) and helpers (`src/lib/lab.ts`) already exist — **adding an entry should not touch any of that scaffolding.**
+
+To add one, create a folder under `src/content/lab/<slug>/` with:
+
+- `index.mdx` — frontmatter (`title`, `blurb` one-line 观点, `date`, `category` from the `lib/lab.ts` enum, `tags`, optional `source` URL) + the write-up. Embed the demo with:
+  ```mdx
+  import DemoFrame from '@/components/lab/DemoFrame.astro'
+  import Demo from './Demo.tsx'
+
+  <DemoFrame bleed>
+    <Demo client:visible />
+  </DemoFrame>
+  ```
+- `Demo.tsx` — the demo component, co-located (the md/mdx loader ignores it).
+
+Conventions:
+
+- A demo is a deliberate self-contained "artifact" (like the terminal sub-theme): it keeps its **own** palette via local CSS variables rather than the global semantic tokens. Make it theme-aware by defining a dark override keyed on `.dark` (e.g. `.dark .demo-root { --bg: … }`) — the demo's inline `<style>` is global CSS, so use `.dark <sel>`, not `:global()`. `DemoFrame`'s chrome (border/shadow) already follows the site light/dark tokens.
+- Keep every animation behind a `prefers-reduced-motion: reduce` override (see `DESIGN.md`).
+- Run `bun run check` before committing (the `.tsx`/`.mdx` are type-checked by Vercel's build).


### PR DESCRIPTION
Moves the `/lab` how-to out of the always-loaded root `CLAUDE.md` into `src/content/lab/CLAUDE.md`, which loads only when working under that tree — about 370 fewer tokens in every session. A one-line pointer stays in the root file so it remains discoverable before the directory is touched.

Notes: the `lab` collection globs `**/*.{md,mdx}`, so the new file had to be excluded from the loader alongside the existing `.en` mirror exclusion — otherwise it loads as a lab entry and fails schema validation. `bun run check` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the `/lab` how-to from the root `CLAUDE.md` to `src/content/lab/CLAUDE.md` so it loads only in the lab context, cutting ~370 tokens from every session. Updated the `lab` collection glob in `src/content.config.ts` to exclude the nested guide (avoiding schema validation errors) and kept a one-line pointer in the root doc for discoverability.

<sup>Written for commit 09036baac6f17ebcee142f4d4dac48b64de45731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/joyehuang/blog/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

