### PR TITLE
chore(links): add Weisley's Blog and 歌鱼 friend links

### DIFF
--- a/public/links.json
+++ b/public/links.json
@@ -5,6 +5,24 @@
       "desc": "Friends I exchange blog links with",
       "link_list": [
         {
+          "name": "歌鱼",
+          "intro": "我思故我在 · Build fast, learn faster",
+          "link": "https://ailiujiarui.github.io/blog/",
+          "avatar": "https://github.com/ailiujiarui.png",
+          "since": "2026-07-29",
+          "met": "互换友链",
+          "note": "用 Astro 写字，也在开源夏令营里边学边做的记录者。"
+        },
+        {
+          "name": "Weisley's Blog",
+          "intro": "People die, but what we do lives on",
+          "link": "https://www.weisley1314.com/",
+          "avatar": "https://avatars.githubusercontent.com/u/267644970",
+          "since": "2026-07-29",
+          "met": "互换友链",
+          "note": "生死之外，把做过的事留下来的记录者。"
+        },
+        {
           "name": "Cxin Blog",
           "intro": "AI Native",
           "link": "https://cxin.vercel.app/",


### PR DESCRIPTION
Adds two friend links to `public/links.json`:
- Weisley's Blog (https://www.weisley1314.com/)
- 歌鱼 (https://ailiujiarui.github.io/blog/)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two friend links to `public/links.json` so they appear on the site: “Weisley's Blog” and “歌鱼”. Each entry includes link, avatar, since date, and a short note.

<sup>Written for commit 53092befad237f50039a2b11706409d4d2af2e7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/joyehuang/blog/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

