### PR TITLE
feat(site): add 404 shell, console greeting, read-to-end reward

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -344,7 +344,19 @@ not a bug to normalize away:
 - `jojo.css`'s speech bubble uses theme tokens (`--card`/`--foreground`/
   `--border`) for color but its own literal `10px` radius / `6px 10px`
   padding — color follows the system, geometry doesn't.
+- [`NotFoundTerminal.astro`](src/components/NotFoundTerminal.astro) is the
+  same sub-theme applied to the 404 page: its own `--nf-*` set (matching
+  `0.85rem` radius, mono type, the pinned traffic-light hexes). It also adds
+  `--nf-err`, because `--destructive` is a *fill* color and goes too dark in
+  dark mode to use as stderr text — if a new surface needs an error tone on a
+  dark background, give it a local token rather than reusing `--destructive`.
 
 When extending one of these surfaces, stay inside its local token set
-(`--wt-*`, `--term-*`) rather than pulling in the global `--radius`/spacing
-scale.
+(`--wt-*`, `--term-*`, `--nf-*`) rather than pulling in the global
+`--radius`/spacing scale.
+
+One caveat when a sub-theme surface builds nodes at runtime: Astro's scoped
+styles compile to `:where(.astro-<hash>)`, which `document.createElement` can
+never satisfy. Author the markup in a `<template>` and `cloneNode` it (see
+`NotFoundTerminal.astro`'s suggestion list) instead of constructing elements
+and hand-setting `className`.

--- a/src/components/ConsoleGreeting.astro
+++ b/src/components/ConsoleGreeting.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * Easter egg for whoever opens devtools: JoJo says hi from the console and
+ * points at the parts of the site that are not linked from the nav.
+ *
+ * Mounted once in BaseLayout. Zero visual footprint — nothing here touches the
+ * page, so it stays out of the way of the calm reading surfaces.
+ */
+---
+
+<script>
+  // Console colors cannot read the theme's CSS variables, so these two are
+  // picked to stay legible against both a light and a dark devtools panel.
+  const ACCENT = '#3f8fa8'
+  const MUTED = '#8b8b93'
+  const MONO = "font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace"
+
+  // Guard against a double greeting if this module is ever evaluated twice.
+  const flag = globalThis as typeof globalThis & { __joyeConsoleGreeted?: boolean }
+
+  if (!flag.__joyeConsoleGreeted) {
+    flag.__joyeConsoleGreeted = true
+
+    const en = window.location.pathname === '/en' || window.location.pathname.startsWith('/en/')
+
+    const mascot = ['  ╭──────╮', '  │ ●  ● │', '  │  ᴗ   │', '  ╰─┬──┬─╯', '    ╵  ╵'].join('\n')
+
+    const lines = en
+      ? [
+          "hi — i'm jojo. people who open the console are usually colleagues.",
+          '',
+          '  `        open the dev-mode terminal, on any page',
+          '  /lab     small self-contained frontend demos',
+          '  /talks   the weekly sharing session',
+          '',
+          '  mail     huangdeshiou@gmail.com',
+          '  source   https://github.com/joyehuang'
+        ]
+      : [
+          '你好，我是 jojo。会翻控制台的，一般是同行。',
+          '',
+          '  `        在任意页面打开 dev mode 终端',
+          '  /lab     前端小实验，每个都能直接玩',
+          '  /talks   每周的分享会',
+          '',
+          '  邮箱     huangdeshiou@gmail.com',
+          '  源码     https://github.com/joyehuang'
+        ]
+
+    console.log(`%c${mascot}`, `color:${ACCENT};${MONO};line-height:1.15`)
+    console.log(`%c${lines.join('\n')}`, `color:${MUTED};${MONO};line-height:1.6`)
+  }
+</script>

--- a/src/components/NotFoundTerminal.astro
+++ b/src/components/NotFoundTerminal.astro
@@ -1,0 +1,439 @@
+---
+import { buildSiteRoutes } from '@/lib/site-routes'
+
+/**
+ * The 404 easter egg: a missing page is a filesystem miss, so it gets reported
+ * like one. The requested path is only knowable in the browser (this page is
+ * prerendered), so the route index is inlined as JSON and the "did you mean"
+ * scoring runs client-side against `location.pathname`.
+ *
+ * Follows the terminal sub-theme (DESIGN.md → Sub-themes): its own `--nf-*`
+ * tokens and mono type rather than the global card/radius scale.
+ *
+ * Degrades without JS: the command line keeps its `$REQUEST_PATH` placeholder
+ * and the `ls /` listing stays visible, so a visitor still lands somewhere.
+ */
+
+interface Props {
+  lang: 'zh' | 'en'
+}
+
+const { lang } = Astro.props
+
+const copy = {
+  zh: {
+    heading: '404 · 页面不存在',
+    suggest: '# 你是不是想找：',
+    fallback: '# 没有接近的匹配。这是根目录：',
+    hintBefore: '提示：站内任意位置按',
+    hintAfter: '打开 dev mode，自己 ls 一圈。',
+    home: '回首页',
+    roots: [
+      { url: '/blog', label: 'blog/', desc: '长文' },
+      { url: '/notes', label: 'notes/', desc: '短笔记' },
+      { url: '/curated', label: 'curated/', desc: '外部好文' },
+      { url: '/lab', label: 'lab/', desc: '前端小实验' },
+      { url: '/talks', label: 'talks/', desc: '每周分享会' },
+      { url: '/projects', label: 'projects/', desc: '项目' },
+      { url: '/about', label: 'about', desc: '关于我' }
+    ]
+  },
+  en: {
+    heading: '404 · page not found',
+    suggest: '# did you mean:',
+    fallback: '# no close match. here is the root:',
+    hintBefore: 'hint: press',
+    hintAfter: 'anywhere to open dev mode and ls around.',
+    home: 'Back to home',
+    roots: [
+      { url: '/en/blog', label: 'blog/', desc: 'long-form posts' },
+      { url: '/en/notes', label: 'notes/', desc: 'short notes' },
+      { url: '/en/curated', label: 'curated/', desc: 'external readings' },
+      { url: '/lab', label: 'lab/', desc: 'frontend experiments' },
+      { url: '/en/projects', label: 'projects/', desc: 'projects' },
+      { url: '/en/about', label: 'about', desc: 'about me' }
+    ]
+  }
+} as const
+
+const t = copy[lang]
+const routes = await buildSiteRoutes()
+const homeHref = lang === 'en' ? '/en' : '/'
+// `set:html` does not escape — neutralise `<` so a title can never break out.
+const routesJson = JSON.stringify(routes).replace(/</g, '\\u003c')
+---
+
+<div class='nf-wrap'>
+  <h1 class='nf-heading'>{t.heading}</h1>
+
+  <section class='nf-shell' data-nf-root aria-label={t.heading}>
+    <header class='nf-chrome'>
+      <span class='nf-dots' aria-hidden='true'><i></i><i></i><i></i></span>
+      <span class='nf-chrome-title'>joye@joyehuang.me — /bin/sh</span>
+      <span class='nf-chrome-status'>exit 1</span>
+    </header>
+
+    <div class='nf-body'>
+      <p class='nf-line'>
+        <span class='nf-prompt' aria-hidden='true'>$</span>
+        <span data-nf-cmd>cat $REQUEST_PATH</span>
+      </p>
+
+      <p class='nf-line nf-stage nf-err' data-nf-error>
+        cat: $REQUEST_PATH: No such file or directory
+      </p>
+
+      <div class='nf-stage' data-nf-suggestions hidden>
+        <p class='nf-comment'>{t.suggest}</p>
+        <ul class='nf-list' data-nf-list></ul>
+        {
+          /* Cloned per suggestion — authored here so Astro's scoped-style
+            class lands on the markup, which it cannot do for nodes built
+            with `document.createElement`. */
+        }
+        <template data-nf-item>
+          <li>
+            <a href=''>
+              <span class='nf-item-name'></span>
+              <span class='nf-item-desc'></span>
+            </a>
+          </li>
+        </template>
+      </div>
+
+      <div class='nf-stage' data-nf-fallback>
+        <p class='nf-comment'>{t.fallback}</p>
+        <ul class='nf-list'>
+          {
+            t.roots.map((root) => (
+              <li>
+                <a href={root.url}>
+                  <span class='nf-item-name'>{root.label}</span>
+                  <span class='nf-item-desc'>{root.desc}</span>
+                </a>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+
+      <p class='nf-line nf-stage'>
+        <span class='nf-prompt' aria-hidden='true'>$</span>
+        <span class='nf-cursor' aria-hidden='true'></span>
+      </p>
+    </div>
+
+    <footer class='nf-foot nf-stage'>
+      <span>{t.hintBefore} <kbd class='nf-kbd'>`</kbd> {t.hintAfter}</span>
+      <a class='nf-home' href={homeHref}>{t.home} →</a>
+    </footer>
+  </section>
+
+  <script type='application/json' data-nf-routes is:inline set:html={routesJson} />
+</div>
+
+<script>
+  import { normalizePath, suggestRoutes, type SiteRoute } from '@/lib/not-found'
+
+  const root = document.querySelector<HTMLElement>('[data-nf-root]')
+  const payload = document.querySelector<HTMLScriptElement>('[data-nf-routes]')
+
+  if (root && payload) {
+    // Hold the output back until the command has "run" — without JS this
+    // attribute never lands and everything stays visible from the start.
+    root.dataset.nfState = 'typing'
+
+    const routes = JSON.parse(payload.textContent || '[]') as SiteRoute[]
+    const asked = normalizePath(window.location.pathname)
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    const errorEl = root.querySelector<HTMLElement>('[data-nf-error]')
+    if (errorEl) errorEl.textContent = `cat: ${asked}: No such file or directory`
+
+    const matches = suggestRoutes(asked, routes)
+    const list = root.querySelector<HTMLElement>('[data-nf-list]')
+    const template = root.querySelector<HTMLTemplateElement>('[data-nf-item]')
+    const suggestions = root.querySelector<HTMLElement>('[data-nf-suggestions]')
+    const fallback = root.querySelector<HTMLElement>('[data-nf-fallback]')
+
+    if (matches.length > 0 && list && template && suggestions && fallback) {
+      for (const match of matches) {
+        const item = template.content.cloneNode(true) as DocumentFragment
+        const link = item.querySelector('a')
+        const name = item.querySelector('.nf-item-name')
+        const desc = item.querySelector('.nf-item-desc')
+        if (!link || !name || !desc) continue
+        link.setAttribute('href', match.url)
+        name.textContent = match.url
+        desc.textContent = match.title
+        list.append(item)
+      }
+      suggestions.hidden = false
+      fallback.remove()
+    }
+
+    const cmdEl = root.querySelector<HTMLElement>('[data-nf-cmd]')
+    const full = `cat ${asked}`
+    const finish = () => {
+      root.dataset.nfState = 'done'
+    }
+
+    if (!cmdEl || reduced) {
+      if (cmdEl) cmdEl.textContent = full
+      finish()
+    } else {
+      cmdEl.textContent = ''
+      // Cap the whole type-out at ~0.7s so a long slug never drags.
+      const step = Math.min(18, 700 / full.length)
+      let typed = 0
+      const tick = () => {
+        typed += 1
+        cmdEl.textContent = full.slice(0, typed)
+        if (typed < full.length) window.setTimeout(tick, step)
+        else window.setTimeout(finish, 120)
+      }
+      window.setTimeout(tick, 260)
+    }
+  }
+</script>
+
+<style>
+  .nf-wrap {
+    --nf-radius: 0.85rem;
+    --nf-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    --nf-ring: 210 20% 22%;
+    --nf-ring-alpha: 0.28;
+    --nf-err: var(--destructive);
+
+    margin: 2rem auto 3rem;
+    max-width: 44rem;
+    width: 100%;
+  }
+  :global(.dark) .nf-wrap {
+    --nf-ring: 0 0% 100%;
+    --nf-ring-alpha: 0.1;
+    /* `--destructive` goes dark in dark mode because it is a fill, not a text
+       color — this is stderr, so it needs its own readable red. */
+    --nf-err: 0 75% 70%;
+  }
+
+  .nf-heading {
+    margin: 0 0 1rem;
+    font-family: var(--nf-mono);
+    font-size: 0.8125rem;
+    font-weight: 400;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .nf-shell {
+    border-radius: var(--nf-radius);
+    border: 1px solid hsl(var(--nf-ring) / var(--nf-ring-alpha));
+    background: linear-gradient(180deg, hsl(var(--card) / 0.95) 0%, hsl(var(--card) / 0.86) 100%);
+    box-shadow: 0 14px 38px hsl(var(--foreground) / 0.06);
+    overflow: hidden;
+    font-family: var(--nf-mono);
+  }
+
+  .nf-chrome {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 14px;
+    border-bottom: 1px solid hsl(var(--nf-ring) / var(--nf-ring-alpha));
+    background: hsl(var(--muted) / 0.5);
+    font-size: 11.5px;
+    color: hsl(var(--muted-foreground));
+  }
+  .nf-dots {
+    display: flex;
+    gap: 6px;
+  }
+  /* macOS traffic lights are chrome skeuomorphism, not theme content — pinned
+     across light/dark, same as terminal.css. */
+  .nf-dots i {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: #ff6058;
+  }
+  .nf-dots i:nth-child(2) {
+    background: #ffbd2e;
+  }
+  .nf-dots i:nth-child(3) {
+    background: #28c93f;
+  }
+  .nf-chrome-title {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .nf-chrome-status {
+    color: hsl(var(--nf-err) / 0.9);
+  }
+
+  .nf-body {
+    padding: 16px 14px 12px;
+    font-size: 13px;
+    line-height: 1.75;
+  }
+
+  .nf-line {
+    margin: 0;
+    display: flex;
+    gap: 8px;
+    word-break: break-all;
+  }
+  .nf-prompt {
+    color: hsl(var(--primary));
+    flex-shrink: 0;
+  }
+  .nf-err {
+    color: hsl(var(--nf-err));
+    padding-left: 18px;
+  }
+  .nf-comment {
+    margin: 14px 0 4px;
+    padding-left: 18px;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .nf-list {
+    margin: 0 0 6px;
+    padding: 0 0 0 18px;
+    list-style: none;
+  }
+  .nf-list a {
+    display: flex;
+    gap: 12px;
+    padding: 3px 8px 3px 0;
+    border-radius: 6px;
+    text-decoration: none;
+    color: inherit;
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease;
+  }
+  .nf-list a:hover,
+  .nf-list a:focus-visible {
+    background: hsl(var(--muted) / 0.7);
+  }
+  .nf-list a::before {
+    content: '→';
+    color: hsl(var(--primary));
+    flex-shrink: 0;
+  }
+  .nf-item-name {
+    color: hsl(var(--primary));
+    word-break: break-all;
+  }
+  .nf-list a:hover .nf-item-name {
+    text-decoration: underline;
+  }
+  .nf-item-desc {
+    color: hsl(var(--muted-foreground));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .nf-cursor {
+    display: inline-block;
+    width: 7px;
+    height: 15px;
+    transform: translateY(3px);
+    background: hsl(var(--primary) / 0.8);
+    animation: nf-blink 1.1s steps(1) infinite;
+  }
+  @keyframes nf-blink {
+    0%,
+    49% {
+      opacity: 1;
+    }
+    50%,
+    100% {
+      opacity: 0;
+    }
+  }
+
+  .nf-foot {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 10px 14px;
+    border-top: 1px solid hsl(var(--nf-ring) / var(--nf-ring-alpha));
+    background: hsl(var(--muted) / 0.35);
+    font-size: 11.5px;
+    color: hsl(var(--muted-foreground));
+  }
+  .nf-kbd {
+    padding: 1px 6px;
+    border: 1px solid hsl(var(--border));
+    border-radius: 4px;
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+  }
+  .nf-home {
+    color: hsl(var(--primary));
+    text-decoration: none;
+  }
+  .nf-home:hover {
+    text-decoration: underline;
+  }
+
+  /* Staged reveal. `typing` hides the command's output; `done` fades it in.
+     Neither lands without JS, so the content is simply always visible. */
+  [data-nf-state='typing'] .nf-stage {
+    opacity: 0;
+  }
+  [data-nf-state='done'] .nf-stage {
+    animation: nf-stage-in 0.28s ease both;
+  }
+  [data-nf-state='done'] [data-nf-suggestions],
+  [data-nf-state='done'] [data-nf-fallback] {
+    animation-delay: 0.07s;
+  }
+  [data-nf-state='done'] .nf-foot {
+    animation-delay: 0.14s;
+  }
+  @keyframes nf-stage-in {
+    from {
+      opacity: 0;
+      transform: translateY(3px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .nf-cursor {
+      animation: none;
+    }
+    [data-nf-state='done'] .nf-stage {
+      animation: none;
+    }
+    .nf-list a {
+      transition: none;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .nf-body {
+      font-size: 12px;
+    }
+    .nf-list a {
+      flex-direction: column;
+      gap: 0;
+    }
+    .nf-item-desc {
+      padding-left: 20px;
+    }
+  }
+</style>

--- a/src/components/blog/ReadingReward.tsx
+++ b/src/components/blog/ReadingReward.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+import JoJo from '../mascot/JoJo'
+
+import './reading-reward.css'
+
+/**
+ * Easter egg for readers who actually finish a long post: JoJo pops into the
+ * corner once, says one thing, and leaves.
+ *
+ * Two gates, so it rewards reading rather than scrolling:
+ *   - the end of the article body has to reach the upper 75% of the viewport
+ *   - the visitor has to have been on the page for at least `DWELL_MS`
+ *
+ * Fires at most once per post per session. Short posts never mount it at all —
+ * `BlogPost.astro` checks `READING_REWARD_MIN_WORDS` server-side.
+ */
+
+/** Below this, finishing the post is not an achievement worth interrupting. */
+export const READING_REWARD_MIN_WORDS = 1200
+
+const DWELL_MS = 15_000
+const VISIBLE_MS = 7000
+const EXIT_MS = 300
+
+// Kept short on purpose — the JoJo bubble is `white-space: nowrap`.
+const QUIPS = {
+  zh: ['你居然读完了', '读到底了，佩服', '谢谢你读完', '这篇不短，辛苦了'],
+  en: ['you actually finished', 'made it to the end', 'thanks for reading it all']
+} as const
+
+export type ReadingRewardProps = {
+  /** Post id, used to keep the once-per-session flag per article. */
+  slug: string
+  lang: 'zh' | 'en'
+}
+
+function alreadyRewarded(key: string): boolean {
+  try {
+    return window.sessionStorage.getItem(key) === '1'
+  } catch {
+    // private mode / storage disabled — just let the egg fire again
+    return false
+  }
+}
+
+function markRewarded(key: string): void {
+  try {
+    window.sessionStorage.setItem(key, '1')
+  } catch {
+    // non-fatal: the reward is cosmetic
+  }
+}
+
+export default function ReadingReward({ slug, lang }: ReadingRewardProps) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+  const [reachedEnd, setReachedEnd] = useState(false)
+  const [dwelled, setDwelled] = useState(false)
+  const [shown, setShown] = useState(false)
+  const [leaving, setLeaving] = useState(false)
+  const [mounted, setMounted] = useState(false)
+
+  const storageKey = `joye:read-reward:${slug}`
+  const quip = useMemo(() => {
+    const pool = QUIPS[lang]
+    return pool[Math.floor(Math.random() * pool.length)]
+  }, [lang])
+
+  // `createPortal` needs a DOM target, so hold off until after hydration.
+  useEffect(() => setMounted(true), [])
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDwelled(true), DWELL_MS)
+    return () => window.clearTimeout(timer)
+  }, [])
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel || typeof IntersectionObserver === 'undefined') return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setReachedEnd(true)
+          observer.disconnect()
+        }
+      },
+      // Require the end of the article to clear the lower quarter of the
+      // viewport — merely nudging it into view is not "finished".
+      { rootMargin: '0px 0px -25% 0px' }
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [])
+
+  const dismiss = useCallback(() => {
+    setLeaving(true)
+    window.setTimeout(() => setShown(false), EXIT_MS)
+  }, [])
+
+  useEffect(() => {
+    if (!reachedEnd || !dwelled || shown) return
+    if (alreadyRewarded(storageKey)) return
+    markRewarded(storageKey)
+    setShown(true)
+  }, [reachedEnd, dwelled, shown, storageKey])
+
+  useEffect(() => {
+    if (!shown) return
+    const timer = window.setTimeout(dismiss, VISIBLE_MS)
+    return () => window.clearTimeout(timer)
+  }, [shown, dismiss])
+
+  return (
+    <>
+      <div ref={sentinelRef} aria-hidden='true' />
+      {mounted &&
+        shown &&
+        createPortal(
+          <div className='rr-root' data-leaving={leaving} role='status' aria-live='polite'>
+            <JoJo size='md' speak={quip} autoQuips={false} onClick={dismiss} />
+          </div>,
+          document.body
+        )}
+    </>
+  )
+}

--- a/src/components/blog/reading-reward.css
+++ b/src/components/blog/reading-reward.css
@@ -1,0 +1,51 @@
+@keyframes rr-in {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+@keyframes rr-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(8px) scale(0.94);
+  }
+}
+
+.rr-root {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 30;
+  animation: rr-in 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.rr-root[data-leaving='true'] {
+  animation: rr-out 0.28s ease both;
+}
+
+/* The mascot is a companion, not a control — never let it sit on top of
+   whatever the reader is actually trying to click. */
+.rr-root .jojo-pre {
+  pointer-events: auto;
+}
+
+/* No room for a floating mascot next to a phone-width column. */
+@media (max-width: 640px) {
+  .rr-root {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rr-root,
+  .rr-root[data-leaving='true'] {
+    animation: none;
+  }
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,6 +8,7 @@ import type { SiteMeta } from 'astro-pure/types'
 import AnalyticsEvents from '@/components/AnalyticsEvents.astro'
 import BaseHead from '@/components/BaseHead.astro'
 import ViewCounter from '@/components/comment/ViewCounter.astro'
+import ConsoleGreeting from '@/components/ConsoleGreeting.astro'
 import Header from '@/components/Header.astro'
 import DevModeHost from '@/components/terminal/DevModeHost'
 import ThemeProvider from '@/components/ThemeProvider.astro'
@@ -56,6 +57,7 @@ const htmlLang = lang === 'en' ? 'en' : config.locale.lang
       {chrome && <Footer />}
     </div>
     <DevModeHost client:only='react' />
+    <ConsoleGreeting />
     <Analytics />
     <AnalyticsEvents />
     <SpeedInsights />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -12,6 +12,7 @@ import { ArticleBottom, Copyright, Hero } from 'astro-pure/components/pages'
 import PageLayout from '@/layouts/ContentLayout.astro'
 import CopyrightEn from '@/components/blog/CopyrightEn.astro'
 import HeroEn from '@/components/blog/HeroEn.astro'
+import ReadingReward, { READING_REWARD_MIN_WORDS } from '@/components/blog/ReadingReward'
 import Comment from '@/components/comment/Comment.astro'
 import JsonLd from '@/components/JsonLd.astro'
 import TableOfContents from '@/components/navigation/TableOfContents.astro'
@@ -37,12 +38,7 @@ const {
   enHero = false
 } = Astro.props
 
-const {
-  description,
-  publishDate,
-  title,
-  updatedDate
-} = data
+const { description, publishDate, title, updatedDate } = data
 
 // English mirrors (id ends in `.en`) reuse the Chinese post's generated OG image
 // unless a post provides a custom static social card.
@@ -57,6 +53,10 @@ const tocHeadings = headings
     ...heading,
     text: tocLabels[heading.slug] ?? heading.text
   }))
+
+// Only long posts get the read-to-the-end easter egg — gated here so short
+// ones never ship the island at all.
+const words = typeof remarkPluginFrontmatter.words === 'number' ? remarkPluginFrontmatter.words : 0
 
 // Structured data：BlogPosting + 面包屑；author/publisher 引用 BaseHead 里全站输出的 Person
 const lang = getLangFromUrl(Astro.url)
@@ -116,6 +116,7 @@ const breadcrumbLd = {
   }
 
   <slot />
+  {words >= READING_REWARD_MIN_WORDS && <ReadingReward client:idle slug={id} {lang} />}
 
   <Fragment slot='bottom'>
     {/* Copyright */}

--- a/src/lib/not-found.ts
+++ b/src/lib/not-found.ts
@@ -1,0 +1,122 @@
+/**
+ * Fuzzy route matching behind the 404 page's `command not found` easter egg.
+ *
+ * Deliberately pure and dependency-free: the route index is shaped at build
+ * time (see `site-routes.ts`, which does reach for `astro:content`) but the
+ * scoring runs in the browser, because a prerendered 404 only learns which
+ * path was requested from `location.pathname`.
+ */
+
+/** One real, reachable page. Kept to two fields so the inlined index stays small. */
+export type SiteRoute = {
+  /** Absolute site path, e.g. `/blog/20260517---agentonboardingguide`. */
+  url: string
+  /** Human title shown beside the suggestion. */
+  title: string
+}
+
+export type Suggestion = SiteRoute & { score: number }
+
+/** Everything that is not a latin word char or a CJK ideograph is a separator. */
+const SEPARATORS = /[^a-z0-9\u4e00-\u9fff]+/g
+
+export function normalizePath(pathname: string): string {
+  let path = pathname
+  try {
+    path = decodeURI(pathname)
+  } catch {
+    // malformed percent-escapes — score the raw string rather than throwing
+  }
+  path = path.toLowerCase().replace(/\/+$/, '')
+  return path || '/'
+}
+
+export function sectionOf(url: string): string {
+  const parts = url.split('/').filter(Boolean)
+  return (parts[0] === 'en' ? parts[1] : parts[0]) ?? ''
+}
+
+export function langOf(url: string): 'zh' | 'en' {
+  return url === '/en' || url.startsWith('/en/') ? 'en' : 'zh'
+}
+
+function tokenize(input: string): string[] {
+  return input
+    .toLowerCase()
+    .split(SEPARATORS)
+    .filter((token) => token.length > 1)
+}
+
+/**
+ * Padded character trigrams. Padding makes short strings comparable and
+ * gives the head/tail of a slug a little extra weight.
+ */
+function trigrams(input: string): Set<string> {
+  const flat = ` ${input.toLowerCase().replace(SEPARATORS, ' ').trim()} `
+  const grams = new Set<string>()
+  for (let i = 0; i < flat.length - 2; i += 1) grams.add(flat.slice(i, i + 3))
+  return grams
+}
+
+/** Sørensen–Dice coefficient over two trigram sets. */
+function dice(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0
+  let shared = 0
+  for (const gram of a) if (b.has(gram)) shared += 1
+  return (2 * shared) / (a.size + b.size)
+}
+
+/**
+ * How many of the requested path's words show up in the candidate. Partial
+ * (substring either way) counts half, so `agent` still pulls in
+ * `agentonboardingguide`.
+ */
+function tokenOverlap(asked: string[], candidate: string[]): number {
+  if (asked.length === 0 || candidate.length === 0) return 0
+  const exact = new Set(candidate)
+  let hits = 0
+  for (const token of asked) {
+    if (exact.has(token)) hits += 1
+    else if (candidate.some((other) => other.includes(token) || token.includes(other))) hits += 0.5
+  }
+  return hits / asked.length
+}
+
+export type SuggestOptions = {
+  limit?: number
+  /** Below this, a match is noise — better to fall back to `ls /`. */
+  minScore?: number
+}
+
+/**
+ * Rank real pages against a path that does not exist. Trigram similarity does
+ * the heavy lifting (it survives typos and truncation); word overlap, staying
+ * in the same section, and matching the visitor's locale break ties.
+ */
+export function suggestRoutes(
+  pathname: string,
+  routes: SiteRoute[],
+  { limit = 3, minScore = 0.26 }: SuggestOptions = {}
+): Suggestion[] {
+  const path = normalizePath(pathname)
+  const askedLang = langOf(path)
+  const askedSection = sectionOf(path)
+  const pathGrams = trigrams(path)
+  const pathTokens = tokenize(path)
+
+  return routes
+    .map<Suggestion>((route) => {
+      const similarity = Math.max(
+        dice(pathGrams, trigrams(route.url)),
+        dice(pathGrams, trigrams(route.title))
+      )
+      const overlap = tokenOverlap(pathTokens, tokenize(`${route.url} ${route.title}`))
+      const sameSection = askedSection !== '' && sectionOf(route.url) === askedSection ? 1 : 0
+      const sameLang = langOf(route.url) === askedLang ? 1 : 0
+      const score = 0.5 * similarity + 0.3 * overlap + 0.14 * sameSection + 0.06 * sameLang
+      return { ...route, score }
+    })
+    .filter((suggestion) => suggestion.score >= minScore)
+    .sort((a, b) => b.score - a.score || a.url.localeCompare(b.url))
+    .slice(0, limit)
+}

--- a/src/lib/site-routes.ts
+++ b/src/lib/site-routes.ts
@@ -1,0 +1,75 @@
+import { getCollection } from 'astro:content'
+
+import type { SiteRoute } from './not-found'
+
+/**
+ * Every reachable page, flattened into a `{ url, title }` index for the 404
+ * page's "did you mean" suggestions. Built at build time and inlined into the
+ * prerendered 404 HTML — a few KB, which beats making a broken URL wait on a
+ * manifest fetch before it can be helpful.
+ *
+ * Deliberately excludes: the alternate homepages (`/v2`, `/v3`), API routes,
+ * OG image endpoints, and the 404s themselves — none of them are somewhere a
+ * visitor meant to land.
+ */
+
+const STATIC_ROUTES: SiteRoute[] = [
+  { url: '/', title: '首页' },
+  { url: '/blog', title: 'Blog' },
+  { url: '/notes', title: 'Notes' },
+  { url: '/curated', title: 'Curated' },
+  { url: '/lab', title: 'Lab' },
+  { url: '/talks', title: 'Talks · 分享会' },
+  { url: '/projects', title: 'Projects' },
+  { url: '/links', title: 'Links · 友链' },
+  { url: '/about', title: 'About' },
+  { url: '/contact', title: 'Contact' },
+  { url: '/archives', title: 'Archives' },
+  { url: '/agent-teams', title: 'Agent 组队' },
+  { url: '/search', title: 'Search' },
+  { url: '/tags', title: 'Tags' },
+  { url: '/en', title: 'Home' },
+  { url: '/en/blog', title: 'Blog' },
+  { url: '/en/notes', title: 'Notes' },
+  { url: '/en/curated', title: 'Curated' },
+  { url: '/en/projects', title: 'Projects' },
+  { url: '/en/links', title: 'Links' },
+  { url: '/en/about', title: 'About' },
+  { url: '/en/contact', title: 'Contact' },
+  { url: '/en/search', title: 'Search' },
+  { url: '/en/tags', title: 'Tags' }
+]
+
+export async function buildSiteRoutes(): Promise<SiteRoute[]> {
+  const [blog, blogEn, notes, notesEn, lab] = await Promise.all([
+    getCollection('blog', ({ data }) => !data.draft),
+    getCollection('blogEn', ({ data }) => !data.draft && Boolean(data.translationKey)),
+    getCollection('notes', ({ data }) => !data.draft),
+    getCollection('notesEn', ({ data }) => !data.draft && Boolean(data.translationKey)),
+    getCollection('lab', ({ data }) => !data.draft)
+  ])
+
+  return [
+    ...STATIC_ROUTES,
+    ...blog.map<SiteRoute>((entry) => ({
+      url: `/blog/${encodeURI(entry.id)}`,
+      title: entry.data.title
+    })),
+    ...blogEn.map<SiteRoute>((entry) => ({
+      url: `/en/blog/${encodeURI(entry.data.translationKey!)}`,
+      title: entry.data.title
+    })),
+    ...notes.map<SiteRoute>((entry) => ({
+      url: `/notes/${encodeURI(entry.id)}`,
+      title: entry.data.title
+    })),
+    ...notesEn.map<SiteRoute>((entry) => ({
+      url: `/en/notes/${encodeURI(entry.data.translationKey!)}`,
+      title: entry.data.title
+    })),
+    ...lab.map<SiteRoute>((entry) => ({
+      url: `/lab/${encodeURI(entry.id)}`,
+      title: entry.data.title
+    }))
+  ]
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,6 +1,6 @@
 ---
-import { Button } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
+import NotFoundTerminal from '@/components/NotFoundTerminal.astro'
 
 export const prerender = true
 
@@ -12,10 +12,7 @@ const meta = {
 ---
 
 <PageLayout {meta}>
-  <div class='px-4 py-10 text-center sm:px-6 lg:px-8'>
-    <h1 class='block text-7xl font-bold sm:text-9xl'>404</h1>
-    <p class='mt-3 text-muted-foreground'>Oops, something went wrong.</p>
-    <p class='text-lg'>Sorry, we couldn't find your page.</p>
-    <Button title='Back to home' href='/' style='ahead' class='mt-5' />
+  <div class='px-4 py-10 sm:px-6 lg:px-8'>
+    <NotFoundTerminal lang='zh' />
   </div>
 </PageLayout>

--- a/src/pages/en/404.astro
+++ b/src/pages/en/404.astro
@@ -1,6 +1,6 @@
 ---
-import { Button } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
+import NotFoundTerminal from '@/components/NotFoundTerminal.astro'
 
 export const prerender = true
 
@@ -12,10 +12,7 @@ const meta = {
 ---
 
 <PageLayout {meta}>
-  <div class='px-4 py-10 text-center sm:px-6 lg:px-8'>
-    <h1 class='block text-7xl font-bold sm:text-9xl'>404</h1>
-    <p class='mt-3 text-muted-foreground'>Oops, something went wrong.</p>
-    <p class='text-lg'>Sorry, we couldn't find your page.</p>
-    <Button title='Back to home' href='/en' style='ahead' class='mt-5' />
+  <div class='px-4 py-10 sm:px-6 lg:px-8'>
+    <NotFoundTerminal lang='en' />
   </div>
 </PageLayout>

--- a/src/pages/en/[...slug].astro
+++ b/src/pages/en/[...slug].astro
@@ -1,6 +1,6 @@
 ---
-import { Button } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
+import NotFoundTerminal from '@/components/NotFoundTerminal.astro'
 
 // Catch-all for any /en/* path with no matching page (e.g. /en/talks, which
 // has no English mirror). Without this, Vercel's routing falls back to the
@@ -15,10 +15,7 @@ const meta = {
 ---
 
 <PageLayout {meta}>
-  <div class='px-4 py-10 text-center sm:px-6 lg:px-8'>
-    <h1 class='block text-7xl font-bold sm:text-9xl'>404</h1>
-    <p class='mt-3 text-muted-foreground'>Oops, something went wrong.</p>
-    <p class='text-lg'>Sorry, we couldn't find your page.</p>
-    <Button title='Back to home' href='/en' style='ahead' class='mt-5' />
+  <div class='px-4 py-10 sm:px-6 lg:px-8'>
+    <NotFoundTerminal lang='en' />
   </div>
 </PageLayout>


### PR DESCRIPTION
Three small easter eggs, all reusing the existing terminal/mascot sub-theme.

- **404** — reports a missing page as `cat: <path>: No such file or directory`, with fuzzy "did you mean" matches against a build-time index of every real route; falls back to an `ls /` of the top-level sections. Applied to all three 404 exits (zh, en, `/en/[...slug]`).
- **Console** — JoJo says hi in devtools and points at `` ` ``, `/lab`, `/talks`, contact. No visual footprint.
- **Read-to-end reward** — JoJo pops into the corner once when the end of a long post reaches the upper viewport *and* the visitor has been on the page 15s. Once per post per session; posts under 1200 words never ship the island.

Also fixed along the way, both recorded in `DESIGN.md`: JS-built nodes can't satisfy Astro's `:where(.astro-<hash>)` scoping (use a `<template>` + `cloneNode`), and `--destructive` is a fill color that's unreadable as stderr text in dark mode (added a local `--nf-err`).

Notes: the 404's 6.7KB route index is inlined at build time so a broken URL doesn't wait on a fetch. The read-to-end reward's two trigger gates could not be exercised locally — the verification browser pane runs hidden, where IntersectionObserver never fires and timers throttle — so the rendering was verified but the trigger needs a look on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three small easter eggs: a terminal-styled 404 with fuzzy suggestions, a devtools console greeting, and a one-time read-to-end reward on long posts. This improves error recovery and discoverability without adding visible UI.

- 404 shows cat: <path>: No such file or directory, then suggests close matches or falls back to an ls / of top sections.
- Suggestion scoring runs client-side against an inlined (~6.7 KB) build-time `{url,title}` route index and works in both zh and en 404s, including `/en/[...slug]`.
- Degrades without JS: the fallback listing is visible and the command line keeps a `$REQUEST_PATH` placeholder.
- Console greeting prints JoJo and pointers (backtick dev mode, `/lab`, `/talks`, contact) in the developer console; mounted globally with no visual footprint.
- Read-to-end reward shows JoJo once when the article end crosses the upper viewport and dwell time ≥15s; once per post per session; posts under 1200 words do not ship the island.
- Adds a local `--nf-err` token for readable stderr text in dark mode and documents the scoped-style template cloning caveat in `DESIGN.md`.

<sup>Written for commit 4691295fb16f43e3244bcd330b3de55938dcba2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/joyehuang/blog/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

