### PR TITLE
chore(projects): add sponsors, collapse list into scrollable panel

### DIFF
--- a/src/components/projects/Sponsors.astro
+++ b/src/components/projects/Sponsors.astro
@@ -1,36 +1,57 @@
 ---
+import { Collapse } from 'astro-pure/user'
 import { cn } from 'astro-pure/utils'
 
 interface Props {
   class?: string
+  title?: string
   sponsors: {
     name: string
     amount: string
     date: string
   }[]
 }
-const { class: className, sponsors, ...props } = Astro.props
+const { class: className, title, sponsors, ...props } = Astro.props
+
+const total = sponsors.reduce((sum, s) => sum + (parseFloat(s.amount.replace(/[^0-9.]/g, '')) || 0), 0)
+const defaultTitle = `${sponsors.length} sponsors, ¥${total.toFixed(1).replace(/\.0$/, '')} total`
+const sorted = [...sponsors].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
 ---
 
-<div class={cn('border px-3 sm:px-4 py-2 rounded-xl', className)} {...props}>
-  <table class='my-0'>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Amount</th>
-        <th>Date</th>
-      </tr>
-    </thead>
-    <tbody>
-      {
-        sponsors.map((sponsor) => (
-          <tr>
-            <td>{sponsor.name}</td>
-            <td>{sponsor.amount}</td>
-            <td>{sponsor.date}</td>
-          </tr>
-        ))
-      }
-    </tbody>
-  </table>
-</div>
+<Collapse class={cn(className)} title={title ?? defaultTitle} {...props}>
+  <div class='max-h-60 overflow-y-auto'>
+    <table class='sponsors-table my-0'>
+      <thead>
+        <tr>
+          <th class='bg-muted'>Name</th>
+          <th class='bg-muted'>Amount</th>
+          <th class='bg-muted'>Date</th>
+        </tr>
+      </thead>
+      <tbody>
+        {
+          sorted.map((sponsor) => (
+            <tr>
+              <td>{sponsor.name}</td>
+              <td>{sponsor.amount}</td>
+              <td>{sponsor.date}</td>
+            </tr>
+          ))
+        }
+      </tbody>
+    </table>
+  </div>
+</Collapse>
+
+<style>
+  .sponsors-table.sponsors-table {
+    display: table;
+  }
+  .sponsors-table.sponsors-table thead {
+    display: table-header-group;
+  }
+  .sponsors-table th {
+    position: sticky;
+    top: 0;
+  }
+</style>

--- a/src/pages/en/projects/index.astro
+++ b/src/pages/en/projects/index.astro
@@ -143,7 +143,17 @@ const headings = [
     sponsors={[
       { name: '这个是备忘录🤭', amount: '¥25', date: '2026-04-27' },
       { name: '*烫', amount: '¥9.9', date: '2026-05-18' },
-      { name: '*恒', amount: '¥9.9', date: '2026-06-14' }
+      { name: '牧*', amount: '¥66', date: '2026-06-06' },
+      { name: '*恒', amount: '¥9.9', date: '2026-06-14' },
+      { name: '*成', amount: '¥9.9', date: '2026-06-25' },
+      { name: '*冉', amount: '¥100', date: '2026-06-25' },
+      { name: '*似', amount: '¥9.9', date: '2026-06-25' },
+      { name: 'O*u', amount: '¥30', date: '2026-06-26' },
+      { name: '*鸣', amount: '¥6.6', date: '2026-06-29' },
+      { name: '🌲', amount: '¥50', date: '2026-07-06' },
+      { name: '芝*', amount: '¥9.9', date: '2026-07-08' },
+      { name: '*豆', amount: '¥5.2', date: '2026-07-13' },
+      { name: '*落', amount: '¥9.9', date: '2026-07-26' }
     ]}
   />
 </PageLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -192,7 +192,17 @@ const headings = [
     sponsors={[
       { name: '这个是备忘录🤭', amount: '¥25', date: '2026-04-27' },
       { name: '*烫', amount: '¥9.9', date: '2026-05-18' },
-      { name: '*恒', amount: '¥9.9', date: '2026-06-14' }
+      { name: '牧*', amount: '¥66', date: '2026-06-06' },
+      { name: '*恒', amount: '¥9.9', date: '2026-06-14' },
+      { name: '*成', amount: '¥9.9', date: '2026-06-25' },
+      { name: '*冉', amount: '¥100', date: '2026-06-25' },
+      { name: '*似', amount: '¥9.9', date: '2026-06-25' },
+      { name: 'O*u', amount: '¥30', date: '2026-06-26' },
+      { name: '*鸣', amount: '¥6.6', date: '2026-06-29' },
+      { name: '🌲', amount: '¥50', date: '2026-07-06' },
+      { name: '芝*', amount: '¥9.9', date: '2026-07-08' },
+      { name: '*豆', amount: '¥5.2', date: '2026-07-13' },
+      { name: '*落', amount: '¥9.9', date: '2026-07-26' }
     ]}
   />
 </PageLayout>


### PR DESCRIPTION
Adds 10 new sponsorship entries (2026-06-06 to 2026-07-26) to both zh and en projects pages, and reworks `Sponsors.astro` so the list collapses behind a count/total summary (reusing the existing `Collapse` component) with a scrollable, sticky-header table instead of a flat, ever-growing block.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the sponsors list into a scrollable panel with a sticky header and summary, and adds 10 new sponsor entries to both zh and en project pages. Improves readability as the list grows and auto-shows count and total.

- **New Features**
  - Uses `Collapse` to show a compact title: "<count> sponsors, ¥<total> total".
  - Computes total from amounts and sorts entries newest-first.
  - Adds a 240px max-height panel with vertical scroll and sticky table header.
  - Updates sponsors data with 10 new entries (2026-06-06 to 2026-07-26) on both pages.

<sup>Written for commit 2bf1f9fb354dc6605f9be6c7eb1f440ba952649f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/joyehuang/blog/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

